### PR TITLE
Cat equiv

### DIFF
--- a/Cubical/Categories/Instances/Functors/More.agda
+++ b/Cubical/Categories/Instances/Functors/More.agda
@@ -121,8 +121,15 @@ module _ (C : Category ℓC ℓC') (D : Category ℓD ℓD') where
         λη .N-ob γ .N-ob c ∎))
       ) ) ∣₁)
 
+    -- TODO : λF is especially badly named in the context of all these other names
+    preimage-obj : (FUNCTOR Γ (FUNCTOR C D)) .ob → (FUNCTOR (Γ ×C C) D) .ob
+    preimage-obj λF .F-ob (γ , c) =  λF .F-ob γ .F-ob c
+    preimage-obj λF .F-hom {x = (γ₁ , c₁)} {y = (γ₂ , c₂)} (ϕ , ψ) =  λF .F-hom ϕ .N-ob c₁ ⋆⟨ D ⟩ λF .F-ob γ₂ .F-hom ψ
+    preimage-obj λF .F-seq (ϕ₁ , ψ₁) (ϕ₂ , ψ₂) = {!!}
+    preimage-obj λF .F-id = {!!}
+
     λF-ess-surj : isEssentiallySurj λF-functor
-    λF-ess-surj = {!!}
+    λF-ess-surj λF = {!!}
 
     λF-isFaithful : isFaithful λF-functor
     λF-isFaithful F G η₁ η₂ λη₁≡λη₂ = makeNatTransPath (funExt (λ (γ , c) →

--- a/Cubical/Categories/Instances/Functors/More.agda
+++ b/Cubical/Categories/Instances/Functors/More.agda
@@ -17,12 +17,30 @@ open import Cubical.Categories.Constructions.BinProduct
 
 private
   variable
-    ℓC ℓC' ℓD ℓD' ℓΓ ℓΓ' : Level
+    ℓC ℓC' ℓD ℓD' ℓΓ ℓΓ' ℓ ℓ' : Level
 
 module _ (C : Category ℓC ℓC') (D : Category ℓD ℓD') where
   open Category
   open Functor
   open NatTrans
+
+  -- TODO: don't really know what's going on w universes here. Introduced levels ℓ ℓ' not tied to C, D, or Γ in hopes to make this general
+  -- The type of this record makes no sense to me at the moment, but does make everything type check.
+  -- TODO: Maybe put this is a different file
+  record EquivalenceOfCategories {A B : Category ℓ ℓ'}(F : Functor A B) (G : Functor B A) : Type (ℓ-max ℓ ℓ') where
+    constructor is-equiv-of-cats
+    field
+      F∘G-iso-to-id : NatIso (funcComp F G) (Id)
+      G∘F-iso-to-id : NatIso (funcComp G F) (Id)
+
+  -- TODO: find proper syntax for existential quantification
+  -- Want to show that we have an equivalence of categories iff ess surj on objs, full, faithful
+  --alt-equiv-of-categories : {A B : Category ℓ ℓ'} → (F : Functor A B) →
+  --  isFull F →
+  --  isFaithful F →
+  --  isEssentiallySurj F →
+  --  ∃ G EquivalenceOfCategories F G
+  --alt-equiv-of-categories _ = ?
 
   appF : Functor ((FUNCTOR C D) ×C C) D
   appF .F-ob (F , c) = F ⟅ c ⟆

--- a/Cubical/Categories/Instances/Functors/More.agda
+++ b/Cubical/Categories/Instances/Functors/More.agda
@@ -76,6 +76,7 @@ module _ (C : Category ℓC ℓC') (D : Category ℓD ℓD') where
           ≡⟨ F .F-seq (γ , C .id) (δ , C .id) ⟩
         F .F-hom (γ , C .id) ⋆⟨ D ⟩ F .F-hom (δ , C .id) ∎))
 
+    -- TODO: come up with a better name for this
     λF-functor : Functor (FUNCTOR (Γ ×C C) D) (FUNCTOR Γ (FUNCTOR C D))
     λF-functor .F-ob = λFr
     λF-functor .F-hom η .N-ob γ .N-ob c = η .N-ob (γ , c)
@@ -89,7 +90,7 @@ module _ (C : Category ℓC ℓC') (D : Category ℓD ℓD') where
     λF-ess-surj = {!!}
 
     λF-isFull : isFull λF-functor
-    λF-isFull F G λη = ?
+    λF-isFull F G λη = {!!}
 
     λF-isFaithful : isFaithful λF-functor
     λF-isFaithful F G η₁ η₂ λη₁≡λη₂ = makeNatTransPath (funExt (λ (γ , c) →

--- a/Cubical/Categories/Instances/Functors/More.agda
+++ b/Cubical/Categories/Instances/Functors/More.agda
@@ -79,12 +79,6 @@ module _ (C : Category ℓC ℓC') (D : Category ℓD ℓD') where
           ≡⟨ F .F-seq (γ , C .id) (δ , C .id) ⟩
         F .F-hom (γ , C .id) ⋆⟨ D ⟩ F .F-hom (δ , C .id) ∎))
 
-    -- The action of currying out the right argument of a Functor (Γ ×C C) D
-    -- To show this is also an equivalence of categories, show properties about the right handed version,
-    -- then show that swapping arguments is also an equivalence
-    λFl : Functor (C ×C Γ) D → Functor Γ (FUNCTOR C D)
-    λFl F = λFr (F ∘F (Snd Γ C ,F Fst Γ C))
-
     -- Functorially extend the currying action from a function on objects to a functor between
     -- the relevant functor categories
     -- Here "currying" pulls out the right argument. We will define a similar left-sided version
@@ -245,3 +239,56 @@ module _ (C : Category ℓC ℓC') (D : Category ℓD ℓD') where
     curryEquivalence : FUNCTOR (Γ ×C C) D ≃ᶜ FUNCTOR Γ (FUNCTOR C D)
     curryEquivalence .func = curryF
     curryEquivalence ._≃ᶜ_.isEquiv = curryF-isEquivalence
+
+    -- We also want a notion of currying out the left argument. We do this by composing
+    -- a swapping functor with the right-sided currying functor
+    -- To show that this left-handed currying is also an equivalence, we will need to show that
+    -- the swapping functor is an equivalence
+    swapArgs : Functor (FUNCTOR (C ×C Γ) D) (FUNCTOR (Γ ×C C) D)
+    swapArgs .F-ob F .F-ob (c , γ) = F .F-ob (γ , c)
+    swapArgs .F-ob F .F-hom (ψ , ϕ) = F .F-hom (ϕ , ψ)
+    swapArgs .F-ob F .F-id = F .F-id
+    swapArgs .F-ob F .F-seq (ψ₁ , ϕ₁) (ψ₂ , ϕ₂) = F .F-seq (ϕ₁ , ψ₁) (ϕ₂ , ψ₂)
+    swapArgs .F-hom η .N-ob (γ , c) = η .N-ob (c , γ)
+    swapArgs .F-hom η .N-hom (ϕ , ψ) = η .N-hom (ψ , ϕ)
+    swapArgs .F-id = makeNatTransPath (funExt λ (γ , c) → refl)
+    swapArgs .F-seq η η' = makeNatTransPath (funExt λ (γ , c) → refl)
+
+    swapArgs-inv : Functor (FUNCTOR (Γ ×C C) D) (FUNCTOR (C ×C Γ) D)
+    swapArgs-inv .F-ob F .F-ob (γ , c) = F .F-ob (c , γ)
+    swapArgs-inv .F-ob F .F-hom (ϕ , ψ) = F .F-hom (ψ , ϕ)
+    swapArgs-inv .F-ob F .F-id = F .F-id
+    swapArgs-inv .F-ob F .F-seq (ϕ₁ , ψ₁) (ϕ₂ , ψ₂) = F .F-seq (ψ₁ , ϕ₁) (ψ₂ , ϕ₂)
+    swapArgs-inv .F-hom η .N-ob (γ , c) = η .N-ob (c , γ)
+    swapArgs-inv .F-hom η .N-hom (ψ , ϕ) = η .N-hom (ϕ , ψ)
+    swapArgs-inv .F-id = makeNatTransPath (funExt λ (γ , c) → refl)
+    swapArgs-inv .F-seq η η' = makeNatTransPath (funExt λ (γ , c) → refl)
+
+    open isEquivalence
+    open NatIso
+
+    swapArgs-isEquivalence : isEquivalence swapArgs
+    swapArgs-isEquivalence = {!!}
+    -- swapArgs-isEquivalence .invFunc = swapArgs-inv
+    -- swapArgs-isEquivalence .η .trans .N-ob F .N-ob γ =  D .id
+    -- swapArgs-isEquivalence .η .trans .N-ob F .N-hom ϕ = solveCat! D
+    -- swapArgs-isEquivalence .η .trans .N-hom α = makeNatTransPath (funExt (λ (c , γ) → solveCat! D))
+    -- swapArgs-isEquivalence .η .nIso F .inv .N-ob (c , γ) = D .id
+    -- swapArgs-isEquivalence .η .nIso F .inv .N-hom (ψ , ϕ) = solveCat! D
+    -- swapArgs-isEquivalence .η .nIso F .sec = makeNatTransPath (funExt (λ (c , γ) → solveCat! D))
+    -- swapArgs-isEquivalence .η .nIso F .ret = makeNatTransPath (funExt (λ (c , γ) → solveCat! D))
+    -- swapArgs-isEquivalence .ε .trans .N-ob F .N-ob c = D .id
+    -- swapArgs-isEquivalence .ε .trans .N-ob F .N-hom ψ = solveCat! D
+    -- swapArgs-isEquivalence .ε .trans .N-hom α = makeNatTransPath (funExt (λ (γ , c) → solveCat! D))
+    -- swapArgs-isEquivalence .ε .nIso F .inv .N-ob (γ , c) = D .id
+    -- swapArgs-isEquivalence .ε .nIso F .inv .N-hom (ϕ , ψ) = solveCat! D
+    -- swapArgs-isEquivalence .ε .nIso F .sec = makeNatTransPath (funExt (λ (γ , c) → solveCat! D))
+    -- swapArgs-isEquivalence .ε .nIso F .ret = makeNatTransPath (funExt (λ (γ , c) → solveCat! D))
+
+    curryFl : Functor (FUNCTOR (C ×C Γ) D) (FUNCTOR Γ (FUNCTOR C D))
+    curryFl = curryF ∘F swapArgs
+
+    curryFl-isEquivalence : isEquivalence curryFl
+    curryFl-isEquivalence .invFunc = {!swapArgs-isEquivalence .invFunc ∘F curryF-isEquivalence .invFunc!}
+    curryFl-isEquivalence .η = {!!}
+    curryFl-isEquivalence .ε = {!!}

--- a/Cubical/Categories/Instances/Functors/More.agda
+++ b/Cubical/Categories/Instances/Functors/More.agda
@@ -18,6 +18,7 @@ open import Cubical.Categories.Equivalence.WeakEquivalence
 open import Cubical.Categories.Functor.Properties
 open import Cubical.Categories.Equivalence.Base
 open import Cubical.HITs.PropositionalTruncation
+open import Cubical.Categories.Category
 
 open import AltEquationalReasoning
 open import Cubical.Tactics.CategorySolver.Reflection
@@ -93,8 +94,6 @@ module _ (C : Category ℓC ℓC') (D : Category ℓD ℓD') where
     preimage {F} {G} λη .N-hom {(γ₁ , c₁)} {(γ₂ , c₂)} (ϕ₁ , ϕ₂) =
       F .F-hom (ϕ₁ , ϕ₂) ⋆⟨ D ⟩ preimage λη .N-ob (γ₂ , c₂)
         ≡⟨ (λ i → (F .F-hom ((Γ .⋆IdR ϕ₁) (~ i) , (C .⋆IdL ϕ₂) (~ i)) ⋆⟨ D ⟩ preimage λη .N-ob (γ₂ , c₂))) ⟩
-      F .F-hom (ϕ₁ ⋆⟨ Γ ⟩ Γ .id , C .id ⋆⟨ C ⟩ ϕ₂) ⋆⟨ D ⟩ preimage λη .N-ob (γ₂ , c₂)
-        ≡⟨ refl ⟩
       F .F-hom ((ϕ₁ , C .id) ⋆⟨ Γ ×C C ⟩ (Γ .id , ϕ₂)) ⋆⟨ D ⟩ preimage λη .N-ob (γ₂ , c₂)
         ≡⟨ (λ i → (F .F-seq (ϕ₁ , C .id) (Γ .id , ϕ₂)) (i) ⋆⟨ D ⟩ preimage λη .N-ob (γ₂ , c₂)) ⟩
       F .F-hom (ϕ₁ , C .id) ⋆⟨ D ⟩ F .F-hom (Γ .id , ϕ₂) ⋆⟨ D ⟩ preimage λη .N-ob (γ₂ , c₂)
@@ -124,12 +123,88 @@ module _ (C : Category ℓC ℓC') (D : Category ℓD ℓD') where
     -- TODO : λF is especially badly named in the context of all these other names
     preimage-obj : (FUNCTOR Γ (FUNCTOR C D)) .ob → (FUNCTOR (Γ ×C C) D) .ob
     preimage-obj λF .F-ob (γ , c) =  λF .F-ob γ .F-ob c
-    preimage-obj λF .F-hom {x = (γ₁ , c₁)} {y = (γ₂ , c₂)} (ϕ , ψ) =  λF .F-hom ϕ .N-ob c₁ ⋆⟨ D ⟩ λF .F-ob γ₂ .F-hom ψ
-    preimage-obj λF .F-seq (ϕ₁ , ψ₁) (ϕ₂ , ψ₂) = {!!}
-    preimage-obj λF .F-id = {!!}
+    preimage-obj λF .F-hom {x = (γ₁ , c₁)} {y = (γ₂ , c₂)} (ϕ , ψ) = λF .F-hom ϕ .N-ob c₁ ⋆⟨ D ⟩ λF .F-ob γ₂ .F-hom ψ
+    preimage-obj λF .F-seq {x = (γ₁ , c₁)} {y = (γ₂ , c₂)} {z = (γ₃ , c₃)} (ϕ₁ , ψ₁) (ϕ₂ , ψ₂) = (
+      preimage-obj λF .F-hom ((ϕ₁ , ψ₁) ⋆⟨ Γ ×C C ⟩ (ϕ₂ , ψ₂))
+        ≡⟨ ((λ i → ( (λF .F-seq ϕ₁ ϕ₂ (i) ) .N-ob c₁ ⋆⟨ D ⟩ λF .F-ob γ₃ .F-hom (ψ₁ ⋆⟨ C ⟩ ψ₂)))) ⟩
+      (λF .F-hom ϕ₁ ⋆⟨ FUNCTOR C D ⟩ λF .F-hom ϕ₂) .N-ob c₁ ⋆⟨ D ⟩ λF .F-ob γ₃ .F-hom (ψ₁ ⋆⟨ C ⟩ ψ₂)
+        ≡⟨ (λ i → (λF .F-hom ϕ₁ .N-ob c₁ ⋆⟨ D ⟩ λF .F-hom ϕ₂ .N-ob c₁ ⋆⟨ D ⟩ λF .F-ob γ₃ .F-seq ψ₁ ψ₂ i)) ⟩
+      (λF .F-hom ϕ₁ .N-ob c₁ ⋆⟨ D ⟩ λF .F-hom ϕ₂ .N-ob c₁) ⋆⟨ D ⟩ (λF .F-ob γ₃ .F-hom ψ₁ ⋆⟨ D ⟩ λF .F-ob γ₃ .F-hom ψ₂)
+        ≡⟨ solveCat! D ⟩
+      λF .F-hom ϕ₁ .N-ob c₁ ⋆⟨ D ⟩ (λF .F-hom ϕ₂ .N-ob c₁ ⋆⟨ D ⟩ λF .F-ob γ₃ .F-hom ψ₁) ⋆⟨ D ⟩ λF .F-ob γ₃ .F-hom ψ₂
+        ≡⟨ ((λ i → ( λF .F-hom ϕ₁ .N-ob c₁ ⋆⟨ D ⟩ (λF .F-hom ϕ₂ .N-hom ψ₁ (~ i) ) ⋆⟨ D ⟩ λF .F-ob γ₃ .F-hom ψ₂ ))) ⟩
+      λF .F-hom ϕ₁ .N-ob c₁ ⋆⟨ D ⟩ (λF .F-ob γ₂ .F-hom ψ₁ ⋆⟨ D ⟩ λF .F-hom ϕ₂ .N-ob c₂) ⋆⟨ D ⟩ λF .F-ob γ₃ .F-hom ψ₂
+        ≡⟨ solveCat! D ⟩
+      preimage-obj λF .F-hom (ϕ₁ , ψ₁) ⋆⟨ D ⟩ preimage-obj λF .F-hom (ϕ₂ , ψ₂) ∎)
+    preimage-obj λF .F-id  {x = (γ , c)} = (
+      preimage-obj λF .F-hom (Γ .id , C .id)
+        ≡⟨ ((λ i → (λF .F-id i .N-ob c ⋆⟨ D ⟩ λF .F-ob γ .F-hom (C .id)))) ⟩
+      D .id ⋆⟨ D ⟩ λF .F-ob γ .F-hom (C .id)
+        ≡⟨ ((λ i → (D .id ⋆⟨ D ⟩ (λF .F-ob γ .F-id i)))) ⟩
+      D .id ⋆⟨ D ⟩ D .id
+        ≡⟨ D .⋆IdL (D .id) ⟩
+      D .id
+      ∎ )
+    preimage-iso : (λF : (FUNCTOR Γ (FUNCTOR C D)) .ob) → NatTrans (λF-functor .F-ob (preimage-obj λF)) λF
+    preimage-iso λF .N-ob γ .N-ob c = D .id
+    preimage-iso λF .N-ob γ .N-hom {x = c₁} {y = c₂} ψ =
+      ((λF .F-hom (Γ .id) .N-ob c₁) ⋆⟨ D ⟩ (λF .F-ob γ .F-hom ψ)) ⋆⟨ D ⟩ D .id
+        ≡⟨ (λ i → (D .⋆IdR ((λF .F-hom (Γ .id) .N-ob c₁) ⋆⟨ D ⟩ (λF .F-ob γ .F-hom ψ)) (i) )) ⟩
+      (λF .F-hom (Γ .id) .N-ob c₁) ⋆⟨ D ⟩ λF .F-ob γ .F-hom ψ
+        ≡⟨ ((λ i → ((λF .F-id i) .N-ob c₁ ⋆⟨ D ⟩ λF .F-ob γ .F-hom ψ ))) ⟩
+      D .id ⋆⟨ D ⟩ λF .F-ob γ .F-hom ψ ∎
+    preimage-iso λF .N-hom {x = γ₁} {y = γ₂} ϕ = makeNatTransPath (funExt (λ (c : C .ob) →
+      λF-functor .F-ob (preimage-obj λF) .F-hom ϕ .N-ob c ⋆⟨ D ⟩ (preimage-iso λF) .N-ob γ₂ .N-ob c
+        ≡⟨ D .⋆IdR (λF-functor .F-ob (preimage-obj λF) .F-hom ϕ .N-ob c) ⟩
+      λF .F-hom ϕ .N-ob c ⋆⟨ D ⟩ λF .F-ob γ₂ .F-hom (C .id)
+        ≡⟨ ((λ i → (λF .F-hom ϕ .N-ob c ⋆⟨ D ⟩ λF .F-ob γ₂ .F-id i))) ⟩
+      λF .F-hom ϕ .N-ob c ⋆⟨ D ⟩ D .id
+        ≡⟨ D .⋆IdR (λF .F-hom ϕ .N-ob c) ⟩
+      λF .F-hom ϕ .N-ob c
+        ≡⟨ ((λ i → (D .⋆IdL (λF .F-hom ϕ .N-ob c) (~ i) ))) ⟩
+      (preimage-iso λF) .N-ob γ₁ .N-ob c ⋆⟨ D ⟩ λF .F-hom ϕ .N-ob c ∎))
+
+    open isIso
+
+    preimage-iso-isIso : (λF : (FUNCTOR Γ (FUNCTOR C D)) .ob) → isIsoC (FUNCTOR Γ (FUNCTOR C D)) (preimage-iso λF)
+    preimage-iso-isIso λF .inv .N-ob γ .N-ob c =  D .id
+    preimage-iso-isIso λF .inv .N-ob γ .N-hom {x = c₁} {y = c₂} ψ =
+      λF .F-ob γ .F-hom ψ ⋆⟨ D ⟩ D .id
+        ≡⟨ D .⋆IdR (λF .F-ob γ .F-hom ψ) ⟩
+      λF .F-ob γ .F-hom ψ
+        ≡⟨ (λ i → (D .⋆IdL (λF .F-ob γ .F-hom ψ) (~ i))) ⟩
+      D .id ⋆⟨ D ⟩ λF .F-ob γ .F-hom ψ
+        ≡⟨ ((λ i → (λF .F-id (~ i)) .N-ob c₁ ⋆⟨ D ⟩ λF .F-ob γ .F-hom ψ ) ) ⟩
+     λF-functor .F-ob (preimage-obj λF) .F-ob γ .F-hom ψ
+        ≡⟨ ((λ i → (D .⋆IdL (λF-functor .F-ob (preimage-obj λF) .F-ob γ .F-hom ψ ) (~ i) ))) ⟩
+      D .id ⋆⟨ D ⟩ λF-functor .F-ob (preimage-obj λF) .F-ob γ .F-hom ψ ∎
+    preimage-iso-isIso λF .inv .N-hom {x = γ₁} {y = γ₂} ϕ = makeNatTransPath (funExt (λ (c : C .ob ) →
+      λF .F-hom ϕ .N-ob c ⋆⟨ D ⟩ preimage-iso-isIso λF .inv .N-ob γ₂ .N-ob c
+        ≡⟨ D .⋆IdR (λF .F-hom ϕ .N-ob c) ⟩
+      λF .F-hom ϕ .N-ob c
+        ≡⟨ ((λ i → (D .⋆IdR (λF .F-hom ϕ .N-ob c) (~ i)))) ⟩
+      λF .F-hom ϕ .N-ob c ⋆⟨ D ⟩ D .id
+        ≡⟨ ((λ i → ( λF .F-hom ϕ .N-ob c ⋆⟨ D ⟩ λF .F-ob γ₂ .F-id (~ i )))) ⟩
+      λFr (preimage-obj λF) .F-hom ϕ .N-ob c
+        ≡⟨ ((λ i → ((D .⋆IdL (λFr (preimage-obj λF) .F-hom ϕ .N-ob c) (~ i)) ))) ⟩
+      D .id ⋆⟨ D ⟩ λFr (preimage-obj λF) .F-hom ϕ .N-ob c ∎
+      ))
+    preimage-iso-isIso λF .sec = makeNatTransPath (funExt (λ (γ : Γ .ob) →
+      makeNatTransPath (funExt (λ (c : C .ob) →
+        preimage-iso-isIso λF .inv .N-ob γ .N-ob c ⋆⟨ D ⟩ preimage-iso λF .N-ob γ .N-ob c
+          ≡⟨ D .⋆IdR (preimage-iso-isIso λF .inv .N-ob γ .N-ob c) ⟩
+        D .id ∎
+      ))))
+    preimage-iso-isIso λF .ret = makeNatTransPath (funExt (λ (γ : Γ .ob) →
+      makeNatTransPath (funExt (λ (c : C .ob) →
+         preimage-iso λF .N-ob γ .N-ob c ⋆⟨ D ⟩ preimage-iso-isIso λF .inv .N-ob γ .N-ob c
+          ≡⟨ D .⋆IdR (preimage-iso-isIso λF .inv .N-ob γ .N-ob c) ⟩
+        D .id ∎
+      ))))
+
 
     λF-ess-surj : isEssentiallySurj λF-functor
-    λF-ess-surj λF = {!!}
+    λF-ess-surj λF = ( ∣ preimage-obj λF , (preimage-iso λF , preimage-iso-isIso λF) ∣₁ )
 
     λF-isFaithful : isFaithful λF-functor
     λF-isFaithful F G η₁ η₂ λη₁≡λη₂ = makeNatTransPath (funExt (λ (γ , c) →

--- a/Cubical/Categories/Instances/Functors/More.agda
+++ b/Cubical/Categories/Instances/Functors/More.agda
@@ -92,18 +92,17 @@ module _ (C : Category ℓC ℓC') (D : Category ℓD ℓD') where
     preimage {F} {G} λη .N-ob (γ , c) = λη .N-ob γ .N-ob c
     preimage {F} {G} λη .N-hom {(γ₁ , c₁)} {(γ₂ , c₂)} (ϕ₁ , ϕ₂) =
       F .F-hom (ϕ₁ , ϕ₂) ⋆⟨ D ⟩ preimage λη .N-ob (γ₂ , c₂)
-        -- TODO: this is wrong
-        ≡⟨ {!(λ i → (F .F-hom (Γ ⋆IdR ϕ₁ , C ⋆IdL ϕ₂) ⋆⟨ D ⟩ preimage λη .N-ob (γ₂ , c₂)))!} ⟩
+        ≡⟨ (λ i → (F .F-hom ((Γ .⋆IdR ϕ₁) (~ i) , (C .⋆IdL ϕ₂) (~ i)) ⋆⟨ D ⟩ preimage λη .N-ob (γ₂ , c₂))) ⟩
       F .F-hom (ϕ₁ ⋆⟨ Γ ⟩ (Γ .id), (C .id) ⋆⟨ C ⟩ ϕ₂) ⋆⟨ D ⟩ preimage λη .N-ob (γ₂ , c₂)
         ≡⟨ refl ⟩
       F .F-hom ((ϕ₁ , (C .id)) ⋆⟨ Γ ×C C ⟩ (Γ .id , ϕ₂)) ⋆⟨ D ⟩ preimage λη .N-ob (γ₂ , c₂)
-        ≡⟨ {!!} ⟩
+        ≡⟨ (λ i → (F .F-seq (ϕ₁ , (C .id)) (Γ .id , ϕ₂)) (i) ⋆⟨ D ⟩ preimage λη .N-ob (γ₂ , c₂)) ⟩
       F .F-hom (ϕ₁ , (C .id)) ⋆⟨ D ⟩ F .F-hom ((Γ .id) , ϕ₂) ⋆⟨ D ⟩ preimage λη .N-ob (γ₂ , c₂)
         ≡⟨ {!!} ⟩
       preimage λη .N-ob (γ₁ , c₁) ⋆⟨ D ⟩ G .F-hom (ϕ₁ , ϕ₂) ∎
 
     λF-isFull : isFull λF-functor
-    λF-isFull F G λη = {!!}
+    λF-isFull F G λη =  ∣ {!!} , {!!} ∣₁
 
     λF-ess-surj : isEssentiallySurj λF-functor
     λF-ess-surj = {!!}

--- a/Cubical/Categories/Instances/Functors/More.agda
+++ b/Cubical/Categories/Instances/Functors/More.agda
@@ -73,5 +73,40 @@ module _ (C : Category ℓC ℓC') (D : Category ℓD ℓD') where
           ≡⟨ F .F-seq (γ , C .id) (δ , C .id) ⟩
         F .F-hom (γ , C .id) ⋆⟨ D ⟩ F .F-hom (δ , C .id) ∎))
 
+    -- λF-functor : Functor (FUNCTOR (Γ ×C C) D) (FUNCTOR Γ (FUNCTOR C D))
+    -- λF-functor .F-ob = λF
+    -- Want to define λF-functor .F-hom η to be the map (b ↦ F a b) ↦ (b ↦ η (F a b))
+
+    -- {!!}{!!}{!!}
+    λF-functor : Functor (FUNCTOR (Γ ×C C) D) (FUNCTOR Γ (FUNCTOR C D))
+    λF-functor .F-ob = λF
+    λF-functor .F-hom η .N-ob γ .N-ob c = η .N-ob (γ , c)
+    λF-functor .F-hom η .N-ob γ .N-hom ϕ = η .N-hom (Γ .id , ϕ)
+
+    -- ((λF F .F-hom f) ⋆⟨ D ⟩ (λF-functor .F-hom η) .N-ob y) .N-ob c
+    -- ((λF F .F-hom f) .N-ob c) ⋆⟨ ? ⟩ ((λF-functor .F-hom η) .N-ob y) .N-ob c
+    -- (F .F-hom (f , C .id)) ⋆⟨ ? ⟩ (η .N-ob (y , c))
+    -- (η .N-ob (x , c)) ⋆⟨ ? ⟩ (G .F-hom (f , C .id))
+    -- ((λF-functor .F-hom η) .N-ob x) .N-ob c ⋆⟨ ? ⟩ (λF G .F-hom f) .N-ob c
+    -- ((λF-functor .F-hom η) .N-ob x ⋆⟨ D ⟩ (λF G .F-hom f)) .N-ob c
+
+    λF-functor .F-hom {F} {G} η .N-hom {x} {y} f = {!!}
+
+    -- λF-fucnotr .F-hom idTrans F
+    -- = ((idTrans F) .N-ob γ) .N-ob c
+    -- = (idTrans F) .N-ob (γ , c)
+    -- = D .id
+    -- = idTranse(λF .F-hom F) .N-ob _ = D .id
+    λF-functor .F-id = {!i
+
+!}
+    λF-functor .F-seq η η' = {!!}
+
+
+
+
+    -- λF-ess-surj : isEssentiallySurj λF
+    -- λF-ess-surj = ?
+
     λFl : Functor (C ×C Γ) D → Functor Γ (FUNCTOR C D)
     λFl F = λF (F ∘F (Snd Γ C ,F Fst Γ C))

--- a/Cubical/Categories/Instances/Functors/More.agda
+++ b/Cubical/Categories/Instances/Functors/More.agda
@@ -50,7 +50,7 @@ module _ (C : Category ℓC ℓC') (D : Category ℓD ℓD') where
       ≡⟨ solveCat! D ⟩
     (F ⟪ f ⟫ ⋆⟨ D ⟩ α .N-ob c') ⋆⟨ D ⟩ (F' ⟪ f' ⟫ ⋆⟨ D ⟩ α' .N-ob c'') ∎
 
-  module _ {Γ : Category ℓΓ ℓΓ'}  (isUniv-Γ×C→D : isUnivalent (FUNCTOR (Γ ×C C) D)) (isUniv-Γ→C→D : isUnivalent (FUNCTOR Γ (FUNCTOR C D))) where
+  module _ {Γ : Category ℓΓ ℓΓ'} (isUnivD : isUnivalent D) where
     -- The action of currying out the right argument of a Functor (Γ ×C C) D
     λFr : Functor (Γ ×C C) D → Functor Γ (FUNCTOR C D)
     λFr F .F-ob a .F-ob b = F ⟅ a , b ⟆
@@ -229,6 +229,17 @@ module _ (C : Category ℓC ℓC') (D : Category ℓD ℓD') where
     curryF-isWeakEquiv .esssurj = curryF-ess-surj
 
     open isUnivalent
+
+    -- D univalent implies that the functors into D are univalent
+    isUniv-Γ×C→D : isUnivalent (FUNCTOR (Γ ×C C) D)
+    isUniv-Γ×C→D = isUnivalentFUNCTOR (Γ ×C C) D isUnivD
+
+    isUniv-C→D : isUnivalent (FUNCTOR C D)
+    isUniv-C→D = isUnivalentFUNCTOR C D isUnivD
+
+    isUniv-Γ→C→D : isUnivalent (FUNCTOR Γ (FUNCTOR C D))
+    isUniv-Γ→C→D = isUnivalentFUNCTOR Γ (FUNCTOR C D) isUniv-C→D
+
 
     -- weak equivalence + univalent = equivalence
     curryF-isEquivalence : isEquivalence curryF

--- a/Cubical/Categories/Instances/Functors/More.agda
+++ b/Cubical/Categories/Instances/Functors/More.agda
@@ -50,7 +50,7 @@ module _ (C : Category ℓC ℓC') (D : Category ℓD ℓD') where
       ≡⟨ solveCat! D ⟩
     (F ⟪ f ⟫ ⋆⟨ D ⟩ α .N-ob c') ⋆⟨ D ⟩ (F' ⟪ f' ⟫ ⋆⟨ D ⟩ α' .N-ob c'') ∎
 
-  module _ {Γ : Category ℓΓ ℓΓ'} where
+  module _ {Γ : Category ℓΓ ℓΓ'}  (isUniv-Γ×C→D : isUnivalent (FUNCTOR (Γ ×C C) D)) (isUniv-Γ→C→D : isUnivalent (FUNCTOR Γ (FUNCTOR C D))) where
     -- The action of currying out the right argument of a Functor (Γ ×C C) D
     λFr : Functor (Γ ×C C) D → Functor Γ (FUNCTOR C D)
     λFr F .F-ob a .F-ob b = F ⟅ a , b ⟆
@@ -125,8 +125,6 @@ module _ (C : Category ℓC ℓC') (D : Category ℓD ℓD') where
     curryF-isFull : isFull curryF
     curryF-isFull F G λη =  (∣ curryF-full-preimage λη , makeNatTransPath (funExt (λ (γ : Γ .ob) →
       makeNatTransPath (funExt (λ (c : C .ob) →
-        curryF .F-hom (curryF-full-preimage λη) .N-ob γ .N-ob c
-        ≡⟨ refl ⟩
         λη .N-ob γ .N-ob c ∎))
       ) ) ∣₁)
 
@@ -225,23 +223,25 @@ module _ (C : Category ℓC ℓC') (D : Category ℓD ℓD') where
       ≡⟨ (λ i → λη₁≡λη₂ i .N-ob γ .N-ob c) ⟩
        η₂ .N-ob (γ , c) ∎))
 
+    -- full + faithul = fully faithful
     curryF-isFullyFaithful : isFullyFaithful curryF
     curryF-isFullyFaithful = isFull+Faithful→isFullyFaithful {F = curryF} curryF-isFull curryF-isFaithful
 
     open isWeakEquivalence
 
-    λF-isWeakEquiv : isWeakEquivalence curryF
-    λF-isWeakEquiv .fullfaith = curryF-isFullyFaithful
-    λF-isWeakEquiv .esssurj = curryF-ess-surj
+    -- fully faithful + ESO = weak equivalence
+    curryF-isWeakEquiv : isWeakEquivalence curryF
+    curryF-isWeakEquiv .fullfaith = curryF-isFullyFaithful
+    curryF-isWeakEquiv .esssurj = curryF-ess-surj
 
-    -- open isUnivalent
+    open isUnivalent
 
-    -- λF-isEquivalence : isEquivalence curryF
-    -- λF-isEquivalence = isWeakEquiv→isEquiv λF-isWeakEquiv
+    -- weak equivalence + univalent = equivalence
+    curryF-isEquivalence : isEquivalence curryF
+    curryF-isEquivalence = isWeakEquiv→isEquiv isUniv-Γ×C→D isUniv-Γ→C→D curryF-isWeakEquiv
 
-    -- open _≃ᶜ_
+    open Cubical.Categories.Equivalence.Base._≃ᶜ_
 
-    -- curryEquivalence : FUNCTOR (Γ ×C C) D ≃ᶜ FUNCTOR Γ (FUNCTOR C D)
-    -- curryEquivalence .func = curry
-    -- curryEquivalence .isEquiv = λF-isEquivalence where
-    --   open Cubical.Categories.Equivalence.Base.
+    curryEquivalence : FUNCTOR (Γ ×C C) D ≃ᶜ FUNCTOR Γ (FUNCTOR C D)
+    curryEquivalence .func = curryF
+    curryEquivalence ._≃ᶜ_.isEquiv = curryF-isEquivalence

--- a/Cubical/Categories/Instances/Functors/More.agda
+++ b/Cubical/Categories/Instances/Functors/More.agda
@@ -79,7 +79,7 @@ module _ (C : Category ℓC ℓC') (D : Category ℓD ℓD') where
 
     -- {!!}{!!}{!!}
     λF-functor : Functor (FUNCTOR (Γ ×C C) D) (FUNCTOR Γ (FUNCTOR C D))
-    λF-functor .F-ob = λF
+    λF-functor .F-ob = λFr
     λF-functor .F-hom η .N-ob γ .N-ob c = η .N-ob (γ , c)
     λF-functor .F-hom η .N-ob γ .N-hom ϕ = η .N-hom (Γ .id , ϕ)
 
@@ -90,16 +90,18 @@ module _ (C : Category ℓC ℓC') (D : Category ℓD ℓD') where
     -- ((λF-functor .F-hom η) .N-ob x) .N-ob c ⋆⟨ ? ⟩ (λF G .F-hom f) .N-ob c
     -- ((λF-functor .F-hom η) .N-ob x ⋆⟨ D ⟩ (λF G .F-hom f)) .N-ob c
 
-    λF-functor .F-hom {F} {G} η .N-hom {x} {y} f = {!!}
+    λF-functor .F-hom {F} {G} η .N-hom {x} {y} f = {!
+    funExt (λ c →
+    (λF F .F-hom f) .N-ob c ⋆⟨ D ⟩ (((λF-functor .F-hom η) .N-ob y) .N-ob c)
+    )
+!}
 
     -- λF-fucnotr .F-hom idTrans F
     -- = ((idTrans F) .N-ob γ) .N-ob c
     -- = (idTrans F) .N-ob (γ , c)
     -- = D .id
     -- = idTranse(λF .F-hom F) .N-ob _ = D .id
-    λF-functor .F-id = {!i
-
-!}
+    λF-functor .F-id = {!!}
     λF-functor .F-seq η η' = {!!}
 
 

--- a/Cubical/Categories/Instances/Functors/More.agda
+++ b/Cubical/Categories/Instances/Functors/More.agda
@@ -81,20 +81,6 @@ module _ (C : Category ℓC ℓC') (D : Category ℓD ℓD') where
     λF-functor .F-hom η .N-ob γ .N-ob c = η .N-ob (γ , c)
     λF-functor .F-hom η .N-ob γ .N-hom ϕ = η .N-hom (Γ .id , ϕ)
     λF-functor .F-hom η .N-hom f = makeNatTransPath (funExt (λ (c : C .ob) → η .N-hom (f , C .id)))
-
-    -- TODO: which is better style. Longer == easier to understand when reading
-     -- ((λFr F .F-hom f) ⋆⟨ FUNCTOR C D ⟩ (λF-functor .F-hom η) .N-ob γ₂) .N-ob c
-     --  ≡⟨ refl ⟩
-     --  (λFr F .F-hom  f) .N-ob c ⋆⟨ D ⟩ (λF-functor .F-hom η) .N-ob γ₂ .N-ob c
-     --  ≡⟨ refl ⟩
-     --  (F .F-hom (f , C .id)) ⋆⟨ D ⟩ (η .N-ob (γ₂ , c))
-     --  ≡⟨  η .N-hom (f , C .id) ⟩
-     --  η .N-ob (γ₁ , c) ⋆⟨ D ⟩ G .F-hom (f , C .id)
-     --  ≡⟨ refl ⟩
-     --  (λF-functor .F-hom η) .N-ob γ₁ .N-ob c ⋆⟨ D ⟩ (λFr G .F-hom f) .N-ob c
-     --  ≡⟨ refl ⟩
-     --  ((λF-functor .F-hom η) .N-ob γ₁ ⋆⟨ FUNCTOR C D ⟩ (λFr G .F-hom f)) .N-ob c ∎))
-
     λF-functor .F-id = makeNatTransPath (funExt λ (γ : Γ .ob) → refl)
     λF-functor .F-seq η η' = makeNatTransPath (funExt λ (γ : Γ .ob) → refl)
 
@@ -103,14 +89,13 @@ module _ (C : Category ℓC ℓC') (D : Category ℓD ℓD') where
     λF-ess-surj = {!!}
 
     λF-isFull : isFull λF-functor
-    λF-isFull = {!!}
+    λF-isFull F G λη = ?
 
     λF-isFaithful : isFaithful λF-functor
-    λF-isFaithful F G η₁ η₂ λη₁=λη₂ = makeNatTransPath (funExt (λ (γ , c) →
+    λF-isFaithful F G η₁ η₂ λη₁≡λη₂ = makeNatTransPath (funExt (λ (γ , c) →
       η₁ .N-ob (γ , c)
-        ≡⟨ {!λ (i : I) → λη₁=λη₂ i .N-ob γ .N-ob c i!} ⟩
-      η₂ .N-ob (γ , c)
-      ∎))
+        ≡⟨ (λ i → λη₁≡λη₂ i .N-ob γ .N-ob c) ⟩
+       η₂ .N-ob (γ , c) ∎))
 
     λF-isFullyFaithful : isFullyFaithful λF-functor
     λF-isFullyFaithful = isFull+Faithful→isFullyFaithful {F = λF-functor} λF-isFull λF-isFaithful

--- a/Cubical/Categories/Instances/Functors/More.agda
+++ b/Cubical/Categories/Instances/Functors/More.agda
@@ -33,14 +33,21 @@ module _ (C : Category ℓC ℓC') (D : Category ℓD ℓD') where
       F∘G-iso-to-id : NatIso (funcComp F G) (Id)
       G∘F-iso-to-id : NatIso (funcComp G F) (Id)
 
+  -- Emily Riehl - Category Theory in Context (CTIC) Lemma 1.5.10
+  -- f-induces-unique-map-between-isos : {C : Category ℓ ℓ'} → {a b a' b' : C .ob} →
+  -- (f : Hom[ a , b ]) → (ϕ : CatIso a a') → (ψ : CatIso b b') →
+  -- Σ[ f' : Hom[ a', b' ] ] (∀ g → (TODO : would need to describe all 4 commuting diags from CTIC here))
+  -- TODO: Should just return ψ ∘ f ∘ ϕ
+
   -- TODO: find proper syntax for existential quantification
   -- Want to show that we have an equivalence of categories iff ess surj on objs, full, faithful
-  --alt-equiv-of-categories : {A B : Category ℓ ℓ'} → (F : Functor A B) →
-  --  isFull F →
-  --  isFaithful F →
-  --  isEssentiallySurj F →
-  --  ∃ G EquivalenceOfCategories F G
-  --alt-equiv-of-categories _ = ?
+  -- Want to just follow CTIC Theorem 1.5.9, but that uses choice
+  alt-equiv-of-categories-forward : {A B : Category ℓ ℓ'} → (F : Functor A B) →
+    isFull F →
+    isFaithful F →
+    isEssentiallySurj F →
+    Σ[ G ∈ Functor B A ] EquivalenceOfCategories F G
+  alt-equiv-of-categories-forward _ = {!!}
 
   appF : Functor ((FUNCTOR C D) ×C C) D
   appF .F-ob (F , c) = F ⟅ c ⟆

--- a/Cubical/Categories/Instances/Functors/More.agda
+++ b/Cubical/Categories/Instances/Functors/More.agda
@@ -17,6 +17,7 @@ open import Cubical.Categories.Constructions.BinProduct
 open import Cubical.Categories.Equivalence.WeakEquivalence
 open import Cubical.Categories.Functor.Properties
 open import Cubical.Categories.Equivalence.Base
+open import Cubical.HITs.PropositionalTruncation
 
 open import AltEquationalReasoning
 open import Cubical.Tactics.CategorySolver.Reflection
@@ -86,16 +87,31 @@ module _ (C : Category ℓC ℓC') (D : Category ℓD ℓD') where
     λF-functor .F-seq η η' = makeNatTransPath (funExt λ (γ : Γ .ob) → refl)
 
 
-    λF-ess-surj : isEssentiallySurj λF-functor
-    λF-ess-surj = {!!}
+    -- Preimage for the fullness proof
+    preimage : {F G : Functor (Γ ×C C) D} (λη : NatTrans (λF-functor .F-ob F) (λF-functor .F-ob G)) → (NatTrans F G)
+    preimage {F} {G} λη .N-ob (γ , c) = λη .N-ob γ .N-ob c
+    preimage {F} {G} λη .N-hom {(γ₁ , c₁)} {(γ₂ , c₂)} (ϕ₁ , ϕ₂) =
+      F .F-hom (ϕ₁ , ϕ₂) ⋆⟨ D ⟩ preimage λη .N-ob (γ₂ , c₂)
+        -- TODO: this is wrong
+        ≡⟨ {!(λ i → (F .F-hom (Γ ⋆IdR ϕ₁ , C ⋆IdL ϕ₂) ⋆⟨ D ⟩ preimage λη .N-ob (γ₂ , c₂)))!} ⟩
+      F .F-hom (ϕ₁ ⋆⟨ Γ ⟩ (Γ .id), (C .id) ⋆⟨ C ⟩ ϕ₂) ⋆⟨ D ⟩ preimage λη .N-ob (γ₂ , c₂)
+        ≡⟨ refl ⟩
+      F .F-hom ((ϕ₁ , (C .id)) ⋆⟨ Γ ×C C ⟩ (Γ .id , ϕ₂)) ⋆⟨ D ⟩ preimage λη .N-ob (γ₂ , c₂)
+        ≡⟨ {!!} ⟩
+      F .F-hom (ϕ₁ , (C .id)) ⋆⟨ D ⟩ F .F-hom ((Γ .id) , ϕ₂) ⋆⟨ D ⟩ preimage λη .N-ob (γ₂ , c₂)
+        ≡⟨ {!!} ⟩
+      preimage λη .N-ob (γ₁ , c₁) ⋆⟨ D ⟩ G .F-hom (ϕ₁ , ϕ₂) ∎
 
     λF-isFull : isFull λF-functor
     λF-isFull F G λη = {!!}
 
+    λF-ess-surj : isEssentiallySurj λF-functor
+    λF-ess-surj = {!!}
+
     λF-isFaithful : isFaithful λF-functor
     λF-isFaithful F G η₁ η₂ λη₁≡λη₂ = makeNatTransPath (funExt (λ (γ , c) →
       η₁ .N-ob (γ , c)
-        ≡⟨ (λ i → λη₁≡λη₂ i .N-ob γ .N-ob c) ⟩
+      ≡⟨ (λ i → λη₁≡λη₂ i .N-ob γ .N-ob c) ⟩
        η₂ .N-ob (γ , c) ∎))
 
     λF-isFullyFaithful : isFullyFaithful λF-functor

--- a/Cubical/Categories/Instances/Functors/More.agda
+++ b/Cubical/Categories/Instances/Functors/More.agda
@@ -33,6 +33,13 @@ module _ (C : Category ℓC ℓC') (D : Category ℓD ℓD') where
       F∘G-iso-to-id : NatIso (funcComp F G) (Id)
       G∘F-iso-to-id : NatIso (funcComp G F) (Id)
 
+  record EquivalenceOfCategories' {A B : Category ℓ ℓ'} (F : Functor A B) : Type (ℓ-max ℓ ℓ') where
+    constructor is-equiv-of-cats'
+    field
+      full : isFull F
+      faithful : isFaithful F
+      essentiallySurj : isEssentiallySurj F
+
   -- Emily Riehl - Category Theory in Context (CTIC) Lemma 1.5.10
   -- f-induces-unique-map-between-isos : {C : Category ℓ ℓ'} → {a b a' b' : C .ob} →
   -- (f : Hom[ a , b ]) → (ϕ : CatIso a a') → (ψ : CatIso b b') →
@@ -42,12 +49,15 @@ module _ (C : Category ℓC ℓC') (D : Category ℓD ℓD') where
   -- TODO: find proper syntax for existential quantification
   -- Want to show that we have an equivalence of categories iff ess surj on objs, full, faithful
   -- Want to just follow CTIC Theorem 1.5.9, but that uses choice
-  alt-equiv-of-categories-forward : {A B : Category ℓ ℓ'} → (F : Functor A B) →
-    isFull F →
-    isFaithful F →
-    isEssentiallySurj F →
+  equiv-of-categories-forward : {A B : Category ℓ ℓ'} → (F : Functor A B) →
+    EquivalenceOfCategories' F →
     Σ[ G ∈ Functor B A ] EquivalenceOfCategories F G
-  alt-equiv-of-categories-forward _ = {!!}
+  equiv-of-categories-forward _ = {!!}
+
+  equiv-of-categories-reverse : {A B : Category ℓ ℓ'} → (F : Functor A B) →
+    Σ[ G ∈ Functor B A ] EquivalenceOfCategories F G →
+    EquivalenceOfCategories' F
+  equiv-of-categories-reverse F G,EquivFG = {!!}
 
   appF : Functor ((FUNCTOR C D) ×C C) D
   appF .F-ob (F , c) = F ⟅ c ⟆

--- a/Cubical/Categories/Instances/Functors/More.agda
+++ b/Cubical/Categories/Instances/Functors/More.agda
@@ -24,41 +24,6 @@ module _ (C : Category ℓC ℓC') (D : Category ℓD ℓD') where
   open Functor
   open NatTrans
 
-  -- TODO: don't really know what's going on w universes here. Introduced levels ℓ ℓ' not tied to C, D, or Γ in hopes to make this general
-  -- The type of this record makes no sense to me at the moment, but does make everything type check.
-  -- TODO: Maybe put this is a different file
-  record EquivalenceOfCategories {A B : Category ℓ ℓ'}(F : Functor A B) (G : Functor B A) : Type (ℓ-max ℓ ℓ') where
-    constructor is-equiv-of-cats
-    field
-      F∘G-iso-to-id : NatIso (funcComp F G) (Id)
-      G∘F-iso-to-id : NatIso (funcComp G F) (Id)
-
-  record EquivalenceOfCategories' {A B : Category ℓ ℓ'} (F : Functor A B) : Type (ℓ-max ℓ ℓ') where
-    constructor is-equiv-of-cats'
-    field
-      full : isFull F
-      faithful : isFaithful F
-      essentiallySurj : isEssentiallySurj F
-
-  -- Emily Riehl - Category Theory in Context (CTIC) Lemma 1.5.10
-  -- f-induces-unique-map-between-isos : {C : Category ℓ ℓ'} → {a b a' b' : C .ob} →
-  -- (f : Hom[ a , b ]) → (ϕ : CatIso a a') → (ψ : CatIso b b') →
-  -- Σ[ f' : Hom[ a', b' ] ] (∀ g → (TODO : would need to describe all 4 commuting diags from CTIC here))
-  -- TODO: Should just return ψ ∘ f ∘ ϕ
-
-  -- TODO: find proper syntax for existential quantification
-  -- Want to show that we have an equivalence of categories iff ess surj on objs, full, faithful
-  -- Want to just follow CTIC Theorem 1.5.9, but that uses choice
-  equiv-of-categories-forward : {A B : Category ℓ ℓ'} → (F : Functor A B) →
-    EquivalenceOfCategories' F →
-    Σ[ G ∈ Functor B A ] EquivalenceOfCategories F G
-  equiv-of-categories-forward _ = {!!}
-
-  equiv-of-categories-reverse : {A B : Category ℓ ℓ'} → (F : Functor A B) →
-    Σ[ G ∈ Functor B A ] EquivalenceOfCategories F G →
-    EquivalenceOfCategories' F
-  equiv-of-categories-reverse F G,EquivFG = {!!}
-
   appF : Functor ((FUNCTOR C D) ×C C) D
   appF .F-ob (F , c) = F ⟅ c ⟆
   appF .F-hom {x = (F , c)}{y = (F' , c')} (α , f) = F ⟪ f ⟫ ⋆⟨ D ⟩ α .N-ob c'

--- a/Cubical/Categories/Instances/Functors/More.agda
+++ b/Cubical/Categories/Instances/Functors/More.agda
@@ -14,6 +14,9 @@ open import Cubical.Foundations.HLevels
 open import Cubical.Foundations.Isomorphism
 open import Cubical.Categories.Instances.Functors
 open import Cubical.Categories.Constructions.BinProduct
+open import Cubical.Categories.Equivalence.WeakEquivalence
+open import Cubical.Categories.Functor.Properties
+open import Cubical.Categories.Equivalence.Base
 
 open import AltEquationalReasoning
 open import Cubical.Tactics.CategorySolver.Reflection
@@ -92,15 +95,43 @@ module _ (C : Category ℓC ℓC') (D : Category ℓD ℓD') where
      --  ≡⟨ refl ⟩
      --  ((λF-functor .F-hom η) .N-ob γ₁ ⋆⟨ FUNCTOR C D ⟩ (λFr G .F-hom f)) .N-ob c ∎))
 
-
     λF-functor .F-id = makeNatTransPath (funExt λ (γ : Γ .ob) → refl)
     λF-functor .F-seq η η' = makeNatTransPath (funExt λ (γ : Γ .ob) → refl)
 
 
+    λF-ess-surj : isEssentiallySurj λF-functor
+    λF-ess-surj = {!!}
 
+    λF-isFull : isFull λF-functor
+    λF-isFull = {!!}
 
-    -- λF-ess-surj : isEssentiallySurj λF
-    -- λF-ess-surj = ?
+    λF-isFaithful : isFaithful λF-functor
+    λF-isFaithful F G η₁ η₂ λη₁=λη₂ = makeNatTransPath (funExt (λ (γ , c) →
+      η₁ .N-ob (γ , c)
+        ≡⟨ {!λ (i : I) → λη₁=λη₂ i .N-ob γ .N-ob c i!} ⟩
+      η₂ .N-ob (γ , c)
+      ∎))
+
+    λF-isFullyFaithful : isFullyFaithful λF-functor
+    λF-isFullyFaithful = isFull+Faithful→isFullyFaithful {F = λF-functor} λF-isFull λF-isFaithful
+
+    open isWeakEquivalence
+
+    λF-isWeakEquiv : isWeakEquivalence λF-functor
+    λF-isWeakEquiv .fullfaith = λF-isFullyFaithful
+    λF-isWeakEquiv .esssurj = λF-ess-surj
+
+    -- open isUnivalent
+
+    -- λF-isEquivalence : isEquivalence λF-functor
+    -- λF-isEquivalence = isWeakEquiv→isEquiv λF-isWeakEquiv
+
+    -- open _≃ᶜ_
+
+    -- curryEquivalence : FUNCTOR (Γ ×C C) D ≃ᶜ FUNCTOR Γ (FUNCTOR C D)
+    -- curryEquivalence .func = λF-functor
+    -- curryEquivalence .isEquiv = λF-isEquivalence where
+    --   open Cubical.Categories.Equivalence.Base.
 
     λFl : Functor (C ×C Γ) D → Functor Γ (FUNCTOR C D)
     λFl F = λFr (F ∘F (Snd Γ C ,F Fst Γ C))

--- a/Cubical/Categories/Instances/Functors/More.agda
+++ b/Cubical/Categories/Instances/Functors/More.agda
@@ -93,16 +93,28 @@ module _ (C : Category ℓC ℓC') (D : Category ℓD ℓD') where
     preimage {F} {G} λη .N-hom {(γ₁ , c₁)} {(γ₂ , c₂)} (ϕ₁ , ϕ₂) =
       F .F-hom (ϕ₁ , ϕ₂) ⋆⟨ D ⟩ preimage λη .N-ob (γ₂ , c₂)
         ≡⟨ (λ i → (F .F-hom ((Γ .⋆IdR ϕ₁) (~ i) , (C .⋆IdL ϕ₂) (~ i)) ⋆⟨ D ⟩ preimage λη .N-ob (γ₂ , c₂))) ⟩
-      F .F-hom (ϕ₁ ⋆⟨ Γ ⟩ (Γ .id), (C .id) ⋆⟨ C ⟩ ϕ₂) ⋆⟨ D ⟩ preimage λη .N-ob (γ₂ , c₂)
+      F .F-hom (ϕ₁ ⋆⟨ Γ ⟩ Γ .id , C .id ⋆⟨ C ⟩ ϕ₂) ⋆⟨ D ⟩ preimage λη .N-ob (γ₂ , c₂)
         ≡⟨ refl ⟩
-      F .F-hom ((ϕ₁ , (C .id)) ⋆⟨ Γ ×C C ⟩ (Γ .id , ϕ₂)) ⋆⟨ D ⟩ preimage λη .N-ob (γ₂ , c₂)
-        ≡⟨ (λ i → (F .F-seq (ϕ₁ , (C .id)) (Γ .id , ϕ₂)) (i) ⋆⟨ D ⟩ preimage λη .N-ob (γ₂ , c₂)) ⟩
-      F .F-hom (ϕ₁ , (C .id)) ⋆⟨ D ⟩ F .F-hom ((Γ .id) , ϕ₂) ⋆⟨ D ⟩ preimage λη .N-ob (γ₂ , c₂)
-        ≡⟨ {!!} ⟩
+      F .F-hom ((ϕ₁ , C .id) ⋆⟨ Γ ×C C ⟩ (Γ .id , ϕ₂)) ⋆⟨ D ⟩ preimage λη .N-ob (γ₂ , c₂)
+        ≡⟨ (λ i → (F .F-seq (ϕ₁ , C .id) (Γ .id , ϕ₂)) (i) ⋆⟨ D ⟩ preimage λη .N-ob (γ₂ , c₂)) ⟩
+      F .F-hom (ϕ₁ , C .id) ⋆⟨ D ⟩ F .F-hom (Γ .id , ϕ₂) ⋆⟨ D ⟩ preimage λη .N-ob (γ₂ , c₂)
+        ≡⟨ D .⋆Assoc (F .F-hom (ϕ₁ , C .id)) (F .F-hom (Γ .id , ϕ₂) ) (preimage λη .N-ob (γ₂ , c₂)) ⟩
+      F .F-hom (ϕ₁ , C .id) ⋆⟨ D ⟩ (F .F-hom (Γ .id , ϕ₂) ⋆⟨ D ⟩ preimage λη .N-ob (γ₂ , c₂))
+        ≡⟨ ((λ i → ((F .F-hom (ϕ₁ , C .id)) ⋆⟨ D ⟩ (λη .N-ob γ₂ .N-hom ϕ₂ (i))))) ⟩
+      F .F-hom (ϕ₁ , C .id) ⋆⟨ D ⟩ (preimage λη .N-ob (γ₂ , c₁) ⋆⟨ D ⟩ G .F-hom (Γ .id , ϕ₂))
+        ≡⟨  sym (D .⋆Assoc (F .F-hom (ϕ₁ , C .id)) (preimage λη .N-ob (γ₂ , c₁)) (G .F-hom (Γ .id , ϕ₂)))  ⟩
+      (F .F-hom (ϕ₁ , C .id) ⋆⟨ D ⟩ preimage λη .N-ob (γ₂ , c₁)) ⋆⟨ D ⟩ G .F-hom (Γ .id , ϕ₂)
+        ≡⟨ ((λ i → ( ((λη .N-hom ϕ₁ (i)) .N-ob c₁) ⋆⟨ D ⟩ G .F-hom (Γ .id , ϕ₂) ))) ⟩
+      (preimage λη .N-ob (γ₁ , c₁) ⋆⟨ D ⟩ G .F-hom (ϕ₁ , C .id)) ⋆⟨ D ⟩ G .F-hom (Γ .id , ϕ₂)
+        ≡⟨ D .⋆Assoc (preimage λη .N-ob (γ₁ , c₁)) (G .F-hom (ϕ₁ , C .id)) (G .F-hom (Γ .id , ϕ₂)) ⟩
+      preimage λη .N-ob (γ₁ , c₁) ⋆⟨ D ⟩ (G .F-hom (ϕ₁ , C .id) ⋆⟨ D ⟩ G .F-hom (Γ .id , ϕ₂))
+        ≡⟨ ((λ i → (preimage λη .N-ob (γ₁ , c₁) ⋆⟨ D ⟩ (G .F-seq (ϕ₁ , C .id) (Γ .id , ϕ₂)) (~ i) ))) ⟩
+      preimage λη .N-ob (γ₁ , c₁) ⋆⟨ D ⟩ (G .F-hom ((ϕ₁ , C .id) ⋆⟨ Γ ×C C ⟩ (Γ .id , ϕ₂)))
+        ≡⟨ ((λ i → (preimage λη .N-ob (γ₁ , c₁) ⋆⟨ D ⟩ (G .F-hom (((Γ .⋆IdR ϕ₁) i), ((C .⋆IdL ϕ₂) i))) ))) ⟩
       preimage λη .N-ob (γ₁ , c₁) ⋆⟨ D ⟩ G .F-hom (ϕ₁ , ϕ₂) ∎
 
     λF-isFull : isFull λF-functor
-    λF-isFull F G λη =  ∣ {!!} , {!!} ∣₁
+    λF-isFull F G λη =  ∣ preimage λη , makeNatTransPath (funExt (λ (γ : Γ .ob) → {!!} )) ∣₁
 
     λF-ess-surj : isEssentiallySurj λF-functor
     λF-ess-surj = {!!}

--- a/Cubical/Categories/Instances/Functors/More.agda
+++ b/Cubical/Categories/Instances/Functors/More.agda
@@ -73,36 +73,28 @@ module _ (C : Category ℓC ℓC') (D : Category ℓD ℓD') where
           ≡⟨ F .F-seq (γ , C .id) (δ , C .id) ⟩
         F .F-hom (γ , C .id) ⋆⟨ D ⟩ F .F-hom (δ , C .id) ∎))
 
-    -- λF-functor : Functor (FUNCTOR (Γ ×C C) D) (FUNCTOR Γ (FUNCTOR C D))
-    -- λF-functor .F-ob = λF
-    -- Want to define λF-functor .F-hom η to be the map (b ↦ F a b) ↦ (b ↦ η (F a b))
-
-    -- {!!}{!!}{!!}
     λF-functor : Functor (FUNCTOR (Γ ×C C) D) (FUNCTOR Γ (FUNCTOR C D))
     λF-functor .F-ob = λFr
     λF-functor .F-hom η .N-ob γ .N-ob c = η .N-ob (γ , c)
     λF-functor .F-hom η .N-ob γ .N-hom ϕ = η .N-hom (Γ .id , ϕ)
+    λF-functor .F-hom η .N-hom f = makeNatTransPath (funExt (λ (c : C .ob) → η .N-hom (f , C .id)))
 
-    -- ((λF F .F-hom f) ⋆⟨ D ⟩ (λF-functor .F-hom η) .N-ob y) .N-ob c
-    -- ((λF F .F-hom f) .N-ob c) ⋆⟨ ? ⟩ ((λF-functor .F-hom η) .N-ob y) .N-ob c
-    -- (F .F-hom (f , C .id)) ⋆⟨ ? ⟩ (η .N-ob (y , c))
-    -- (η .N-ob (x , c)) ⋆⟨ ? ⟩ (G .F-hom (f , C .id))
-    -- ((λF-functor .F-hom η) .N-ob x) .N-ob c ⋆⟨ ? ⟩ (λF G .F-hom f) .N-ob c
-    -- ((λF-functor .F-hom η) .N-ob x ⋆⟨ D ⟩ (λF G .F-hom f)) .N-ob c
+    -- TODO: which is better style. Longer == easier to understand when reading
+     -- ((λFr F .F-hom f) ⋆⟨ FUNCTOR C D ⟩ (λF-functor .F-hom η) .N-ob γ₂) .N-ob c
+     --  ≡⟨ refl ⟩
+     --  (λFr F .F-hom  f) .N-ob c ⋆⟨ D ⟩ (λF-functor .F-hom η) .N-ob γ₂ .N-ob c
+     --  ≡⟨ refl ⟩
+     --  (F .F-hom (f , C .id)) ⋆⟨ D ⟩ (η .N-ob (γ₂ , c))
+     --  ≡⟨  η .N-hom (f , C .id) ⟩
+     --  η .N-ob (γ₁ , c) ⋆⟨ D ⟩ G .F-hom (f , C .id)
+     --  ≡⟨ refl ⟩
+     --  (λF-functor .F-hom η) .N-ob γ₁ .N-ob c ⋆⟨ D ⟩ (λFr G .F-hom f) .N-ob c
+     --  ≡⟨ refl ⟩
+     --  ((λF-functor .F-hom η) .N-ob γ₁ ⋆⟨ FUNCTOR C D ⟩ (λFr G .F-hom f)) .N-ob c ∎))
 
-    λF-functor .F-hom {F} {G} η .N-hom {x} {y} f = {!
-    funExt (λ c →
-    (λF F .F-hom f) .N-ob c ⋆⟨ D ⟩ (((λF-functor .F-hom η) .N-ob y) .N-ob c)
-    )
-!}
 
-    -- λF-fucnotr .F-hom idTrans F
-    -- = ((idTrans F) .N-ob γ) .N-ob c
-    -- = (idTrans F) .N-ob (γ , c)
-    -- = D .id
-    -- = idTranse(λF .F-hom F) .N-ob _ = D .id
-    λF-functor .F-id = {!!}
-    λF-functor .F-seq η η' = {!!}
+    λF-functor .F-id = makeNatTransPath (funExt λ (γ : Γ .ob) → refl)
+    λF-functor .F-seq η η' = makeNatTransPath (funExt λ (γ : Γ .ob) → refl)
 
 
 

--- a/Cubical/Categories/Instances/Functors/More.agda
+++ b/Cubical/Categories/Instances/Functors/More.agda
@@ -114,7 +114,12 @@ module _ (C : Category ℓC ℓC') (D : Category ℓD ℓD') where
       preimage λη .N-ob (γ₁ , c₁) ⋆⟨ D ⟩ G .F-hom (ϕ₁ , ϕ₂) ∎
 
     λF-isFull : isFull λF-functor
-    λF-isFull F G λη =  ∣ preimage λη , makeNatTransPath (funExt (λ (γ : Γ .ob) → {!!} )) ∣₁
+    λF-isFull F G λη =  (∣ preimage λη , makeNatTransPath (funExt (λ (γ : Γ .ob) →
+      makeNatTransPath (funExt (λ (c : C .ob) →
+        λF-functor .F-hom (preimage λη) .N-ob γ .N-ob c
+        ≡⟨ refl ⟩
+        λη .N-ob γ .N-ob c ∎))
+      ) ) ∣₁)
 
     λF-ess-surj : isEssentiallySurj λF-functor
     λF-ess-surj = {!!}


### PR DESCRIPTION
Established that currying is an equivalence of categories. Some notes about this:

- I renamed everything to make more sense. Maybe a little too verbose, but the public parts seem to have nice enough names. And the non-public parts at least have descriptive names
- Not sure how to organize the `module`s in the code so that only the parts we want are exposed in the public interface
- I define a `swapArgs` functor, so that we can left-hand curry as well. Show that `swapArgs` is an equivalence doesn't seem to play nicely with Agda's termination checker. I'm not doing any recursion by hand, but perhaps `solveCat!` is inducing some strange behavior here
- After talking some with Pranav, it seems like it might be useful to build a proper uncurry functor, as we have all of the data for it laying around in these proofs

These last two points are not complete, but I think there may be enough that is complete to unblock the other issues