### PR TITLE
Removing Univalence Dependency in Curry Equivalence Proof

### DIFF
--- a/Cubical/Categories/Equivalence/More.agda
+++ b/Cubical/Categories/Equivalence/More.agda
@@ -18,6 +18,7 @@ open import Cubical.Categories.Equivalence.Base
 open import Cubical.Categories.Category
 
 open import Cubical.Tactics.CategorySolver.Reflection
+open import Cubical.Categories.NaturalTransformation.More
 
 private
   variable
@@ -34,14 +35,51 @@ module _
   open NatTrans
   open isEquivalence
   open NatIso
+  open isIso
 
   isEquivalenceComp : isEquivalence F → isEquivalence G → isEquivalence (G ∘F F)
   isEquivalenceComp Feq Geq = record { invFunc = F'G' ; η = η-iso ; ε = ε-iso } where
     F'G' : Functor E C
     F'G' = Feq .invFunc ∘F  Geq .invFunc
     η-iso : NatIso 𝟙⟨ C ⟩ (F'G' ∘F (G ∘F F))
-    η-iso .trans .N-ob c = Feq .invFunc .F-hom (Geq .η .trans .N-ob (F .F-ob c))
-    η-iso .trans .N-hom = {!   !}
-    η-iso .nIso = {!   !}
+    η-iso = seqNatIso 
+      -- proof that 1 and (F' F) are iso
+      (Feq .η)
+      -- proof that (F' F) and (F' G') (G F) are iso
+      (seqNatIso
+        -- precompose nested iso with F'
+        ((Feq .invFunc) ∘ʳi seqNatIso
+          -- proof that F and (G' G) F are isomorphic
+          (seqNatIso
+            -- proof that F and 1 F are iso
+            (symNatIso (CAT⋆IdR {F = F}))
+            -- proof that 1 F and (G' G) F are iso (whisker with F)
+            (F ∘ˡi (Geq .η)))
+          -- associate the parentheses (G' G) F and G' (G F)
+          (symNatIso (CAT⋆Assoc F G (Geq .invFunc)))
+        )
+        -- fix final assoc F' (G' (G F) iso to (F' G') (G F)
+        (CAT⋆Assoc (G ∘F F) (Geq .invFunc) (Feq .invFunc))
+      )
+
     ε-iso : NatIso ((G ∘F F) ∘F F'G') 𝟙⟨ E ⟩
-    ε-iso = {!   !}
+    ε-iso = seqNatIso
+      -- proof that (G F) (F' G') and G G' are iso
+      (seqNatIso
+        -- proof that (G F) (F' G') and G (F (F' G')) are iso
+        (symNatIso (CAT⋆Assoc (F'G') F G))
+        -- post compose nested proof with G
+        (G ∘ʳi seqNatIso
+          -- proof that F (F' G') and 1 G' are iso
+          (seqNatIso
+            -- proof that F (F' G') and (F F') G' are iso
+            (CAT⋆Assoc (Geq .invFunc) (Feq .invFunc) F) 
+            -- proof that (F F') G' and 1 G' are iso (whisker with G')
+            ((Geq .invFunc) ∘ˡi (Feq .ε))
+          )
+          -- proof that (1 G') and G are iso
+          (CAT⋆IdR {F = Geq .invFunc})
+        )
+      )
+      -- proof that G G' and 1 are iso 
+      (Geq .ε)

--- a/Cubical/Categories/Equivalence/More.agda
+++ b/Cubical/Categories/Equivalence/More.agda
@@ -22,12 +22,12 @@ open import Cubical.Categories.NaturalTransformation.More
 
 private
   variable
-    ℓC ℓC' ℓD ℓD' ℓE ℓE' ℓ ℓ' : Level
+    ℓC ℓC' ℓD ℓD' ℓE ℓE' : Level
 
 
 module _ 
   {C : Category ℓC ℓC'} {D : Category ℓD ℓD'} {E : Category ℓE ℓE'} 
-  (F : Functor C D) (G : Functor D E)
+  {F : Functor C D} {G : Functor D E}
   where
   
   open Category

--- a/Cubical/Categories/Equivalence/More.agda
+++ b/Cubical/Categories/Equivalence/More.agda
@@ -2,23 +2,14 @@
 
 module Cubical.Categories.Equivalence.More where
 
-open import Cubical.Categories.Category renaming (isIso to isIsoC)
+open import Cubical.Categories.Category
 open import Cubical.Categories.Functor.Base
 open import Cubical.Categories.NaturalTransformation.Base
 open import Cubical.Categories.NaturalTransformation.Properties
-open import Cubical.Categories.Morphism
-open import Cubical.Foundations.Prelude
-open import Cubical.Foundations.Equiv
-open import Cubical.Foundations.Equiv.Properties
-open import Cubical.Foundations.HLevels
-open import Cubical.Foundations.Isomorphism
-open import Cubical.Categories.Instances.Functors
-open import Cubical.Categories.Functor.Properties
-open import Cubical.Categories.Equivalence.Base
-open import Cubical.Categories.Category
-
-open import Cubical.Tactics.CategorySolver.Reflection
 open import Cubical.Categories.NaturalTransformation.More
+open import Cubical.Foundations.Prelude
+open import Cubical.Categories.Equivalence.Base
+
 
 private
   variable
@@ -58,7 +49,7 @@ module _
           -- associate the parentheses (G' G) F and G' (G F)
           (symNatIso (CAT⋆Assoc F G (Geq .invFunc)))
         )
-        -- fix final assoc F' (G' (G F) iso to (F' G') (G F)
+        -- fix final assoc F' (G' (G F)) iso to (F' G') (G F)
         (CAT⋆Assoc (G ∘F F) (Geq .invFunc) (Feq .invFunc))
       )
 

--- a/Cubical/Categories/Equivalence/More.agda
+++ b/Cubical/Categories/Equivalence/More.agda
@@ -1,0 +1,47 @@
+{-# OPTIONS --safe #-}
+
+module Cubical.Categories.Equivalence.More where
+
+open import Cubical.Categories.Category renaming (isIso to isIsoC)
+open import Cubical.Categories.Functor.Base
+open import Cubical.Categories.NaturalTransformation.Base
+open import Cubical.Categories.NaturalTransformation.Properties
+open import Cubical.Categories.Morphism
+open import Cubical.Foundations.Prelude
+open import Cubical.Foundations.Equiv
+open import Cubical.Foundations.Equiv.Properties
+open import Cubical.Foundations.HLevels
+open import Cubical.Foundations.Isomorphism
+open import Cubical.Categories.Instances.Functors
+open import Cubical.Categories.Functor.Properties
+open import Cubical.Categories.Equivalence.Base
+open import Cubical.Categories.Category
+
+open import Cubical.Tactics.CategorySolver.Reflection
+
+private
+  variable
+    ℓC ℓC' ℓD ℓD' ℓE ℓE' ℓ ℓ' : Level
+
+
+module _ 
+  {C : Category ℓC ℓC'} {D : Category ℓD ℓD'} {E : Category ℓE ℓE'} 
+  (F : Functor C D) (G : Functor D E)
+  where
+  
+  open Category
+  open Functor
+  open NatTrans
+  open isEquivalence
+  open NatIso
+
+  isEquivalenceComp : isEquivalence F → isEquivalence G → isEquivalence (G ∘F F)
+  isEquivalenceComp Feq Geq = record { invFunc = F'G' ; η = η-iso ; ε = ε-iso } where
+    F'G' : Functor E C
+    F'G' = Feq .invFunc ∘F  Geq .invFunc
+    η-iso : NatIso 𝟙⟨ C ⟩ (F'G' ∘F (G ∘F F))
+    η-iso .trans .N-ob c = Feq .invFunc .F-hom (Geq .η .trans .N-ob (F .F-ob c))
+    η-iso .trans .N-hom = {!   !}
+    η-iso .nIso = {!   !}
+    ε-iso : NatIso ((G ∘F F) ∘F F'G') 𝟙⟨ E ⟩
+    ε-iso = {!   !}

--- a/Cubical/Categories/Instances/Functors/More.agda
+++ b/Cubical/Categories/Instances/Functors/More.agda
@@ -14,10 +14,8 @@ open import Cubical.Foundations.HLevels
 open import Cubical.Foundations.Isomorphism
 open import Cubical.Categories.Instances.Functors
 open import Cubical.Categories.Constructions.BinProduct
--- open import Cubical.Categories.Equivalence.WeakEquivalence
 open import Cubical.Categories.Functor.Properties
 open import Cubical.Categories.Equivalence.Base
--- open import Cubical.HITs.PropositionalTruncation
 open import Cubical.Categories.Category
 
 open import Cubical.Tactics.CategorySolver.Reflection
@@ -91,37 +89,6 @@ module _ (C : Category ℓC ℓC') (D : Category ℓD ℓD') where
     curryF .F-hom η .N-hom f = makeNatTransPath (funExt (λ (c : C .ob) → η .N-hom (f , C .id)))
     curryF .F-id = makeNatTransPath (funExt λ (γ : Γ .ob) → refl)
     curryF .F-seq η η' = makeNatTransPath (funExt λ (γ : Γ .ob) → refl)
-
-    -- Preimage for the fullness proof --- i.e. a morphism in FUNCTOR (Γ ×C C) D that maps to λη under curryF
-    -- curryF-full-preimage : {F G : Functor (Γ ×C C) D} (λη : NatTrans (curryF .F-ob F) (curryF .F-ob G)) → (NatTrans F G)
-    -- curryF-full-preimage {F} {G} λη .N-ob (γ , c) = λη .N-ob γ .N-ob c
-    -- curryF-full-preimage {F} {G} λη .N-hom {(γ₁ , c₁)} {(γ₂ , c₂)} (ϕ₁ , ϕ₂) =
-    --   F .F-hom (ϕ₁ , ϕ₂) ⋆⟨ D ⟩ curryF-full-preimage λη .N-ob (γ₂ , c₂)
-    --     ≡⟨ (λ i → (F .F-hom ((Γ .⋆IdR ϕ₁) (~ i) , (C .⋆IdL ϕ₂) (~ i)) ⋆⟨ D ⟩ curryF-full-preimage λη .N-ob (γ₂ , c₂))) ⟩
-    --   F .F-hom ((ϕ₁ , C .id) ⋆⟨ Γ ×C C ⟩ (Γ .id , ϕ₂)) ⋆⟨ D ⟩ curryF-full-preimage λη .N-ob (γ₂ , c₂)
-    --     ≡⟨ (λ i → (F .F-seq (ϕ₁ , C .id) (Γ .id , ϕ₂)) (i) ⋆⟨ D ⟩ curryF-full-preimage λη .N-ob (γ₂ , c₂)) ⟩
-    --   F .F-hom (ϕ₁ , C .id) ⋆⟨ D ⟩ F .F-hom (Γ .id , ϕ₂) ⋆⟨ D ⟩ curryF-full-preimage λη .N-ob (γ₂ , c₂)
-    --     ≡⟨ D .⋆Assoc (F .F-hom (ϕ₁ , C .id)) (F .F-hom (Γ .id , ϕ₂) ) (curryF-full-preimage λη .N-ob (γ₂ , c₂)) ⟩
-    --   F .F-hom (ϕ₁ , C .id) ⋆⟨ D ⟩ (F .F-hom (Γ .id , ϕ₂) ⋆⟨ D ⟩ curryF-full-preimage λη .N-ob (γ₂ , c₂))
-    --     ≡⟨ ((λ i → ((F .F-hom (ϕ₁ , C .id)) ⋆⟨ D ⟩ (λη .N-ob γ₂ .N-hom ϕ₂ (i))))) ⟩
-    --   F .F-hom (ϕ₁ , C .id) ⋆⟨ D ⟩ (curryF-full-preimage λη .N-ob (γ₂ , c₁) ⋆⟨ D ⟩ G .F-hom (Γ .id , ϕ₂))
-    --     ≡⟨  sym (D .⋆Assoc (F .F-hom (ϕ₁ , C .id)) (curryF-full-preimage λη .N-ob (γ₂ , c₁)) (G .F-hom (Γ .id , ϕ₂)))  ⟩
-    --   (F .F-hom (ϕ₁ , C .id) ⋆⟨ D ⟩ curryF-full-preimage λη .N-ob (γ₂ , c₁)) ⋆⟨ D ⟩ G .F-hom (Γ .id , ϕ₂)
-    --     ≡⟨ ((λ i → ( ((λη .N-hom ϕ₁ (i)) .N-ob c₁) ⋆⟨ D ⟩ G .F-hom (Γ .id , ϕ₂) ))) ⟩
-    --   (curryF-full-preimage λη .N-ob (γ₁ , c₁) ⋆⟨ D ⟩ G .F-hom (ϕ₁ , C .id)) ⋆⟨ D ⟩ G .F-hom (Γ .id , ϕ₂)
-    --     ≡⟨ D .⋆Assoc (curryF-full-preimage λη .N-ob (γ₁ , c₁)) (G .F-hom (ϕ₁ , C .id)) (G .F-hom (Γ .id , ϕ₂)) ⟩
-    --   curryF-full-preimage λη .N-ob (γ₁ , c₁) ⋆⟨ D ⟩ (G .F-hom (ϕ₁ , C .id) ⋆⟨ D ⟩ G .F-hom (Γ .id , ϕ₂))
-    --     ≡⟨ ((λ i → (curryF-full-preimage λη .N-ob (γ₁ , c₁) ⋆⟨ D ⟩ (G .F-seq (ϕ₁ , C .id) (Γ .id , ϕ₂)) (~ i) ))) ⟩
-    --   curryF-full-preimage λη .N-ob (γ₁ , c₁) ⋆⟨ D ⟩ (G .F-hom ((ϕ₁ , C .id) ⋆⟨ Γ ×C C ⟩ (Γ .id , ϕ₂)))
-    --     ≡⟨ ((λ i → (curryF-full-preimage λη .N-ob (γ₁ , c₁) ⋆⟨ D ⟩ (G .F-hom (((Γ .⋆IdR ϕ₁) i), ((C .⋆IdL ϕ₂) i))) ))) ⟩
-    --   curryF-full-preimage λη .N-ob (γ₁ , c₁) ⋆⟨ D ⟩ G .F-hom (ϕ₁ , ϕ₂) ∎
-
-    -- -- curryF is a full functor
-    -- curryF-isFull : isFull curryF
-    -- curryF-isFull F G λη =  (∣ curryF-full-preimage λη , makeNatTransPath (funExt (λ (γ : Γ .ob) →
-    --   makeNatTransPath (funExt (λ (c : C .ob) →
-    --     λη .N-ob γ .N-ob c ∎))
-    --   ) ) ∣₁)
 
     -- Preimage for the ESO proof --- an object in (FUNCTOR Γ (FUNCTOR C D)) that maps to λF
     curryF-ESO-object-preimage : (FUNCTOR Γ (FUNCTOR C D)) .ob → (FUNCTOR (Γ ×C C) D) .ob
@@ -208,6 +175,7 @@ module _ (C : Category ℓC ℓC') (D : Category ℓD ℓD') where
       ))))
     
     
+    -- to prove that curryF is an equivalence, we construct the inverse functor, uncurryF
     uncurryF : Functor (FUNCTOR Γ (FUNCTOR C D)) (FUNCTOR (Γ ×C C) D)
     uncurryF .F-ob λF = curryF-ESO-object-preimage λF
     -- stolen from curryF-full-preimage
@@ -228,31 +196,11 @@ module _ (C : Category ℓC ℓC') (D : Category ℓD ℓD') where
     uncurryF .F-seq λη₁ λη₂ = makeNatTransPath (funExt (λ x → refl ))
 
 
-    -- curryF is essential surjective on objects
-    -- curryF-ess-surj : isEssentiallySurj curryF
-    -- curryF-ess-surj λF = ( ∣ curryF-ESO-object-preimage λF , (curryF-ESO-morphism-preimage λF , curryF-ESO-morphism-preimage-isIso λF) ∣₁ )
-
-    -- curryF is a faithful functor
-    -- curryF-isFaithful : isFaithful curryF
-    -- curryF-isFaithful F G η₁ η₂ λη₁≡λη₂ = makeNatTransPath (funExt (λ (γ , c) →
-    --   η₁ .N-ob (γ , c)
-    --   ≡⟨ (λ i → λη₁≡λη₂ i .N-ob γ .N-ob c) ⟩
-    --    η₂ .N-ob (γ , c) ∎))
-
-    -- full + faithul = fully faithful
-    -- curryF-isFullyFaithful : isFullyFaithful curryF
-    -- curryF-isFullyFaithful = isFull+Faithful→isFullyFaithful {F = curryF} curryF-isFull curryF-isFaithful
-
-    -- open isWeakEquivalence
-
-    -- fully faithful + ESO = weak equivalence
-    -- curryF-isWeakEquiv : isWeakEquivalence curryF
-    -- curryF-isWeakEquiv .fullfaith = curryF-isFullyFaithful
-    -- curryF-isWeakEquiv .esssurj = curryF-ess-surj
-
     open isEquivalence
     open NatIso
 
+    -- curryF is an equivalence. Done using η ε isos constructed explicitly.
+    -- most of the time, these are the identity
     curryF-isEquivalence : isEquivalence curryF
     curryF-isEquivalence = record { invFunc = uncurryF ; η = η-iso ; ε = ε-iso } where
       -- separate definition to sidestep Agda termination issue
@@ -293,28 +241,7 @@ module _ (C : Category ℓC ℓC') (D : Category ℓD ℓD') where
           D .id ⋆⟨ D ⟩ λβ .N-ob γ .N-ob c ∎ ))))
       ε-iso .nIso = (λ λF → curryF-ESO-morphism-preimage-isIso λF)
       
