### PR TITLE
Rezk by HIT

### DIFF
--- a/Cubical/Categories/RezkCompletion/Constructionn.agda
+++ b/Cubical/Categories/RezkCompletion/Constructionn.agda
@@ -1,0 +1,93 @@
+{-
+
+The Construction of Rezk Completion
+
+-}
+{-# OPTIONS --safe --lossy-unification #-}
+
+module Cubical.Categories.RezkCompletion.Constructionn where
+
+open import Cubical.Foundations.Prelude
+
+open import Cubical.Categories.Category
+open import Cubical.Categories.Functor
+open import Cubical.Categories.Equivalence.WeakEquivalence
+open import Cubical.Categories.Constructions.EssentialImage
+open import Cubical.Categories.Presheaf.Base
+open import Cubical.Categories.Yoneda
+
+open import Cubical.Categories.RezkCompletion.Base
+
+private
+  variable
+    ℓ ℓ' : Level
+
+open isWeakEquivalence
+
+
+-- There are two different ways to construct the Rezk completion,
+-- one is using the essential image of the Yoneda embbeding,
+-- another one is using a higher inductive type
+-- (c.f. HoTT Book Chaper 9.9).
+
+-- Yoneda embbeding can give a very simple and quick construction.
+-- Unfortunately, this construction increases the universe level.
+
+-- The HIT construction, on the other hand, keeps the universe level,
+-- but its proof is a bit long and tedious, still easy though.
+
+
+{- The Construction by Yoneda Embedding -}
+
+module RezkByYoneda (C : Category ℓ ℓ) where
+
+  YonedaImage : Category (ℓ-suc ℓ) ℓ
+  YonedaImage = EssentialImage (YO {C = C})
+
+  isUnivalentYonedaImage : isUnivalent YonedaImage
+  isUnivalentYonedaImage = isUnivalentEssentialImage _ isUnivalentPresheafCategory
+
+  ToYonedaImage : Functor C YonedaImage
+  ToYonedaImage = ToEssentialImage _
+
+  isWeakEquivalenceToYonedaImage : isWeakEquivalence ToYonedaImage
+  isWeakEquivalenceToYonedaImage .fullfaith = isFullyFaithfulToEssentialImage _ isFullyFaithfulYO
+  isWeakEquivalenceToYonedaImage .esssurj   = isEssentiallySurjToEssentialImage YO
+
+  isRezkCompletionToYonedaImage : isRezkCompletion ToYonedaImage
+  isRezkCompletionToYonedaImage = makeIsRezkCompletion isUnivalentYonedaImage isWeakEquivalenceToYonedaImage
+
+
+{- The Construction by Higher Inductive Type -}
+
+module RezkByHIT (C : Category ℓ ℓ') where
+  open import Cubical.Categories.Category
+  open Cubical.Categories.Category.Category
+  open import Cubical.Categories.Isomorphism
+  -- TODO: Write the HIT construction of Rezk completion here.
+  data Ĉ₀ : Type (ℓ-max ℓ ℓ') where -- TODO: is this the best we can do w/ the levels?
+    i : (C .ob) → Ĉ₀
+    j : {a b : C .ob}(e : CatIso C a b) → i a ≡ i b
+    jid : {a : C .ob} → j {a} idCatIso ≡ refl
+    jcomp : {a b c : C .ob}(f : CatIso C a b)(g : CatIso C b c) → j (⋆Iso f g) ≡ j f ∙ j g
+    1-truncation : (x y : Ĉ₀)(p q : x ≡ y)(r s : p ≡ q) → r ≡ s
+
+  -- the paragraph directly following the HIT definition, below theorem 9.9.5 of the HOTT book
+  notethatfor : (a b : C .ob)(p : a ≡ b) → j (pathToIso p) ≡ congS i p
+  notethatfor a b p = J (λ y → λ eq → j (pathToIso eq) ≡ congS i eq) (j (pathToIso refl) ≡⟨ congS j pathToIso-refl ⟩ j idCatIso ≡⟨ jid ⟩ congS i refl ∎) p -- TODO: I don't really get this proof and why we want this theorem
+
+  open import Cubical.Foundations.Isomorphism
+  open import Cubical.Categories.Category.Base
+  open Cubical.Categories.Category.isIso
+  Ĉ₁ : Ĉ₀ → Ĉ₀ → Type _
+  Ĉ₁ (i a) (i b) = (C [ a , b ])
+  Ĉ₁ (i a) (j {b} {b'} e i') = isoToPath (iso iso→ iso⁻¹← (λ g → g ⋆⟨ C ⟩ e⁻¹← ⋆⟨ C ⟩ e→ ≡⟨ C .⋆Assoc g e⁻¹← e→ ⟩ g ⋆⟨ C ⟩ (e⁻¹← ⋆⟨ C ⟩ e→)  ≡⟨ congS (λ eq → g ⋆⟨ C ⟩ eq) (e .snd .sec) ⟩ g ⋆⟨ C ⟩ C .id ≡⟨ C .⋆IdR g ⟩ g ∎) (λ f → f ⋆⟨ C ⟩ e→ ⋆⟨ C ⟩ e⁻¹← ≡⟨ C .⋆Assoc f e→ e⁻¹← ⟩ f ⋆⟨ C ⟩ (e→ ⋆⟨ C ⟩ e⁻¹←) ≡⟨ congS (λ eq → f ⋆⟨ C ⟩ eq) (e .snd .ret) ⟩ f ⋆⟨ C ⟩ C .id ≡⟨ C .⋆IdR f ⟩ f ∎ )) i'
+    where
+    e→ = e .fst
+    e⁻¹← = e .snd .inv
+    -- let f ∈ C [ a , b ], g ∈ C [ a , b' ]
+    -- explicit types to manually supply contraints
+    iso→ : C [ a , b ] → C [ a , b' ]
+    iso→ f = f ⋆⟨ C ⟩ e→
+    iso⁻¹← : C [ a , b' ] → C [ a , b ]
+    iso⁻¹← g = g ⋆⟨ C ⟩ e⁻¹←

--- a/Cubical/Categories/RezkCompletion/Constructionn.agda
+++ b/Cubical/Categories/RezkCompletion/Constructionn.agda
@@ -73,15 +73,16 @@ module RezkByHIT (C : Category ℓ ℓ') where
     1-truncation : (x y : Ĉ₀)(p q : x ≡ y)(r s : p ≡ q) → r ≡ s
 
   -- the paragraph directly following the HIT definition, below theorem 9.9.5 of the HOTT book
-  notethatfor : (a b : C .ob)(p : a ≡ b) → j (pathToIso p) ≡ congS i p
-  notethatfor a b p = J (λ y → λ eq → j (pathToIso eq) ≡ congS i eq) (j (pathToIso refl) ≡⟨ congS j pathToIso-refl ⟩ j idCatIso ≡⟨ jid ⟩ congS i refl ∎) p -- TODO: I don't really get this proof and why we want this theorem
+  _ : (a b : C .ob)(p : a ≡ b) → j (pathToIso p) ≡ congS i p
+  _ = λ a b p → J (λ y → λ eq → j (pathToIso eq) ≡ congS i eq) (j (pathToIso refl) ≡⟨ congS j pathToIso-refl ⟩ j idCatIso ≡⟨ jid ⟩ congS i refl ∎) p -- TODO: I don't really get this proof and why we want this theorem
 
   open import Cubical.Foundations.Isomorphism
   open import Cubical.Categories.Category.Base
   open Cubical.Categories.Category.isIso
+  open import Cubical.Foundations.Univalence
   Ĉ₁ : Ĉ₀ → Ĉ₀ → Type _
   Ĉ₁ (i a) (i b) = (C [ a , b ])
-  Ĉ₁ (i a) (j {b} {b'} e i') = isoToPath (iso iso→ iso⁻¹← (λ g → g ⋆⟨ C ⟩ e⁻¹← ⋆⟨ C ⟩ e→ ≡⟨ C .⋆Assoc g e⁻¹← e→ ⟩ g ⋆⟨ C ⟩ (e⁻¹← ⋆⟨ C ⟩ e→)  ≡⟨ congS (λ eq → g ⋆⟨ C ⟩ eq) (e .snd .sec) ⟩ g ⋆⟨ C ⟩ C .id ≡⟨ C .⋆IdR g ⟩ g ∎) (λ f → f ⋆⟨ C ⟩ e→ ⋆⟨ C ⟩ e⁻¹← ≡⟨ C .⋆Assoc f e→ e⁻¹← ⟩ f ⋆⟨ C ⟩ (e→ ⋆⟨ C ⟩ e⁻¹←) ≡⟨ congS (λ eq → f ⋆⟨ C ⟩ eq) (e .snd .ret) ⟩ f ⋆⟨ C ⟩ C .id ≡⟨ C .⋆IdR f ⟩ f ∎ )) i'
+  Ĉ₁ (i a) (j {b} {b'} e i') = isoToPath (iso iso→ iso⁻¹← (λ g → iso→ (iso⁻¹← g) ≡⟨ refl ⟩ g ⋆⟨ C ⟩ e⁻¹← ⋆⟨ C ⟩ e→ ≡⟨ C .⋆Assoc g e⁻¹← e→ ⟩ g ⋆⟨ C ⟩ (e⁻¹← ⋆⟨ C ⟩ e→)  ≡⟨ congS (λ eq → g ⋆⟨ C ⟩ eq) (e .snd .sec) ⟩ g ⋆⟨ C ⟩ C .id ≡⟨ C .⋆IdR g ⟩ g ∎) (λ f → iso⁻¹← (iso→ f) ≡⟨ refl ⟩ f ⋆⟨ C ⟩ e→ ⋆⟨ C ⟩ e⁻¹← ≡⟨ C .⋆Assoc f e→ e⁻¹← ⟩ f ⋆⟨ C ⟩ (e→ ⋆⟨ C ⟩ e⁻¹←) ≡⟨ congS (λ eq → f ⋆⟨ C ⟩ eq) (e .snd .ret) ⟩ f ⋆⟨ C ⟩ C .id ≡⟨ C .⋆IdR f ⟩ f ∎ )) i'
     where
     e→ = e .fst
     e⁻¹← = e .snd .inv
@@ -91,3 +92,13 @@ module RezkByHIT (C : Category ℓ ℓ') where
     iso→ f = f ⋆⟨ C ⟩ e→
     iso⁻¹← : C [ a , b' ] → C [ a , b ]
     iso⁻¹← g = g ⋆⟨ C ⟩ e⁻¹←
+  Ĉ₁ (i a) (jid {b} i' i'') = ((isoToPath (iso iso→ iso⁻¹← (λ g → iso→ (iso⁻¹← g) ≡⟨ refl ⟩ g ⋆⟨ C ⟩ C .id ⋆⟨ C ⟩ C .id ≡⟨ C .⋆Assoc g (C .id) (C .id) ⟩ g ⋆⟨ C ⟩ (C .id ⋆⟨ C ⟩ C .id) ≡⟨ congS (λ eq → g ⋆⟨ C ⟩ eq) (C .⋆IdL (C .id)) ⟩ g ⋆⟨ C ⟩ C .id ≡⟨ C .⋆IdR g ⟩ g ∎ ) (λ f → iso⁻¹← (iso→ f) ≡⟨ refl ⟩ f ⋆⟨ C ⟩ C .id ⋆⟨ C ⟩ C .id ≡⟨ C .⋆Assoc f (C .id) (C .id) ⟩ f ⋆⟨ C ⟩ (C .id ⋆⟨ C ⟩ C .id) ≡⟨ congS (λ eq → f ⋆⟨ C ⟩ eq) (C .⋆IdL (C .id)) ⟩ f ⋆⟨ C ⟩ C .id ≡⟨ C .⋆IdR f ⟩ f ∎))) ≡⟨ {!!} ⟩ refl-hom ∎) i' i''
+    where
+    iso→ : C [ a , b ] → C [ a , b ]
+    iso→ f = f ⋆⟨ C ⟩ (C .id)
+    iso⁻¹← : C [ a , b ] → C [ a , b ]
+    iso⁻¹← g = g ⋆⟨ C ⟩ (C .id)
+    refl-hom : C [ a , b ] ≡ C [ a , b ]
+    refl-hom = refl
+  Ĉ₁ (i a) (jcomp {b} {c} {d} f g i' i'') = {!!}
+  Ĉ₁ (j {a} {a'} e i') (i b) = {!!}

--- a/Cubical/Categories/RezkCompletion/Constructionn.agda
+++ b/Cubical/Categories/RezkCompletion/Constructionn.agda
@@ -79,9 +79,12 @@ module RezkByHIT (C : Category ℓ ℓ') where
   open import Cubical.Foundations.Isomorphism
   open import Cubical.Categories.Category.Base
   open Cubical.Categories.Category.isIso
+  open import Cubical.Foundations.Univalence
+  open import Cubical.Foundations.Equiv
   Ĉ₁ : Ĉ₀ → Ĉ₀ → Type _
   Ĉ₁ (i a) (i b) = (C [ a , b ])
-  Ĉ₁ (i a) (j {b} {b'} e i') = isoToPath (iso iso→ iso⁻¹← (λ g → iso→ (iso⁻¹← g) ≡⟨ refl ⟩ g ⋆⟨ C ⟩ e⁻¹← ⋆⟨ C ⟩ e→ ≡⟨ C .⋆Assoc g e⁻¹← e→ ⟩ g ⋆⟨ C ⟩ (e⁻¹← ⋆⟨ C ⟩ e→)  ≡⟨ congS (λ eq → g ⋆⟨ C ⟩ eq) (e .snd .sec) ⟩ g ⋆⟨ C ⟩ C .id ≡⟨ C .⋆IdR g ⟩ g ∎) (λ f → iso⁻¹← (iso→ f) ≡⟨ refl ⟩ f ⋆⟨ C ⟩ e→ ⋆⟨ C ⟩ e⁻¹← ≡⟨ C .⋆Assoc f e→ e⁻¹← ⟩ f ⋆⟨ C ⟩ (e→ ⋆⟨ C ⟩ e⁻¹←) ≡⟨ congS (λ eq → f ⋆⟨ C ⟩ eq) (e .snd .ret) ⟩ f ⋆⟨ C ⟩ C .id ≡⟨ C .⋆IdR f ⟩ f ∎ )) i'
+  Ĉ₁ (i a) (j {b} {b'} e i') = ua (isoToEquiv (iso iso→ iso⁻¹← (λ g → iso→ (iso⁻¹← g) ≡⟨ refl ⟩ g ⋆⟨ C ⟩ e⁻¹← ⋆⟨ C ⟩ e→ ≡⟨ C .⋆Assoc g e⁻¹← e→ ⟩ g ⋆⟨ C ⟩ (e⁻¹← ⋆⟨ C ⟩ e→)  ≡⟨ congS (λ eq → g ⋆⟨ C ⟩ eq) (e .snd .sec) ⟩ g ⋆⟨ C ⟩ C .id ≡⟨ C .⋆IdR g ⟩ g ∎) (λ f → iso⁻¹← (iso→ f) ≡⟨ refl ⟩ f ⋆⟨ C ⟩ e→ ⋆⟨ C ⟩ e⁻¹← ≡⟨ C .⋆Assoc f e→ e⁻¹← ⟩ f ⋆⟨ C ⟩ (e→ ⋆⟨ C ⟩ e⁻¹←) ≡⟨ congS (λ eq → f ⋆⟨ C ⟩ eq) (e .snd .ret) ⟩ f ⋆⟨ C ⟩ C .id ≡⟨ C .⋆IdR f ⟩ f ∎ ))) i'
+  -- isoToPath (iso iso→ iso⁻¹← (λ g → iso→ (iso⁻¹← g) ≡⟨ refl ⟩ g ⋆⟨ C ⟩ e⁻¹← ⋆⟨ C ⟩ e→ ≡⟨ C .⋆Assoc g e⁻¹← e→ ⟩ g ⋆⟨ C ⟩ (e⁻¹← ⋆⟨ C ⟩ e→)  ≡⟨ congS (λ eq → g ⋆⟨ C ⟩ eq) (e .snd .sec) ⟩ g ⋆⟨ C ⟩ C .id ≡⟨ C .⋆IdR g ⟩ g ∎) (λ f → iso⁻¹← (iso→ f) ≡⟨ refl ⟩ f ⋆⟨ C ⟩ e→ ⋆⟨ C ⟩ e⁻¹← ≡⟨ C .⋆Assoc f e→ e⁻¹← ⟩ f ⋆⟨ C ⟩ (e→ ⋆⟨ C ⟩ e⁻¹←) ≡⟨ congS (λ eq → f ⋆⟨ C ⟩ eq) (e .snd .ret) ⟩ f ⋆⟨ C ⟩ C .id ≡⟨ C .⋆IdR f ⟩ f ∎ )) i'
     where
     e→ = e .fst
     e⁻¹← = e .snd .inv
@@ -91,15 +94,15 @@ module RezkByHIT (C : Category ℓ ℓ') where
     iso→ f = f ⋆⟨ C ⟩ e→
     iso⁻¹← : C [ a , b' ] → C [ a , b ]
     iso⁻¹← g = g ⋆⟨ C ⟩ e⁻¹←
-  Ĉ₁ (i a) (jid {b} i' i'') = ( proof⋆id ≡⟨ J (λ y eq → {! !}) {!!} proof⋆id ⟩ refl-hom ∎) i' i''
+  Ĉ₁ (i a) (jid {b} i' i'') = ( proof⋆id ≡⟨ congS ua (equivEq (funExt λ f → C .⋆IdR f)) ⟩ ua (idEquiv (C [ a , b ])) ≡⟨ uaIdEquiv ⟩ refl-hom ∎) i' i''
     where
     iso→ : C [ a , b ] → C [ a , b ]
     iso→ f = f ⋆⟨ C ⟩ (C .id)
     iso⁻¹← : C [ a , b ] → C [ a , b ]
     iso⁻¹← g = g ⋆⟨ C ⟩ (C .id)
     proof⋆id : C [ a , b ] ≡ C [ a , b ]
-    proof⋆id = isoToPath (iso iso→ iso⁻¹← (λ g → iso→ (iso⁻¹← g) ≡⟨ refl ⟩ g ⋆⟨ C ⟩ C .id ⋆⟨ C ⟩ C .id ≡⟨ C .⋆Assoc g (C .id) (C .id) ⟩ g ⋆⟨ C ⟩ (C .id ⋆⟨ C ⟩ C .id) ≡⟨ congS (λ eq → g ⋆⟨ C ⟩ eq) (C .⋆IdL (C .id)) ⟩ g ⋆⟨ C ⟩ C .id ≡⟨ C .⋆IdR g ⟩ g ∎ ) (λ f → iso⁻¹← (iso→ f) ≡⟨ refl ⟩ f ⋆⟨ C ⟩ C .id ⋆⟨ C ⟩ C .id ≡⟨ C .⋆Assoc f (C .id) (C .id) ⟩ f ⋆⟨ C ⟩ (C .id ⋆⟨ C ⟩ C .id) ≡⟨ congS (λ eq → f ⋆⟨ C ⟩ eq) (C .⋆IdL (C .id)) ⟩ f ⋆⟨ C ⟩ C .id ≡⟨ C .⋆IdR f ⟩ f ∎))
+    proof⋆id = ua (isoToEquiv (iso iso→ iso⁻¹← (λ g → iso→ (iso⁻¹← g) ≡⟨ refl ⟩ g ⋆⟨ C ⟩ C .id ⋆⟨ C ⟩ C .id ≡⟨ C .⋆Assoc g (C .id) (C .id) ⟩ g ⋆⟨ C ⟩ (C .id ⋆⟨ C ⟩ C .id) ≡⟨ congS (λ eq → g ⋆⟨ C ⟩ eq) (C .⋆IdL (C .id)) ⟩ g ⋆⟨ C ⟩ C .id ≡⟨ C .⋆IdR g ⟩ g ∎ ) (λ f → iso⁻¹← (iso→ f) ≡⟨ refl ⟩ f ⋆⟨ C ⟩ C .id ⋆⟨ C ⟩ C .id ≡⟨ C .⋆Assoc f (C .id) (C .id) ⟩ f ⋆⟨ C ⟩ (C .id ⋆⟨ C ⟩ C .id) ≡⟨ congS (λ eq → f ⋆⟨ C ⟩ eq) (C .⋆IdL (C .id)) ⟩ f ⋆⟨ C ⟩ C .id ≡⟨ C .⋆IdR f ⟩ f ∎)))
     refl-hom : C [ a , b ] ≡ C [ a , b ]
     refl-hom = refl
-  Ĉ₁ (i a) (jcomp {b} {c} {d} f g i' i'') = {!!}
-  Ĉ₁ (j {a} {a'} e i') (i b) = {!!}
+  --Ĉ₁ (i a) (jcomp {b} {c} {d} f g i' i'') = {!!}
+  --Ĉ₁ (j {a} {a'} e i') (i b) = {!!}

--- a/Cubical/Categories/RezkCompletion/Constructionn.agda
+++ b/Cubical/Categories/RezkCompletion/Constructionn.agda
@@ -79,7 +79,6 @@ module RezkByHIT (C : Category ℓ ℓ') where
   open import Cubical.Foundations.Isomorphism
   open import Cubical.Categories.Category.Base
   open Cubical.Categories.Category.isIso
-  open import Cubical.Foundations.Univalence
   Ĉ₁ : Ĉ₀ → Ĉ₀ → Type _
   Ĉ₁ (i a) (i b) = (C [ a , b ])
   Ĉ₁ (i a) (j {b} {b'} e i') = isoToPath (iso iso→ iso⁻¹← (λ g → iso→ (iso⁻¹← g) ≡⟨ refl ⟩ g ⋆⟨ C ⟩ e⁻¹← ⋆⟨ C ⟩ e→ ≡⟨ C .⋆Assoc g e⁻¹← e→ ⟩ g ⋆⟨ C ⟩ (e⁻¹← ⋆⟨ C ⟩ e→)  ≡⟨ congS (λ eq → g ⋆⟨ C ⟩ eq) (e .snd .sec) ⟩ g ⋆⟨ C ⟩ C .id ≡⟨ C .⋆IdR g ⟩ g ∎) (λ f → iso⁻¹← (iso→ f) ≡⟨ refl ⟩ f ⋆⟨ C ⟩ e→ ⋆⟨ C ⟩ e⁻¹← ≡⟨ C .⋆Assoc f e→ e⁻¹← ⟩ f ⋆⟨ C ⟩ (e→ ⋆⟨ C ⟩ e⁻¹←) ≡⟨ congS (λ eq → f ⋆⟨ C ⟩ eq) (e .snd .ret) ⟩ f ⋆⟨ C ⟩ C .id ≡⟨ C .⋆IdR f ⟩ f ∎ )) i'
@@ -92,12 +91,14 @@ module RezkByHIT (C : Category ℓ ℓ') where
     iso→ f = f ⋆⟨ C ⟩ e→
     iso⁻¹← : C [ a , b' ] → C [ a , b ]
     iso⁻¹← g = g ⋆⟨ C ⟩ e⁻¹←
-  Ĉ₁ (i a) (jid {b} i' i'') = ((isoToPath (iso iso→ iso⁻¹← (λ g → iso→ (iso⁻¹← g) ≡⟨ refl ⟩ g ⋆⟨ C ⟩ C .id ⋆⟨ C ⟩ C .id ≡⟨ C .⋆Assoc g (C .id) (C .id) ⟩ g ⋆⟨ C ⟩ (C .id ⋆⟨ C ⟩ C .id) ≡⟨ congS (λ eq → g ⋆⟨ C ⟩ eq) (C .⋆IdL (C .id)) ⟩ g ⋆⟨ C ⟩ C .id ≡⟨ C .⋆IdR g ⟩ g ∎ ) (λ f → iso⁻¹← (iso→ f) ≡⟨ refl ⟩ f ⋆⟨ C ⟩ C .id ⋆⟨ C ⟩ C .id ≡⟨ C .⋆Assoc f (C .id) (C .id) ⟩ f ⋆⟨ C ⟩ (C .id ⋆⟨ C ⟩ C .id) ≡⟨ congS (λ eq → f ⋆⟨ C ⟩ eq) (C .⋆IdL (C .id)) ⟩ f ⋆⟨ C ⟩ C .id ≡⟨ C .⋆IdR f ⟩ f ∎))) ≡⟨ {!!} ⟩ refl-hom ∎) i' i''
+  Ĉ₁ (i a) (jid {b} i' i'') = ( proof⋆id ≡⟨ J (λ y eq → {! !}) {!!} proof⋆id ⟩ refl-hom ∎) i' i''
     where
     iso→ : C [ a , b ] → C [ a , b ]
     iso→ f = f ⋆⟨ C ⟩ (C .id)
     iso⁻¹← : C [ a , b ] → C [ a , b ]
     iso⁻¹← g = g ⋆⟨ C ⟩ (C .id)
+    proof⋆id : C [ a , b ] ≡ C [ a , b ]
+    proof⋆id = isoToPath (iso iso→ iso⁻¹← (λ g → iso→ (iso⁻¹← g) ≡⟨ refl ⟩ g ⋆⟨ C ⟩ C .id ⋆⟨ C ⟩ C .id ≡⟨ C .⋆Assoc g (C .id) (C .id) ⟩ g ⋆⟨ C ⟩ (C .id ⋆⟨ C ⟩ C .id) ≡⟨ congS (λ eq → g ⋆⟨ C ⟩ eq) (C .⋆IdL (C .id)) ⟩ g ⋆⟨ C ⟩ C .id ≡⟨ C .⋆IdR g ⟩ g ∎ ) (λ f → iso⁻¹← (iso→ f) ≡⟨ refl ⟩ f ⋆⟨ C ⟩ C .id ⋆⟨ C ⟩ C .id ≡⟨ C .⋆Assoc f (C .id) (C .id) ⟩ f ⋆⟨ C ⟩ (C .id ⋆⟨ C ⟩ C .id) ≡⟨ congS (λ eq → f ⋆⟨ C ⟩ eq) (C .⋆IdL (C .id)) ⟩ f ⋆⟨ C ⟩ C .id ≡⟨ C .⋆IdR f ⟩ f ∎))
     refl-hom : C [ a , b ] ≡ C [ a , b ]
     refl-hom = refl
   Ĉ₁ (i a) (jcomp {b} {c} {d} f g i' i'') = {!!}

--- a/Cubical/Categories/RezkCompletion/Constructionn.agda
+++ b/Cubical/Categories/RezkCompletion/Constructionn.agda
@@ -64,8 +64,7 @@ module RezkByHIT (C : Category ℓ ℓ') where
   open import Cubical.Categories.Category
   open Cubical.Categories.Category.Category
   open import Cubical.Categories.Isomorphism
-  -- TODO: Write the HIT construction of Rezk completion here.
-  data Ĉ₀ : Type (ℓ-max ℓ ℓ') where -- TODO: is this the best we can do w/ the levels?
+  data Ĉ₀ : Type (ℓ-max ℓ ℓ') where
     i : (C .ob) → Ĉ₀
     j : {a b : C .ob}(e : CatIso C a b) → i a ≡ i b
     jid : {a : C .ob} → j {a} idCatIso ≡ refl
@@ -73,18 +72,36 @@ module RezkByHIT (C : Category ℓ ℓ') where
     1-truncation : (x y : Ĉ₀)(p q : x ≡ y)(r s : p ≡ q) → r ≡ s
 
   -- the paragraph directly following the HIT definition, below theorem 9.9.5 of the HOTT book
+  -- TODO: I don't really get why we want this theorem
   _ : (a b : C .ob)(p : a ≡ b) → j (pathToIso p) ≡ congS i p
-  _ = λ a b p → J (λ y → λ eq → j (pathToIso eq) ≡ congS i eq) (j (pathToIso refl) ≡⟨ congS j pathToIso-refl ⟩ j idCatIso ≡⟨ jid ⟩ congS i refl ∎) p -- TODO: I don't really get this proof and why we want this theorem
+  _ = λ a b p → J
+    (λ y → λ eq → j (pathToIso eq) ≡ congS i eq)
+    (j (pathToIso refl) ≡⟨ congS j pathToIso-refl ⟩ j idCatIso ≡⟨ jid ⟩ congS i refl ∎)
+    p
 
   open import Cubical.Foundations.Isomorphism
   open import Cubical.Categories.Category.Base
   open Cubical.Categories.Category.isIso
   open import Cubical.Foundations.Univalence
   open import Cubical.Foundations.Equiv
+  -- Step 1: We define a family by double induction on Ĉ₀
   Ĉ₁ : Ĉ₀ → Ĉ₀ → Type _
   Ĉ₁ (i a) (i b) = (C [ a , b ])
-  Ĉ₁ (i a) (j {b} {b'} e i') = ua (isoToEquiv (iso iso→ iso⁻¹← (λ g → iso→ (iso⁻¹← g) ≡⟨ refl ⟩ g ⋆⟨ C ⟩ e⁻¹← ⋆⟨ C ⟩ e→ ≡⟨ C .⋆Assoc g e⁻¹← e→ ⟩ g ⋆⟨ C ⟩ (e⁻¹← ⋆⟨ C ⟩ e→)  ≡⟨ congS (λ eq → g ⋆⟨ C ⟩ eq) (e .snd .sec) ⟩ g ⋆⟨ C ⟩ C .id ≡⟨ C .⋆IdR g ⟩ g ∎) (λ f → iso⁻¹← (iso→ f) ≡⟨ refl ⟩ f ⋆⟨ C ⟩ e→ ⋆⟨ C ⟩ e⁻¹← ≡⟨ C .⋆Assoc f e→ e⁻¹← ⟩ f ⋆⟨ C ⟩ (e→ ⋆⟨ C ⟩ e⁻¹←) ≡⟨ congS (λ eq → f ⋆⟨ C ⟩ eq) (e .snd .ret) ⟩ f ⋆⟨ C ⟩ C .id ≡⟨ C .⋆IdR f ⟩ f ∎ ))) i'
-  -- isoToPath (iso iso→ iso⁻¹← (λ g → iso→ (iso⁻¹← g) ≡⟨ refl ⟩ g ⋆⟨ C ⟩ e⁻¹← ⋆⟨ C ⟩ e→ ≡⟨ C .⋆Assoc g e⁻¹← e→ ⟩ g ⋆⟨ C ⟩ (e⁻¹← ⋆⟨ C ⟩ e→)  ≡⟨ congS (λ eq → g ⋆⟨ C ⟩ eq) (e .snd .sec) ⟩ g ⋆⟨ C ⟩ C .id ≡⟨ C .⋆IdR g ⟩ g ∎) (λ f → iso⁻¹← (iso→ f) ≡⟨ refl ⟩ f ⋆⟨ C ⟩ e→ ⋆⟨ C ⟩ e⁻¹← ≡⟨ C .⋆Assoc f e→ e⁻¹← ⟩ f ⋆⟨ C ⟩ (e→ ⋆⟨ C ⟩ e⁻¹←) ≡⟨ congS (λ eq → f ⋆⟨ C ⟩ eq) (e .snd .ret) ⟩ f ⋆⟨ C ⟩ C .id ≡⟨ C .⋆IdR f ⟩ f ∎ )) i'
+  -- Let us keep x = i a fixed at first
+  Ĉ₁ (i a) (j {b} {b'} e i') = ua (isoToEquiv
+    (iso iso→ iso⁻¹←
+      (λ g →
+        iso→ (iso⁻¹← g) ≡⟨ refl ⟩
+        g ⋆⟨ C ⟩ e⁻¹← ⋆⟨ C ⟩ e→ ≡⟨ C .⋆Assoc g e⁻¹← e→ ⟩
+        g ⋆⟨ C ⟩ (e⁻¹← ⋆⟨ C ⟩ e→) ≡⟨ congS (λ eq → g ⋆⟨ C ⟩ eq) (e .snd .sec) ⟩
+        g ⋆⟨ C ⟩ C .id ≡⟨ C .⋆IdR g ⟩
+        g ∎)
+      (λ f →
+        iso⁻¹← (iso→ f) ≡⟨ refl ⟩
+        f ⋆⟨ C ⟩ e→ ⋆⟨ C ⟩ e⁻¹← ≡⟨ C .⋆Assoc f e→ e⁻¹← ⟩
+        f ⋆⟨ C ⟩ (e→ ⋆⟨ C ⟩ e⁻¹←) ≡⟨ congS (λ eq → f ⋆⟨ C ⟩ eq) (e .snd .ret) ⟩
+        f ⋆⟨ C ⟩ C .id ≡⟨ C .⋆IdR f ⟩
+        f ∎ ))) i'
     where
     e→ = e .fst
     e⁻¹← = e .snd .inv
@@ -94,15 +111,29 @@ module RezkByHIT (C : Category ℓ ℓ') where
     iso→ f = f ⋆⟨ C ⟩ e→
     iso⁻¹← : C [ a , b' ] → C [ a , b ]
     iso⁻¹← g = g ⋆⟨ C ⟩ e⁻¹←
-  Ĉ₁ (i a) (jid {b} i' i'') = ( proof⋆id ≡⟨ congS ua (equivEq (funExt λ f → C .⋆IdR f)) ⟩ ua (idEquiv (C [ a , b ])) ≡⟨ uaIdEquiv ⟩ refl-hom ∎) i' i''
+  -- As y varies along the identity j 1\_b = reflᵢ\_b
+  Ĉ₁ (i a) (jid {b} i' i'') = (proof⋆id ≡⟨ congS ua (equivEq (funExt λ f → C .⋆IdR f)) ⟩
+    ua (idEquiv (C [ a , b ])) ≡⟨ uaIdEquiv ⟩
+    refl ∎) i' i''
     where
     iso→ : C [ a , b ] → C [ a , b ]
     iso→ f = f ⋆⟨ C ⟩ (C .id)
     iso⁻¹← : C [ a , b ] → C [ a , b ]
     iso⁻¹← g = g ⋆⟨ C ⟩ (C .id)
     proof⋆id : C [ a , b ] ≡ C [ a , b ]
-    proof⋆id = ua (isoToEquiv (iso iso→ iso⁻¹← (λ g → iso→ (iso⁻¹← g) ≡⟨ refl ⟩ g ⋆⟨ C ⟩ C .id ⋆⟨ C ⟩ C .id ≡⟨ C .⋆Assoc g (C .id) (C .id) ⟩ g ⋆⟨ C ⟩ (C .id ⋆⟨ C ⟩ C .id) ≡⟨ congS (λ eq → g ⋆⟨ C ⟩ eq) (C .⋆IdL (C .id)) ⟩ g ⋆⟨ C ⟩ C .id ≡⟨ C .⋆IdR g ⟩ g ∎ ) (λ f → iso⁻¹← (iso→ f) ≡⟨ refl ⟩ f ⋆⟨ C ⟩ C .id ⋆⟨ C ⟩ C .id ≡⟨ C .⋆Assoc f (C .id) (C .id) ⟩ f ⋆⟨ C ⟩ (C .id ⋆⟨ C ⟩ C .id) ≡⟨ congS (λ eq → f ⋆⟨ C ⟩ eq) (C .⋆IdL (C .id)) ⟩ f ⋆⟨ C ⟩ C .id ≡⟨ C .⋆IdR f ⟩ f ∎)))
-    refl-hom : C [ a , b ] ≡ C [ a , b ]
-    refl-hom = refl
-  --Ĉ₁ (i a) (jcomp {b} {c} {d} f g i' i'') = {!!}
+    proof⋆id = ua (isoToEquiv
+      (iso iso→ iso⁻¹←
+        (λ g →
+          iso→ (iso⁻¹← g) ≡⟨ refl ⟩
+          g ⋆⟨ C ⟩ C .id ⋆⟨ C ⟩ C .id ≡⟨ C .⋆Assoc g (C .id) (C .id) ⟩
+          g ⋆⟨ C ⟩ (C .id ⋆⟨ C ⟩ C .id) ≡⟨ congS (λ eq → g ⋆⟨ C ⟩ eq) (C .⋆IdL (C .id)) ⟩
+          g ⋆⟨ C ⟩ C .id ≡⟨ C .⋆IdR g ⟩ g ∎)
+        (λ f →
+          iso⁻¹← (iso→ f) ≡⟨ refl ⟩
+          f ⋆⟨ C ⟩ C .id ⋆⟨ C ⟩ C .id ≡⟨ C .⋆Assoc f (C .id) (C .id) ⟩
+          f ⋆⟨ C ⟩ (C .id ⋆⟨ C ⟩ C .id) ≡⟨ congS (λ eq → f ⋆⟨ C ⟩ eq) (C .⋆IdL (C .id)) ⟩
+          f ⋆⟨ C ⟩ C .id ≡⟨ C .⋆IdR f ⟩
+          f ∎)))
+  -- Similarly, as y varies along the identity j (g ∘ f) = j f ∘ j g
+  Ĉ₁ (i a) (jcomp {b} {c} {d} f g i' i'') = (({!!} ∙ {!!})) i' i''
   --Ĉ₁ (j {a} {a'} e i') (i b) = {!!}


### PR DESCRIPTION
Exercise to learn to work with higher inductive types.
Following the book proof (ch 9.9, second proof) but currently stuck on showing that the reflexive path on C [ a , b ] from isoToPath, where the isomorphism is by postcomposing by 1_b both ways, is equal to refl C [ a , b ]
-- if it's even true?
Tabling this to work on the (binary) cartesian product solver.
 
Also TODO: copy over category lift from my fork so the interface to the rezk completion doesn't force the user to lift their (pre)category themselves.