-
-
-    -- open isUnivalent
-
-    -- D univalent implies that the functors into D are univalent
-    -- isUniv-Γ×C→D : isUnivalent (FUNCTOR (Γ ×C C) D)
-    -- isUniv-Γ×C→D = isUnivalentFUNCTOR (Γ ×C C) D isUnivD
-
-    -- isUniv-C×Γ→D : isUnivalent (FUNCTOR (C ×C Γ) D)
-    -- isUniv-C×Γ→D = isUnivalentFUNCTOR (C ×C Γ) D isUnivD
-
-    -- isUniv-C→D : isUnivalent (FUNCTOR C D)
-    -- isUniv-C→D = isUnivalentFUNCTOR C D isUnivD
-
-    -- isUniv-Γ→C→D : isUnivalent (FUNCTOR Γ (FUNCTOR C D))
-    -- isUniv-Γ→C→D = isUnivalentFUNCTOR Γ (FUNCTOR C D) isUniv-C→D
-
-
-    -- -- weak equivalence + univalent = equivalence
-    -- curryF-isEquivalence : isEquivalence curryF
-    -- curryF-isEquivalence = isWeakEquiv→isEquiv isUniv-Γ×C→D isUniv-Γ→C→D curryF-isWeakEquiv
-
+      
     open Cubical.Categories.Equivalence.Base._≃ᶜ_
 
     curryEquivalence : FUNCTOR (Γ ×C C) D ≃ᶜ FUNCTOR Γ (FUNCTOR C D)
@@ -344,9 +271,6 @@ module _ (C : Category ℓC ℓC') (D : Category ℓD ℓD') where
     swapArgs-inv .F-hom η .N-hom (ψ , ϕ) = η .N-hom (ϕ , ψ)
     swapArgs-inv .F-id = makeNatTransPath (funExt λ (γ , c) → refl)
     swapArgs-inv .F-seq η η' = makeNatTransPath (funExt λ (γ , c) → refl)
-
-    -- open isEquivalence
-    -- open NatIso
 
     swapArgs-isEquivalence : isEquivalence swapArgs
     swapArgs-isEquivalence = record { invFunc = swapArgs-inv ; η = the-η ; ε = the-ε } where
@@ -380,42 +304,3 @@ module _ (C : Category ℓC ℓC') (D : Category ℓD ℓD') where
 
     curryFl-isEquivalence : isEquivalence curryFl
     curryFl-isEquivalence = isEquivalenceComp swapArgs-isEquivalence curryF-isEquivalence
-    --curryFl-isEquivalence = record { invFunc = invcomp ; η = η-iso ; ε = ε-iso } where 
-    --  invcomp : Functor (FUNCTOR Γ (FUNCTOR C D)) (FUNCTOR (C ×C Γ) D)
-    --  invcomp = swapArgs-isEquivalence .invFunc ∘F curryF-isEquivalence .invFunc
-
-    --  test : NatTrans (𝟙⟨ FUNCTOR (C ×C Γ) D ⟩) ((swapArgs-isEquivalence .invFunc) ∘F swapArgs)
-    --  test = swapArgs-isEquivalence .η .trans
-    --  
-    --  η-iso : NatIso 𝟙⟨ FUNCTOR (C ×C Γ) D ⟩ (invcomp ∘F curryFl)
-    --  η-iso .trans = {!   !}
-    --  η-iso .nIso = {!   !}
-    --  ε-iso = {!   !}
-    -- curryFl-isEquivalence .η = pathToNatIso (
-    --   𝟙⟨ FUNCTOR (C ×C Γ) D ⟩
-    --     -- ≡⟨ NatIsoToPath isUniv-C×Γ→D (swapArgs-isEquivalence .η) ⟩
-    --     ≡⟨ NatIsoToPath (swapArgs-isEquivalence .η) ⟩
-    --   swapArgs-inv ∘F swapArgs
-    --     ≡⟨ (λ i → swapArgs-inv ∘F (F-rUnit {F = swapArgs} (~ i))) ⟩
-    --   swapArgs-inv ∘F (𝟙⟨ FUNCTOR (Γ ×C C) D ⟩ ∘F swapArgs)
-    --     -- ≡⟨ ((λ i → (swapArgs-inv ∘F (((NatIsoToPath isUniv-Γ×C→D (curryF-isEquivalence .η)) (i)) ∘F swapArgs )))) ⟩
-    --     ≡⟨ ((λ i → (swapArgs-inv ∘F (((NatIsoToPath (curryF-isEquivalence .η)) (i)) ∘F swapArgs )))) ⟩
-    --   swapArgs-inv ∘F (((curryF-isEquivalence .invFunc) ∘F curryF) ∘F swapArgs)
-    --     ≡⟨ ((λ i → ( swapArgs-inv ∘F ( F-assoc {F = swapArgs} {G = curryF} {H = curryF-isEquivalence .invFunc} (~ i) ) ))) ⟩
-    --   swapArgs-inv ∘F ((curryF-isEquivalence .invFunc) ∘F (curryF ∘F swapArgs))
-    --     ≡⟨ F-assoc ⟩
-    --   (swapArgs-inv ∘F curryF-isEquivalence .invFunc) ∘F (curryF ∘F swapArgs) ∎ )
-    -- curryFl-isEquivalence .ε = pathToNatIso (
-    --   (curryF ∘F swapArgs) ∘F (swapArgs-inv ∘F curryF-isEquivalence .invFunc)
-    --     ≡⟨ sym F-assoc ⟩
-    --   curryF ∘F (swapArgs ∘F (swapArgs-inv ∘F curryF-isEquivalence .invFunc))
-    --     ≡⟨ (λ i → ( curryF ∘F (F-assoc {F = curryF-isEquivalence .invFunc} {G = swapArgs-inv} {H = swapArgs} (i) ) )) ⟩
-    --   curryF ∘F ((swapArgs ∘F swapArgs-inv) ∘F curryF-isEquivalence .invFunc)
-    --     -- ≡⟨ ((λ i → ( curryF ∘F ( ( NatIsoToPath isUniv-Γ×C→D (swapArgs-isEquivalence .ε) ) i ∘F curryF-isEquivalence .invFunc) ))) ⟩
-    --     ≡⟨ ((λ i → ( curryF ∘F ( ( NatIsoToPath (swapArgs-isEquivalence .ε) ) i ∘F curryF-isEquivalence .invFunc) ))) ⟩
-    --   curryF ∘F (𝟙⟨ FUNCTOR (Γ ×C C) D ⟩ ∘F curryF-isEquivalence .invFunc)
-    --     ≡⟨ ((λ i → ( curryF ∘F (F-rUnit {F = curryF-isEquivalence .invFunc} i) ))) ⟩
-    --   curryF ∘F curryF-isEquivalence .invFunc
-    --     -- ≡⟨ NatIsoToPath isUniv-Γ→C→D (curryF-isEquivalence .ε) ⟩
-    --     ≡⟨ NatIsoToPath (curryF-isEquivalence .ε) ⟩
-    --   𝟙⟨ FUNCTOR Γ (FUNCTOR C D) ⟩ ∎)

--- a/Cubical/Categories/Instances/Functors/More.agda
+++ b/Cubical/Categories/Instances/Functors/More.agda
@@ -14,13 +14,14 @@ open import Cubical.Foundations.HLevels
 open import Cubical.Foundations.Isomorphism
 open import Cubical.Categories.Instances.Functors
 open import Cubical.Categories.Constructions.BinProduct
-open import Cubical.Categories.Equivalence.WeakEquivalence
+-- open import Cubical.Categories.Equivalence.WeakEquivalence
 open import Cubical.Categories.Functor.Properties
 open import Cubical.Categories.Equivalence.Base
-open import Cubical.HITs.PropositionalTruncation
+-- open import Cubical.HITs.PropositionalTruncation
 open import Cubical.Categories.Category
 
 open import Cubical.Tactics.CategorySolver.Reflection
+open import Cubical.Categories.Equivalence.More
 
 private
   variable
@@ -49,7 +50,8 @@ module _ (C : Category ℓC ℓC') (D : Category ℓD ℓD') where
       ≡⟨ solveCat! D ⟩
     (F ⟪ f ⟫ ⋆⟨ D ⟩ α .N-ob c') ⋆⟨ D ⟩ (F' ⟪ f' ⟫ ⋆⟨ D ⟩ α' .N-ob c'') ∎
 
-  module _ {Γ : Category ℓΓ ℓΓ'} (isUnivD : isUnivalent D) where
+  module _ {Γ : Category ℓΓ ℓΓ'} where 
+    --(isUnivD : isUnivalent D) where
     -- The action of currying out the right argument of a Functor (Γ ×C C) D
     λFr : Functor (Γ ×C C) D → Functor Γ (FUNCTOR C D)
     λFr F .F-ob a .F-ob b = F ⟅ a , b ⟆
@@ -91,35 +93,35 @@ module _ (C : Category ℓC ℓC') (D : Category ℓD ℓD') where
     curryF .F-seq η η' = makeNatTransPath (funExt λ (γ : Γ .ob) → refl)
 
     -- Preimage for the fullness proof --- i.e. a morphism in FUNCTOR (Γ ×C C) D that maps to λη under curryF
-    curryF-full-preimage : {F G : Functor (Γ ×C C) D} (λη : NatTrans (curryF .F-ob F) (curryF .F-ob G)) → (NatTrans F G)
-    curryF-full-preimage {F} {G} λη .N-ob (γ , c) = λη .N-ob γ .N-ob c
-    curryF-full-preimage {F} {G} λη .N-hom {(γ₁ , c₁)} {(γ₂ , c₂)} (ϕ₁ , ϕ₂) =
-      F .F-hom (ϕ₁ , ϕ₂) ⋆⟨ D ⟩ curryF-full-preimage λη .N-ob (γ₂ , c₂)
-        ≡⟨ (λ i → (F .F-hom ((Γ .⋆IdR ϕ₁) (~ i) , (C .⋆IdL ϕ₂) (~ i)) ⋆⟨ D ⟩ curryF-full-preimage λη .N-ob (γ₂ , c₂))) ⟩
-      F .F-hom ((ϕ₁ , C .id) ⋆⟨ Γ ×C C ⟩ (Γ .id , ϕ₂)) ⋆⟨ D ⟩ curryF-full-preimage λη .N-ob (γ₂ , c₂)
-        ≡⟨ (λ i → (F .F-seq (ϕ₁ , C .id) (Γ .id , ϕ₂)) (i) ⋆⟨ D ⟩ curryF-full-preimage λη .N-ob (γ₂ , c₂)) ⟩
-      F .F-hom (ϕ₁ , C .id) ⋆⟨ D ⟩ F .F-hom (Γ .id , ϕ₂) ⋆⟨ D ⟩ curryF-full-preimage λη .N-ob (γ₂ , c₂)
-        ≡⟨ D .⋆Assoc (F .F-hom (ϕ₁ , C .id)) (F .F-hom (Γ .id , ϕ₂) ) (curryF-full-preimage λη .N-ob (γ₂ , c₂)) ⟩
-      F .F-hom (ϕ₁ , C .id) ⋆⟨ D ⟩ (F .F-hom (Γ .id , ϕ₂) ⋆⟨ D ⟩ curryF-full-preimage λη .N-ob (γ₂ , c₂))
-        ≡⟨ ((λ i → ((F .F-hom (ϕ₁ , C .id)) ⋆⟨ D ⟩ (λη .N-ob γ₂ .N-hom ϕ₂ (i))))) ⟩
-      F .F-hom (ϕ₁ , C .id) ⋆⟨ D ⟩ (curryF-full-preimage λη .N-ob (γ₂ , c₁) ⋆⟨ D ⟩ G .F-hom (Γ .id , ϕ₂))
-        ≡⟨  sym (D .⋆Assoc (F .F-hom (ϕ₁ , C .id)) (curryF-full-preimage λη .N-ob (γ₂ , c₁)) (G .F-hom (Γ .id , ϕ₂)))  ⟩
-      (F .F-hom (ϕ₁ , C .id) ⋆⟨ D ⟩ curryF-full-preimage λη .N-ob (γ₂ , c₁)) ⋆⟨ D ⟩ G .F-hom (Γ .id , ϕ₂)
-        ≡⟨ ((λ i → ( ((λη .N-hom ϕ₁ (i)) .N-ob c₁) ⋆⟨ D ⟩ G .F-hom (Γ .id , ϕ₂) ))) ⟩
-      (curryF-full-preimage λη .N-ob (γ₁ , c₁) ⋆⟨ D ⟩ G .F-hom (ϕ₁ , C .id)) ⋆⟨ D ⟩ G .F-hom (Γ .id , ϕ₂)
-        ≡⟨ D .⋆Assoc (curryF-full-preimage λη .N-ob (γ₁ , c₁)) (G .F-hom (ϕ₁ , C .id)) (G .F-hom (Γ .id , ϕ₂)) ⟩
-      curryF-full-preimage λη .N-ob (γ₁ , c₁) ⋆⟨ D ⟩ (G .F-hom (ϕ₁ , C .id) ⋆⟨ D ⟩ G .F-hom (Γ .id , ϕ₂))
-        ≡⟨ ((λ i → (curryF-full-preimage λη .N-ob (γ₁ , c₁) ⋆⟨ D ⟩ (G .F-seq (ϕ₁ , C .id) (Γ .id , ϕ₂)) (~ i) ))) ⟩
-      curryF-full-preimage λη .N-ob (γ₁ , c₁) ⋆⟨ D ⟩ (G .F-hom ((ϕ₁ , C .id) ⋆⟨ Γ ×C C ⟩ (Γ .id , ϕ₂)))
-        ≡⟨ ((λ i → (curryF-full-preimage λη .N-ob (γ₁ , c₁) ⋆⟨ D ⟩ (G .F-hom (((Γ .⋆IdR ϕ₁) i), ((C .⋆IdL ϕ₂) i))) ))) ⟩
-      curryF-full-preimage λη .N-ob (γ₁ , c₁) ⋆⟨ D ⟩ G .F-hom (ϕ₁ , ϕ₂) ∎
+    -- curryF-full-preimage : {F G : Functor (Γ ×C C) D} (λη : NatTrans (curryF .F-ob F) (curryF .F-ob G)) → (NatTrans F G)
+    -- curryF-full-preimage {F} {G} λη .N-ob (γ , c) = λη .N-ob γ .N-ob c
+    -- curryF-full-preimage {F} {G} λη .N-hom {(γ₁ , c₁)} {(γ₂ , c₂)} (ϕ₁ , ϕ₂) =
+    --   F .F-hom (ϕ₁ , ϕ₂) ⋆⟨ D ⟩ curryF-full-preimage λη .N-ob (γ₂ , c₂)
+    --     ≡⟨ (λ i → (F .F-hom ((Γ .⋆IdR ϕ₁) (~ i) , (C .⋆IdL ϕ₂) (~ i)) ⋆⟨ D ⟩ curryF-full-preimage λη .N-ob (γ₂ , c₂))) ⟩
+    --   F .F-hom ((ϕ₁ , C .id) ⋆⟨ Γ ×C C ⟩ (Γ .id , ϕ₂)) ⋆⟨ D ⟩ curryF-full-preimage λη .N-ob (γ₂ , c₂)
+    --     ≡⟨ (λ i → (F .F-seq (ϕ₁ , C .id) (Γ .id , ϕ₂)) (i) ⋆⟨ D ⟩ curryF-full-preimage λη .N-ob (γ₂ , c₂)) ⟩
+    --   F .F-hom (ϕ₁ , C .id) ⋆⟨ D ⟩ F .F-hom (Γ .id , ϕ₂) ⋆⟨ D ⟩ curryF-full-preimage λη .N-ob (γ₂ , c₂)
+    --     ≡⟨ D .⋆Assoc (F .F-hom (ϕ₁ , C .id)) (F .F-hom (Γ .id , ϕ₂) ) (curryF-full-preimage λη .N-ob (γ₂ , c₂)) ⟩
+    --   F .F-hom (ϕ₁ , C .id) ⋆⟨ D ⟩ (F .F-hom (Γ .id , ϕ₂) ⋆⟨ D ⟩ curryF-full-preimage λη .N-ob (γ₂ , c₂))
+    --     ≡⟨ ((λ i → ((F .F-hom (ϕ₁ , C .id)) ⋆⟨ D ⟩ (λη .N-ob γ₂ .N-hom ϕ₂ (i))))) ⟩
+    --   F .F-hom (ϕ₁ , C .id) ⋆⟨ D ⟩ (curryF-full-preimage λη .N-ob (γ₂ , c₁) ⋆⟨ D ⟩ G .F-hom (Γ .id , ϕ₂))
+    --     ≡⟨  sym (D .⋆Assoc (F .F-hom (ϕ₁ , C .id)) (curryF-full-preimage λη .N-ob (γ₂ , c₁)) (G .F-hom (Γ .id , ϕ₂)))  ⟩
+    --   (F .F-hom (ϕ₁ , C .id) ⋆⟨ D ⟩ curryF-full-preimage λη .N-ob (γ₂ , c₁)) ⋆⟨ D ⟩ G .F-hom (Γ .id , ϕ₂)
+    --     ≡⟨ ((λ i → ( ((λη .N-hom ϕ₁ (i)) .N-ob c₁) ⋆⟨ D ⟩ G .F-hom (Γ .id , ϕ₂) ))) ⟩
+    --   (curryF-full-preimage λη .N-ob (γ₁ , c₁) ⋆⟨ D ⟩ G .F-hom (ϕ₁ , C .id)) ⋆⟨ D ⟩ G .F-hom (Γ .id , ϕ₂)
+    --     ≡⟨ D .⋆Assoc (curryF-full-preimage λη .N-ob (γ₁ , c₁)) (G .F-hom (ϕ₁ , C .id)) (G .F-hom (Γ .id , ϕ₂)) ⟩
+    --   curryF-full-preimage λη .N-ob (γ₁ , c₁) ⋆⟨ D ⟩ (G .F-hom (ϕ₁ , C .id) ⋆⟨ D ⟩ G .F-hom (Γ .id , ϕ₂))
+    --     ≡⟨ ((λ i → (curryF-full-preimage λη .N-ob (γ₁ , c₁) ⋆⟨ D ⟩ (G .F-seq (ϕ₁ , C .id) (Γ .id , ϕ₂)) (~ i) ))) ⟩
+    --   curryF-full-preimage λη .N-ob (γ₁ , c₁) ⋆⟨ D ⟩ (G .F-hom ((ϕ₁ , C .id) ⋆⟨ Γ ×C C ⟩ (Γ .id , ϕ₂)))
+    --     ≡⟨ ((λ i → (curryF-full-preimage λη .N-ob (γ₁ , c₁) ⋆⟨ D ⟩ (G .F-hom (((Γ .⋆IdR ϕ₁) i), ((C .⋆IdL ϕ₂) i))) ))) ⟩
+    --   curryF-full-preimage λη .N-ob (γ₁ , c₁) ⋆⟨ D ⟩ G .F-hom (ϕ₁ , ϕ₂) ∎
 
-    -- curryF is a full functor
-    curryF-isFull : isFull curryF
-    curryF-isFull F G λη =  (∣ curryF-full-preimage λη , makeNatTransPath (funExt (λ (γ : Γ .ob) →
-      makeNatTransPath (funExt (λ (c : C .ob) →
-        λη .N-ob γ .N-ob c ∎))
-      ) ) ∣₁)
+    -- -- curryF is a full functor
+    -- curryF-isFull : isFull curryF
+    -- curryF-isFull F G λη =  (∣ curryF-full-preimage λη , makeNatTransPath (funExt (λ (γ : Γ .ob) →
+    --   makeNatTransPath (funExt (λ (c : C .ob) →
+    --     λη .N-ob γ .N-ob c ∎))
+    --   ) ) ∣₁)
 
     -- Preimage for the ESO proof --- an object in (FUNCTOR Γ (FUNCTOR C D)) that maps to λF
     curryF-ESO-object-preimage : (FUNCTOR Γ (FUNCTOR C D)) .ob → (FUNCTOR (Γ ×C C) D) .ob
@@ -204,48 +206,114 @@ module _ (C : Category ℓC ℓC') (D : Category ℓD ℓD') where
           ≡⟨ D .⋆IdR (curryF-ESO-morphism-preimage-isIso λF .inv .N-ob γ .N-ob c) ⟩
         D .id ∎
       ))))
+    
+    
+    uncurryF : Functor (FUNCTOR Γ (FUNCTOR C D)) (FUNCTOR (Γ ×C C) D)
+    uncurryF .F-ob λF = curryF-ESO-object-preimage λF
+    -- stolen from curryF-full-preimage
+    uncurryF .F-hom {F} {G} λη .N-ob (γ , c) = λη .N-ob γ .N-ob c
+    uncurryF .F-hom {F} {G} λη .N-hom {(γ₁ , c₁)} {(γ₂ , c₂)} (ϕ₁ , ϕ₂) =
+      uncurryF .F-ob F .F-hom (ϕ₁ , ϕ₂) ⋆⟨ D ⟩ uncurryF .F-hom λη .N-ob (γ₂ , c₂)
+        ≡⟨ solveCat! D ⟩
+      F .F-hom (ϕ₁) .N-ob c₁ ⋆⟨ D ⟩ (F .F-ob γ₂ .F-hom ϕ₂ ⋆⟨ D ⟩ λη .N-ob γ₂ .N-ob c₂)
+        ≡⟨ (λ i → (F .F-hom (ϕ₁) .N-ob c₁ ⋆⟨ D ⟩ (λη .N-ob γ₂ .N-hom ϕ₂ (i)))) ⟩
+      F .F-hom (ϕ₁) .N-ob c₁ ⋆⟨ D ⟩ (λη .N-ob γ₂ .N-ob c₁ ⋆⟨ D ⟩ G .F-ob γ₂ .F-hom ϕ₂)
+        ≡⟨ solveCat! D ⟩
+      (F .F-hom (ϕ₁) .N-ob c₁ ⋆⟨ D ⟩ λη .N-ob γ₂ .N-ob c₁) ⋆⟨ D ⟩ G .F-ob γ₂ .F-hom ϕ₂
+       ≡⟨ (λ i → (((λη .N-hom (ϕ₁) (i)) .N-ob c₁) ⋆⟨ D ⟩ G .F-ob γ₂ .F-hom ϕ₂)) ⟩
+      (λη .N-ob γ₁ .N-ob c₁ ⋆⟨ D ⟩ G .F-hom (ϕ₁) .N-ob c₁) ⋆⟨ D ⟩ G .F-ob γ₂ .F-hom ϕ₂
+        ≡⟨ solveCat! D ⟩
+      uncurryF .F-hom λη .N-ob (γ₁ , c₁) ⋆⟨ D ⟩ uncurryF .F-ob G .F-hom (ϕ₁ , ϕ₂) ∎
+    uncurryF .F-id = makeNatTransPath (funExt (λ x → refl ))
+    uncurryF .F-seq λη₁ λη₂ = makeNatTransPath (funExt (λ x → refl ))
+
 
     -- curryF is essential surjective on objects
-    curryF-ess-surj : isEssentiallySurj curryF
-    curryF-ess-surj λF = ( ∣ curryF-ESO-object-preimage λF , (curryF-ESO-morphism-preimage λF , curryF-ESO-morphism-preimage-isIso λF) ∣₁ )
+    -- curryF-ess-surj : isEssentiallySurj curryF
+    -- curryF-ess-surj λF = ( ∣ curryF-ESO-object-preimage λF , (curryF-ESO-morphism-preimage λF , curryF-ESO-morphism-preimage-isIso λF) ∣₁ )
 
     -- curryF is a faithful functor
-    curryF-isFaithful : isFaithful curryF
-    curryF-isFaithful F G η₁ η₂ λη₁≡λη₂ = makeNatTransPath (funExt (λ (γ , c) →
-      η₁ .N-ob (γ , c)
-      ≡⟨ (λ i → λη₁≡λη₂ i .N-ob γ .N-ob c) ⟩
-       η₂ .N-ob (γ , c) ∎))
+    -- curryF-isFaithful : isFaithful curryF
+    -- curryF-isFaithful F G η₁ η₂ λη₁≡λη₂ = makeNatTransPath (funExt (λ (γ , c) →
+    --   η₁ .N-ob (γ , c)
+    --   ≡⟨ (λ i → λη₁≡λη₂ i .N-ob γ .N-ob c) ⟩
+    --    η₂ .N-ob (γ , c) ∎))
 
     -- full + faithul = fully faithful
-    curryF-isFullyFaithful : isFullyFaithful curryF
-    curryF-isFullyFaithful = isFull+Faithful→isFullyFaithful {F = curryF} curryF-isFull curryF-isFaithful
+    -- curryF-isFullyFaithful : isFullyFaithful curryF
+    -- curryF-isFullyFaithful = isFull+Faithful→isFullyFaithful {F = curryF} curryF-isFull curryF-isFaithful
 
-    open isWeakEquivalence
+    -- open isWeakEquivalence
 
     -- fully faithful + ESO = weak equivalence
-    curryF-isWeakEquiv : isWeakEquivalence curryF
-    curryF-isWeakEquiv .fullfaith = curryF-isFullyFaithful
-    curryF-isWeakEquiv .esssurj = curryF-ess-surj
+    -- curryF-isWeakEquiv : isWeakEquivalence curryF
+    -- curryF-isWeakEquiv .fullfaith = curryF-isFullyFaithful
+    -- curryF-isWeakEquiv .esssurj = curryF-ess-surj
 
-    open isUnivalent
+    open isEquivalence
+    open NatIso
+
+    curryF-isEquivalence : isEquivalence curryF
+    curryF-isEquivalence = record { invFunc = uncurryF ; η = η-iso ; ε = ε-iso } where
+      -- separate definition to sidestep Agda termination issue
+      η-trans : NatTrans 𝟙⟨ FUNCTOR (Γ ×C C) D ⟩ (uncurryF ∘F curryF)
+      η-trans .N-ob F .N-ob (γ , c) = D .id
+      η-trans .N-ob F .N-hom {(γ₁ , c₁)} {(γ₂ , c₂)} (ϕ₁ , ϕ₂) = 
+        (F .F-hom (ϕ₁ , ϕ₂)) ⋆⟨ D ⟩ D .id
+          ≡⟨ (λ i → (F .F-hom ((Γ .⋆IdR ϕ₁) (~ i) , (C .⋆IdL ϕ₂) (~ i)) ⋆⟨ D ⟩ D .id)) ⟩
+        (F .F-hom ((ϕ₁ , C .id) ⋆⟨ Γ ×C C ⟩ (Γ .id , ϕ₂))) ⋆⟨ D ⟩ D .id
+          ≡⟨ (λ i → (F .F-seq (ϕ₁ , C .id) (Γ .id , ϕ₂)) (i) ⋆⟨ D ⟩ D .id) ⟩
+        (F .F-hom (ϕ₁ , C .id) ⋆⟨ D ⟩ F .F-hom (Γ .id , ϕ₂)) ⋆⟨ D ⟩ D .id
+          ≡⟨ solveCat! D ⟩
+        D .id ⋆⟨ D ⟩ ((uncurryF ∘F curryF) .F-ob F) .F-hom (ϕ₁ , ϕ₂)  ∎
+      η-trans .N-hom {F} {G} β = makeNatTransPath (funExt (λ (γ , c) → solveCat! D))
+      
+      η-iso : NatIso 𝟙⟨ FUNCTOR (Γ ×C C) D ⟩ (uncurryF ∘F curryF)
+      η-iso .trans = η-trans
+
+      η-iso .nIso F .inv .N-ob (γ , c) = D .id
+      η-iso .nIso F .inv .N-hom {(γ₁ , c₁)} {(γ₂ , c₂)} (ϕ₁ , ϕ₂) =
+        ((uncurryF ∘F curryF) .F-ob F) .F-hom (ϕ₁ , ϕ₂) ⋆⟨ D ⟩ D .id
+          ≡⟨ solveCat! D ⟩
+        D .id ⋆⟨ D ⟩ ((uncurryF ∘F curryF) .F-ob F) .F-hom (ϕ₁ , ϕ₂)
+          ≡⟨ sym (η-iso .trans .N-ob F .N-hom (ϕ₁ , ϕ₂)) ⟩
+        (F .F-hom (ϕ₁ , ϕ₂)) ⋆⟨ D ⟩ D .id
+          ≡⟨ solveCat! D ⟩
+        D .id ⋆⟨ D ⟩ (F .F-hom (ϕ₁ , ϕ₂))  ∎
+      η-iso .nIso F .sec = makeNatTransPath (funExt (λ (γ , c) → solveCat! D))
+      η-iso .nIso F .ret = makeNatTransPath (funExt (λ (γ , c) → solveCat! D))
+      
+      ε-iso : NatIso (curryF ∘F uncurryF) 𝟙⟨ FUNCTOR Γ (FUNCTOR C D) ⟩
+      ε-iso .trans .N-ob λF = curryF-ESO-morphism-preimage λF
+      ε-iso .trans .N-hom {λF} {λG} λβ = makeNatTransPath (funExt (λ γ →
+        makeNatTransPath (funExt (λ c →
+          -- TODO: For some reason this doesn't simplify to just solvecat...
+          (λβ .N-ob γ .N-ob c) ⋆⟨ D ⟩ D .id 
+            ≡⟨ solveCat! D ⟩
+          D .id ⋆⟨ D ⟩ λβ .N-ob γ .N-ob c ∎ ))))
+      ε-iso .nIso = (λ λF → curryF-ESO-morphism-preimage-isIso λF)
+      
+
+
+    -- open isUnivalent
 
     -- D univalent implies that the functors into D are univalent
-    isUniv-Γ×C→D : isUnivalent (FUNCTOR (Γ ×C C) D)
-    isUniv-Γ×C→D = isUnivalentFUNCTOR (Γ ×C C) D isUnivD
+    -- isUniv-Γ×C→D : isUnivalent (FUNCTOR (Γ ×C C) D)
+    -- isUniv-Γ×C→D = isUnivalentFUNCTOR (Γ ×C C) D isUnivD
 
-    isUniv-C×Γ→D : isUnivalent (FUNCTOR (C ×C Γ) D)
-    isUniv-C×Γ→D = isUnivalentFUNCTOR (C ×C Γ) D isUnivD
+    -- isUniv-C×Γ→D : isUnivalent (FUNCTOR (C ×C Γ) D)
+    -- isUniv-C×Γ→D = isUnivalentFUNCTOR (C ×C Γ) D isUnivD
 
-    isUniv-C→D : isUnivalent (FUNCTOR C D)
-    isUniv-C→D = isUnivalentFUNCTOR C D isUnivD
+    -- isUniv-C→D : isUnivalent (FUNCTOR C D)
+    -- isUniv-C→D = isUnivalentFUNCTOR C D isUnivD
 
-    isUniv-Γ→C→D : isUnivalent (FUNCTOR Γ (FUNCTOR C D))
-    isUniv-Γ→C→D = isUnivalentFUNCTOR Γ (FUNCTOR C D) isUniv-C→D
+    -- isUniv-Γ→C→D : isUnivalent (FUNCTOR Γ (FUNCTOR C D))
+    -- isUniv-Γ→C→D = isUnivalentFUNCTOR Γ (FUNCTOR C D) isUniv-C→D
 
 
-    -- weak equivalence + univalent = equivalence
-    curryF-isEquivalence : isEquivalence curryF
-    curryF-isEquivalence = isWeakEquiv→isEquiv isUniv-Γ×C→D isUniv-Γ→C→D curryF-isWeakEquiv
+    -- -- weak equivalence + univalent = equivalence
+    -- curryF-isEquivalence : isEquivalence curryF
+    -- curryF-isEquivalence = isWeakEquiv→isEquiv isUniv-Γ×C→D isUniv-Γ→C→D curryF-isWeakEquiv
 
     open Cubical.Categories.Equivalence.Base._≃ᶜ_
 
@@ -277,8 +345,8 @@ module _ (C : Category ℓC ℓC') (D : Category ℓD ℓD') where
     swapArgs-inv .F-id = makeNatTransPath (funExt λ (γ , c) → refl)
     swapArgs-inv .F-seq η η' = makeNatTransPath (funExt λ (γ , c) → refl)
 
-    open isEquivalence
-    open NatIso
+    -- open isEquivalence
+    -- open NatIso
 
     swapArgs-isEquivalence : isEquivalence swapArgs
     swapArgs-isEquivalence = record { invFunc = swapArgs-inv ; η = the-η ; ε = the-ε } where
@@ -309,29 +377,45 @@ module _ (C : Category ℓC ℓC') (D : Category ℓD ℓD') where
     curryFl : Functor (FUNCTOR (C ×C Γ) D) (FUNCTOR Γ (FUNCTOR C D))
     curryFl = curryF ∘F swapArgs
 
+
     curryFl-isEquivalence : isEquivalence curryFl
-    curryFl-isEquivalence .invFunc = swapArgs-isEquivalence .invFunc ∘F curryF-isEquivalence .invFunc
-    curryFl-isEquivalence .η = pathToNatIso (
-      𝟙⟨ FUNCTOR (C ×C Γ) D ⟩
-        ≡⟨ NatIsoToPath isUniv-C×Γ→D (swapArgs-isEquivalence .η) ⟩
-      swapArgs-inv ∘F swapArgs
-        ≡⟨ (λ i → swapArgs-inv ∘F (F-rUnit {F = swapArgs} (~ i))) ⟩
-      swapArgs-inv ∘F (𝟙⟨ FUNCTOR (Γ ×C C) D ⟩ ∘F swapArgs)
-        ≡⟨ ((λ i → (swapArgs-inv ∘F (((NatIsoToPath isUniv-Γ×C→D (curryF-isEquivalence .η)) (i)) ∘F swapArgs )))) ⟩
-      swapArgs-inv ∘F (((curryF-isEquivalence .invFunc) ∘F curryF) ∘F swapArgs)
-        ≡⟨ ((λ i → ( swapArgs-inv ∘F ( F-assoc {F = swapArgs} {G = curryF} {H = curryF-isEquivalence .invFunc} (~ i) ) ))) ⟩
-      swapArgs-inv ∘F ((curryF-isEquivalence .invFunc) ∘F (curryF ∘F swapArgs))
-        ≡⟨ F-assoc ⟩
-      (swapArgs-inv ∘F curryF-isEquivalence .invFunc) ∘F (curryF ∘F swapArgs) ∎ )
-    curryFl-isEquivalence .ε = pathToNatIso (
-      (curryF ∘F swapArgs) ∘F (swapArgs-inv ∘F curryF-isEquivalence .invFunc)
-        ≡⟨ sym F-assoc ⟩
-      curryF ∘F (swapArgs ∘F (swapArgs-inv ∘F curryF-isEquivalence .invFunc))
-        ≡⟨ (λ i → ( curryF ∘F (F-assoc {F = curryF-isEquivalence .invFunc} {G = swapArgs-inv} {H = swapArgs} (i) ) )) ⟩
-      curryF ∘F ((swapArgs ∘F swapArgs-inv) ∘F curryF-isEquivalence .invFunc)
-        ≡⟨ ((λ i → ( curryF ∘F ( ( NatIsoToPath isUniv-Γ×C→D (swapArgs-isEquivalence .ε) ) i ∘F curryF-isEquivalence .invFunc) ))) ⟩
-      curryF ∘F (𝟙⟨ FUNCTOR (Γ ×C C) D ⟩ ∘F curryF-isEquivalence .invFunc)
-        ≡⟨ ((λ i → ( curryF ∘F (F-rUnit {F = curryF-isEquivalence .invFunc} i) ))) ⟩
-      curryF ∘F curryF-isEquivalence .invFunc
-        ≡⟨ NatIsoToPath isUniv-Γ→C→D (curryF-isEquivalence .ε) ⟩
-      𝟙⟨ FUNCTOR Γ (FUNCTOR C D) ⟩ ∎)
+    curryFl-isEquivalence = isEquivalenceComp swapArgs-isEquivalence curryF-isEquivalence
+    --curryFl-isEquivalence = record { invFunc = invcomp ; η = η-iso ; ε = ε-iso } where 
+    --  invcomp : Functor (FUNCTOR Γ (FUNCTOR C D)) (FUNCTOR (C ×C Γ) D)
+    --  invcomp = swapArgs-isEquivalence .invFunc ∘F curryF-isEquivalence .invFunc
+
+    --  test : NatTrans (𝟙⟨ FUNCTOR (C ×C Γ) D ⟩) ((swapArgs-isEquivalence .invFunc) ∘F swapArgs)
+    --  test = swapArgs-isEquivalence .η .trans
+    --  
+    --  η-iso : NatIso 𝟙⟨ FUNCTOR (C ×C Γ) D ⟩ (invcomp ∘F curryFl)
+    --  η-iso .trans = {!   !}
+    --  η-iso .nIso = {!   !}
+    --  ε-iso = {!   !}
+    -- curryFl-isEquivalence .η = pathToNatIso (
+    --   𝟙⟨ FUNCTOR (C ×C Γ) D ⟩
+    --     -- ≡⟨ NatIsoToPath isUniv-C×Γ→D (swapArgs-isEquivalence .η) ⟩
+    --     ≡⟨ NatIsoToPath (swapArgs-isEquivalence .η) ⟩
+    --   swapArgs-inv ∘F swapArgs
+    --     ≡⟨ (λ i → swapArgs-inv ∘F (F-rUnit {F = swapArgs} (~ i))) ⟩
+    --   swapArgs-inv ∘F (𝟙⟨ FUNCTOR (Γ ×C C) D ⟩ ∘F swapArgs)
+    --     -- ≡⟨ ((λ i → (swapArgs-inv ∘F (((NatIsoToPath isUniv-Γ×C→D (curryF-isEquivalence .η)) (i)) ∘F swapArgs )))) ⟩
+    --     ≡⟨ ((λ i → (swapArgs-inv ∘F (((NatIsoToPath (curryF-isEquivalence .η)) (i)) ∘F swapArgs )))) ⟩
+    --   swapArgs-inv ∘F (((curryF-isEquivalence .invFunc) ∘F curryF) ∘F swapArgs)
+    --     ≡⟨ ((λ i → ( swapArgs-inv ∘F ( F-assoc {F = swapArgs} {G = curryF} {H = curryF-isEquivalence .invFunc} (~ i) ) ))) ⟩
+    --   swapArgs-inv ∘F ((curryF-isEquivalence .invFunc) ∘F (curryF ∘F swapArgs))
+    --     ≡⟨ F-assoc ⟩
+    --   (swapArgs-inv ∘F curryF-isEquivalence .invFunc) ∘F (curryF ∘F swapArgs) ∎ )
+    -- curryFl-isEquivalence .ε = pathToNatIso (
+    --   (curryF ∘F swapArgs) ∘F (swapArgs-inv ∘F curryF-isEquivalence .invFunc)
+    --     ≡⟨ sym F-assoc ⟩
+    --   curryF ∘F (swapArgs ∘F (swapArgs-inv ∘F curryF-isEquivalence .invFunc))
+    --     ≡⟨ (λ i → ( curryF ∘F (F-assoc {F = curryF-isEquivalence .invFunc} {G = swapArgs-inv} {H = swapArgs} (i) ) )) ⟩
+    --   curryF ∘F ((swapArgs ∘F swapArgs-inv) ∘F curryF-isEquivalence .invFunc)
+    --     -- ≡⟨ ((λ i → ( curryF ∘F ( ( NatIsoToPath isUniv-Γ×C→D (swapArgs-isEquivalence .ε) ) i ∘F curryF-isEquivalence .invFunc) ))) ⟩
+    --     ≡⟨ ((λ i → ( curryF ∘F ( ( NatIsoToPath (swapArgs-isEquivalence .ε) ) i ∘F curryF-isEquivalence .invFunc) ))) ⟩
+    --   curryF ∘F (𝟙⟨ FUNCTOR (Γ ×C C) D ⟩ ∘F curryF-isEquivalence .invFunc)
+    --     ≡⟨ ((λ i → ( curryF ∘F (F-rUnit {F = curryF-isEquivalence .invFunc} i) ))) ⟩
+    --   curryF ∘F curryF-isEquivalence .invFunc
+    --     -- ≡⟨ NatIsoToPath isUniv-Γ→C→D (curryF-isEquivalence .ε) ⟩
+    --     ≡⟨ NatIsoToPath (curryF-isEquivalence .ε) ⟩
+    --   𝟙⟨ FUNCTOR Γ (FUNCTOR C D) ⟩ ∎)

--- a/Cubical/Categories/Instances/Functors/More.agda
+++ b/Cubical/Categories/Instances/Functors/More.agda
@@ -49,7 +49,6 @@ module _ (C : Category ℓC ℓC') (D : Category ℓD ℓD') where
     (F ⟪ f ⟫ ⋆⟨ D ⟩ α .N-ob c') ⋆⟨ D ⟩ (F' ⟪ f' ⟫ ⋆⟨ D ⟩ α' .N-ob c'') ∎
 
   module _ {Γ : Category ℓΓ ℓΓ'} where 
-    --(isUnivD : isUnivalent D) where
     -- The action of currying out the right argument of a Functor (Γ ×C C) D
     λFr : Functor (Γ ×C C) D → Functor Γ (FUNCTOR C D)
     λFr F .F-ob a .F-ob b = F ⟅ a , b ⟆

--- a/Cubical/Categories/NaturalTransformation/More.agda
+++ b/Cubical/Categories/NaturalTransformation/More.agda
@@ -52,6 +52,13 @@ module _ {B : Category ℓB ℓB'}{C : Category ℓC ℓC'}{D : Category ℓD �
   _∘ʳi_ K β .trans = K ∘ʳ β .trans
   _∘ʳi_ K β .nIso x = preserveIsosF {F = K} (β .trans .N-ob _ , β .nIso x) .snd
 
+  open Functor
+  _∘ˡi_ : ∀ (K : Functor B C) → {G H : Functor C D} (β : NatIso G H)
+       → NatIso (G ∘F K) (H ∘F K)
+  _∘ˡi_ K β .trans = β .trans ∘ˡ K 
+  _∘ˡi_ K β .nIso b  = β .nIso (K ⟅ b ⟆)
+  
+
 
   CAT⋆Assoc : {E : Category ℓE ℓE'}
             (F : Functor B C)(G : Functor C D)(H : Functor D E)

--- a/Cubical/Categories/Profunctor/General.agda
+++ b/Cubical/Categories/Profunctor/General.agda
@@ -70,6 +70,9 @@ C *-[ ℓS ]-o D = D o-[ ℓS ]-* C
 private
   variable
     ℓs : Level
+  
+
+open Functor
 
 -- | TODO: these should be equivalences (isos?) of categories
 Functor→Prof*-o : (C : Category ℓC ℓC') (D : Category ℓD ℓD') (F : Functor C D) → C *-[ ℓD' ]-o D
@@ -79,10 +82,10 @@ Functor→Profo-* : (C : Category ℓC ℓC') (D : Category ℓD ℓD') (F : Fun
 Functor→Profo-* C D F = HomFunctor D ∘F ((F ^opF) ×F Id {C = D})
 
 Prof*-o→Functor : (C : Category ℓC ℓC') (D : Category ℓD ℓD') (R : C *-[ ℓs ]-o D) → Functor C (FUNCTOR (D ^op) (SET ℓs))
-Prof*-o→Functor C D R = λFl (D ^op) (SET _) R
+Prof*-o→Functor C D R = curryFl (D ^op) (SET _) ⟅ R ⟆
 
 Profo-*→Functor : (C : Category ℓC ℓC') (D : Category ℓD ℓD') (R : C o-[ ℓs ]-* D) → Functor (C ^op) (FUNCTOR D (SET ℓs))
-Profo-*→Functor C D R = λF D (SET _) R
+Profo-*→Functor C D R = curryF D (SET _) ⟅ R ⟆
 
 module _ (C : Category ℓC ℓC') (D : Category ℓD ℓD') where
   open Category


### PR DESCRIPTION
@stschaef and I ran into some univalence propagation issues in Profunctor because of assuming univalence in earlier proofs. 

Repackaged some proofs to explicitly construct the equivalence, and also got a general proof of equivalences composing that didn't rely on `NatIsotoPath` or vice versa. Removes the univalence requirement, allowing Profunctor to simply be defined using `curryF`