### PR TITLE
Defining Hyperdoctrine

### DIFF
--- a/Cubical/Categories/Constructions/Hyperdoctrine/Unary.agda
+++ b/Cubical/Categories/Constructions/Hyperdoctrine/Unary.agda
@@ -1,0 +1,66 @@
+{-# OPTIONS --safe #-}
+
+module Cubical.Categories.Constructions.Hyperdoctrine.Unary where
+
+open import Cubical.Foundations.Prelude
+open import Cubical.Categories.Category
+open import Cubical.Categories.Functor.Base
+
+open import Cubical.Categories.Instances.Posets.Base
+open import Cubical.Categories.Instances.Posets.Monotone
+open import Cubical.Categories.Instances.Posets.MonotoneAdjoint
+open import Cubical.Categories.Limits.BinProduct
+open import Cubical.Categories.Limits.BinProduct.More
+
+private
+  variable
+    ℓ ℓ' : Level
+
+open Category
+open MonFunAdj
+
+record Hyperdoctrine ℓ ℓ' : Type (ℓ-suc (ℓ-max ℓ ℓ')) where
+  field
+    cc : Category ℓ ℓ'
+    bp : BinProducts cc
+    func : Functor (cc  ^op) (POSETADJ ℓ ℓ')
+
+  open Notation cc bp
+  field
+    {-
+    Beck-Chevalley condition
+    Expresses the naturality of the left/right adjoints of the a × _ projection:
+    For f ∈ cc [b , c], we have the following commuting square:
+
+                              func(π₂)
+                 func(a × c) ⟵--------- func(c)
+                   |         ---------→   |
+      func(1 × f)  |         left-adj     | func(f)
+                   |                      |
+                   ↓          func(π₂)    ↓
+                 func(a × b) ←--------- func(b)
+                             ---------→
+                             left-adj
+
+    TODO: Can probably be more cleanly expressed as a bifunctor
+    -}
+    nat-left : ∀ {b c : cc .ob}
+      (a : cc .ob) (f : cc [ b , c ]) →
+      ((MonComp
+        ((func ⟪ (cc .id) ×p f ⟫) .morphism)
+        (fst ((func ⟪ π₂ {a} {b} ⟫) .left-adj)))
+      ≡
+      (MonComp
+        (fst ((func ⟪ π₂ {a} {c} ⟫) .left-adj))
+        ((func ⟪ f ⟫) .morphism))
+      )
+    nat-right : ∀ {b c : cc .ob}
+      (a : cc .ob) (f : cc [ b , c ]) →
+      ((MonComp
+        ((func ⟪ (cc .id) ×p f ⟫) .morphism)
+        (fst ((func ⟪ π₂ {a} {b} ⟫) .right-adj)))
+      ≡
+      (MonComp
+        (fst ((func ⟪ π₂ {a} {c} ⟫) .right-adj))
+        ((func ⟪ f ⟫) .morphism))
+      )

--- a/Cubical/Categories/Instances/Posets/Base.agda
+++ b/Cubical/Categories/Instances/Posets/Base.agda
@@ -1,0 +1,46 @@
+{-# OPTIONS --safe #-}
+
+module Cubical.Categories.Instances.Posets.Base where
+
+open import Cubical.Foundations.Prelude
+open import Cubical.Categories.Category
+open import Cubical.Relation.Binary.Poset
+
+open import Cubical.Categories.Instances.Posets.Monotone
+open import Cubical.Categories.Instances.Posets.MonotoneAdjoint
+
+private
+  variable
+    ℓ ℓ' : Level
+
+open Category
+
+-- Category of Posets
+POSET : (ℓ ℓ' : Level) → Category _ _
+POSET ℓ ℓ' = record
+  { ob = Poset ℓ ℓ'
+  ; Hom[_,_] = λ X Y → MonFun X Y
+  ; id = MonId
+  ; _⋆_ = MonComp
+  ; ⋆IdL = λ {X} {Y} f → eqMon f f refl
+  ; ⋆IdR = λ {X} {Y} f → eqMon f f refl
+  ; ⋆Assoc = λ {X} {Y} {Z} {W} f g h → eqMon _ _ refl
+  ; isSetHom = MonFunIsSet
+  }
+
+
+-- Category of Posets w/ Adjoints
+POSETADJ : (ℓ ℓ' : Level) → Category _ _
+POSETADJ ℓ ℓ' = record
+  { ob = Poset ℓ ℓ'
+  ; Hom[_,_] = λ X Y → MonFunAdj X Y
+  ; id = MonIdAdj
+  ; _⋆_ = MonCompAdj
+  ; ⋆IdL = λ {X} {Y} f → eqMonAdj _ _
+         (eqMon _ _ refl) (eqMon _ _ refl) (eqMon _ _ refl)
+  ; ⋆IdR = λ {X} {Y} f → eqMonAdj _ _
+         (eqMon _ _ refl) (eqMon _ _ refl) (eqMon _ _ refl)
+  ; ⋆Assoc = λ {X} {Y} {Z} {W} f g h → eqMonAdj _ _
+           (eqMon _ _ refl) (eqMon _ _ refl) (eqMon _ _ refl)
+  ; isSetHom = MonFunAdjIsSet
+  }

--- a/Cubical/Categories/Instances/Posets/Monotone.agda
+++ b/Cubical/Categories/Instances/Posets/Monotone.agda
@@ -1,0 +1,211 @@
+{-# OPTIONS --safe #-}
+
+-- TODO: This could be generalized to handle monotone functions on
+-- both preorders and posets.
+
+module Cubical.Categories.Instances.Posets.Monotone where
+
+open import Cubical.Foundations.Prelude
+open import Cubical.Foundations.Equiv
+open import Cubical.Foundations.Function hiding (_$_)
+open import Cubical.Foundations.Structure
+open import Cubical.Foundations.HLevels
+open import Cubical.Foundations.Isomorphism
+open import Cubical.Relation.Binary.Base
+open import Cubical.Reflection.Base
+open import Cubical.Reflection.RecordEquiv
+open import Cubical.Data.Sigma
+
+open import Cubical.Relation.Binary.Poset
+
+open BinaryRelation
+
+
+private
+  variable
+    ℓ ℓ' : Level
+
+
+
+module _ {ℓ ℓ' : Level} where
+
+  -- Because of a bug with Cubical Agda's reflection, we need to declare
+  -- a separate version of MonFun where the arguments to the isMon
+  -- constructor are explicit.
+  -- See https://github.com/agda/cubical/issues/995.
+  module _ {X Y : Poset ℓ ℓ'} where
+
+    module X = PosetStr (X .snd)
+    module Y = PosetStr (Y .snd)
+    _≤X_ = X._≤_
+    _≤Y_ = Y._≤_
+
+    monotone' : (⟨ X ⟩ -> ⟨ Y ⟩) -> Type (ℓ-max ℓ ℓ')
+    monotone' f = (x y : ⟨ X ⟩) -> x ≤X y → f x ≤Y f y
+
+    monotone : (⟨ X ⟩ -> ⟨ Y ⟩) -> Type (ℓ-max ℓ ℓ')
+    monotone f = {x y : ⟨ X ⟩} -> x ≤X y → f x ≤Y f y
+
+  -- Monotone functions from X to Y
+  -- This definition works with Cubical Agda's reflection.
+  record MonFun' (X Y : Poset ℓ ℓ') : Type ((ℓ-max ℓ ℓ')) where
+    field
+      f : (X .fst) → (Y .fst)
+      isMon : monotone' {X} {Y} f
+
+  -- This is the definition we want, where the first two arguments to isMon
+  -- are implicit.
+  record MonFun (X Y : Poset ℓ ℓ') : Type ((ℓ-max ℓ ℓ')) where
+    field
+      f : (X .fst) → (Y .fst)
+      isMon : monotone {X} {Y} f
+
+  open MonFun
+  open IsPoset
+  open PosetStr
+
+  isoMonFunMonFun' : {X Y : Poset ℓ ℓ'} -> Iso (MonFun X Y) (MonFun' X Y)
+  isoMonFunMonFun' = iso
+    (λ g → record { f = MonFun.f g ; isMon = λ x y x≤y → isMon g x≤y })
+    (λ g → record { f = MonFun'.f g ;
+                    isMon = λ {x} {y} x≤y -> MonFun'.isMon g x y x≤y }
+    )
+    (λ g → refl)
+    (λ g → refl)
+
+
+  isPropIsMon : {X Y : Poset ℓ ℓ'} -> (f : MonFun X Y) ->
+    isProp (monotone {X} {Y} (MonFun.f f))
+  isPropIsMon {X} {Y} f =
+    isPropImplicitΠ2 (λ x y ->
+      isPropΠ (λ x≤y -> is-prop-valued (isPoset (str Y))
+        (MonFun.f f x) (MonFun.f f y)))
+
+  isPropIsMon' : {X Y : Poset ℓ ℓ'} -> (f : ⟨ X ⟩ -> ⟨ Y ⟩) ->
+    isProp (monotone' {X} {Y} f)
+  isPropIsMon' {X} {Y} f =
+    isPropΠ3 (λ x y x≤y -> is-prop-valued (isPoset (str Y))
+      (f x) (f y))
+
+  -- Equivalence between MonFun' record and a sigma type
+  unquoteDecl MonFun'IsoΣ = declareRecordIsoΣ MonFun'IsoΣ (quote (MonFun'))
+
+  Sigma : (X Y : Poset ℓ ℓ') -> Type (ℓ-max ℓ ℓ')
+  Sigma X Y =
+     (Σ (X .fst → Y .fst)
+     (λ z → (x y : ⟨ X ⟩) → _≤X_ {X} {Y} x y → _≤Y_ {X} {Y} (z x) (z y)))
+
+  _ : {X Y : Poset ℓ ℓ'} -> Iso (MonFun' X Y) (Sigma X Y)
+  _ = MonFun'IsoΣ
+
+  MonFun≡Sigma : {X Y : Poset ℓ ℓ'} -> MonFun' X Y ≡ Sigma X Y
+  MonFun≡Sigma = isoToPath MonFun'IsoΣ
+
+  Sigma≡ : {X Y : Poset ℓ ℓ'} -> {s1 s2 : Sigma X Y} ->
+    s1 .fst ≡ s2 .fst -> s1 ≡ s2
+  Sigma≡ {X} {Y} = Σ≡Prop (λ f → isPropΠ3
+    (λ x y x≤y -> is-prop-valued (isPoset (str Y)) (f x) (f y)))
+
+  -- Equality of monotone functions is equivalent to equality of the
+  -- underlying functions.
+  eqMon' : {X Y : Poset ℓ ℓ'} -> (f g : MonFun' X Y) ->
+    MonFun'.f f ≡ MonFun'.f g -> f ≡ g
+  eqMon' {X} {Y} f g p = isoFunInjective MonFun'IsoΣ f g
+    (Σ≡Prop (λ h → isPropΠ3 (λ y z q →
+      is-prop-valued (isPoset (str Y)) (h y) (h z))) p)
+
+  eqMon : {X Y : Poset ℓ ℓ'} -> (f g : MonFun X Y) ->
+    MonFun.f f ≡ MonFun.f g -> f ≡ g
+  eqMon {X} {Y} f g p = isoFunInjective isoMonFunMonFun' f g (eqMon' _ _ p)
+
+  -- isSet for Sigma
+  isSetSigma : {X Y : Poset ℓ ℓ'} -> isSet (Sigma X Y)
+  isSetSigma {X} {Y} = isSetΣSndProp
+    (isSet→ (is-set (isPoset (str Y))))
+    λ f -> isPropIsMon' {X} {Y} f
+
+  -- isSet for monotone functions
+  MonFunIsSet : {X Y : Poset ℓ ℓ'} -> isSet (MonFun X Y)
+  MonFunIsSet {X} {Y} =
+    let composedIso = (compIso isoMonFunMonFun' MonFun'IsoΣ) in
+      isSetRetract
+        (Iso.fun composedIso) (Iso.inv composedIso) (Iso.leftInv composedIso)
+        (isSetΣSndProp
+          (isSet→ (is-set (isPoset (str Y))))
+          (isPropIsMon' {X} {Y}))
+
+
+
+  -- Ordering on monotone functions
+  module _ {X Y : Poset ℓ ℓ'} where
+
+    _≤mon_ :
+      MonFun X Y → MonFun X Y → Type (ℓ-max ℓ ℓ')
+    _≤mon_ f g = ∀ x -> (PosetStr._≤_ (Y .snd)) (MonFun.f f x) (MonFun.f g x)
+
+    ≤mon-prop : isPropValued _≤mon_
+    ≤mon-prop f g =
+      isPropΠ (λ x -> (is-prop-valued (isPoset (str Y)))
+        (MonFun.f f x) (MonFun.f g x))
+
+    ≤mon-refl : isRefl _≤mon_
+    ≤mon-refl = λ f x → (is-refl (isPoset (str Y))) (MonFun.f f x)
+
+    ≤mon-trans : isTrans _≤mon_
+    ≤mon-trans = λ f g h f≤g g≤h x →
+      (is-trans (isPoset (str Y))) (MonFun.f f x) (MonFun.f g x) (MonFun.f h x)
+        (f≤g x) (g≤h x)
+
+    ≤mon-antisym : isAntisym _≤mon_
+    ≤mon-antisym = λ f g f≤g g≤f → eqMon f g
+      (funExt λ x →
+        (is-antisym (isPoset (str Y))) (MonFun.f f x) (MonFun.f g x)
+          (f≤g x) (g≤f x)
+      )
+
+
+    -- Alternate definition of ordering on monotone functions, where we allow
+    -- for the arguments to be distinct
+    _≤mon-het_ : MonFun X Y -> MonFun X Y -> Type (ℓ-max ℓ ℓ')
+    _≤mon-het_ f f' = ∀ x x' ->
+                      (PosetStr._≤_ (X .snd)) x x' ->
+                      (PosetStr._≤_ (Y .snd)) (MonFun.f f x) (MonFun.f f' x')
+
+    ≤mon→≤mon-het : (f f' : MonFun X Y) -> f ≤mon f' -> f ≤mon-het f'
+    ≤mon→≤mon-het f f' f≤f' = λ x x' x≤x' →
+      MonFun.f f x    ≤⟨ MonFun.isMon f x≤x' ⟩
+      MonFun.f f x'   ≤⟨ f≤f' x' ⟩
+      MonFun.f f' x'  ◾
+      where
+        open PosetReasoning Y
+
+
+ -- Poset of monotone functions between two posets
+  IntHom : Poset ℓ ℓ' -> Poset ℓ ℓ' ->
+    Poset (ℓ-max ℓ ℓ') (ℓ-max ℓ ℓ')
+  IntHom X Y =
+    MonFun X Y ,
+    (posetstr
+      (_≤mon_)
+      (isposet MonFunIsSet ≤mon-prop ≤mon-refl ≤mon-trans ≤mon-antisym))
+
+    -- Notation
+  _==>_ : Poset ℓ ℓ' -> Poset ℓ ℓ' ->
+    Poset (ℓ-max ℓ ℓ') (ℓ-max ℓ ℓ')
+  X ==> Y = IntHom X Y -- IntHom X Y
+
+
+
+  -- Some basic combinators/utility functions on monotone functions
+
+  MonId : {X : Poset ℓ ℓ'} -> MonFun X X
+  MonId = record { f = λ x -> x ; isMon = λ x≤y → x≤y }
+
+  _$_ : {X Y : Poset ℓ ℓ'} -> MonFun X Y -> ⟨ X ⟩ -> ⟨ Y ⟩
+  f $ x = MonFun.f f x
+
+  MonComp : {X Y Z : Poset ℓ ℓ'} ->
+    MonFun X Y -> MonFun Y Z -> MonFun X Z
+  MonComp f g = record {
+    f = λ x -> g $ (f $ x) ;
+    isMon = λ {x1} {x2} x1≤x2 → isMon g (isMon f x1≤x2) }

--- a/Cubical/Categories/Instances/Posets/MonotoneAdjoint.agda
+++ b/Cubical/Categories/Instances/Posets/MonotoneAdjoint.agda
@@ -1,0 +1,113 @@
+{-# OPTIONS --safe #-}
+
+-- defines adjoint for monotone functions and morphisms in the Poset Category
+-- where each morphism has left and right adjoints
+
+module Cubical.Categories.Instances.Posets.MonotoneAdjoint where
+
+open import Cubical.Foundations.Prelude
+open import Cubical.Foundations.Isomorphism
+open import Cubical.Foundations.HLevels
+
+open import Cubical.Relation.Binary.Poset
+open import Cubical.Data.Sigma
+open import Cubical.HITs.PropositionalTruncation.Base
+open import Cubical.HITs.PropositionalTruncation.Properties
+
+open import Cubical.Categories.Instances.Posets.Monotone
+
+
+private
+  variable
+    ℓ ℓ' : Level
+
+
+module _ {ℓ ℓ' : Level} where
+
+  -- the Galois Connection between Posets
+  -- adjoints for monotone functions
+  record _⊣_ {X Y : Poset ℓ ℓ'}
+             (L : MonFun X Y) (R : MonFun Y X) : Type (ℓ-max ℓ ℓ') where
+    field
+      adjIff : ∀ {x y} → Iso
+        ((PosetStr._≤_ (Y .snd)) (MonFun.f L x) y)
+        ((PosetStr._≤_ (X .snd)) x (MonFun.f R y))
+
+  -- monotone functions that have left and right adjoint
+  record MonFunAdj (X Y : Poset ℓ ℓ') : Type ((ℓ-max ℓ ℓ')) where
+    field
+      morphism : MonFun X Y
+      left-adj : Σ[ L ∈ MonFun Y X ] ∥ (L ⊣ morphism) ∥₁
+      right-adj : Σ[ R ∈ MonFun Y X ] ∥ (morphism ⊣ R) ∥₁
+
+  MonId⊣MonId : {X : Poset ℓ ℓ'} → MonId {X = X} ⊣ MonId {X = X}
+  MonId⊣MonId {X} =
+    record { adjIff = iso (λ h → h) (λ h → h) ( λ _ → refl)  (λ _ → refl) }
+
+  open MonFunAdj
+  open _⊣_
+
+  MonIdAdj : {X : Poset ℓ ℓ'} → MonFunAdj X X
+  MonIdAdj {X} = record {
+    morphism = MonId ;
+    left-adj = MonId , ∣ MonId⊣MonId ∣₁ ;
+    right-adj =  MonId , ∣ MonId⊣MonId ∣₁ }
+
+  MonCompAdj : {X Y Z : Poset ℓ ℓ'} ->
+    MonFunAdj X Y -> MonFunAdj Y Z -> MonFunAdj X Z
+  MonCompAdj f g = record {
+    morphism = MonComp (f .morphism) (g .morphism) ;
+    left-adj = MonComp (fst (g .left-adj)) (fst (f .left-adj)) ,
+      rec2  isPropPropTrunc
+        (λ l1 l2 → ∣ record { adjIff = compIso (l1 .adjIff) (l2 .adjIff) } ∣₁)
+        (snd (f .left-adj)) (snd (g .left-adj))  ;
+    right-adj = MonComp (fst (g .right-adj)) (fst (f .right-adj)) ,
+      rec2  isPropPropTrunc
+        (λ r1 r2 → ∣ record { adjIff = compIso (r1 .adjIff) (r2 .adjIff) } ∣₁)
+        (snd (g .right-adj)) (snd (f .right-adj))  }
+
+
+  -- equality of underlying monotone functions
+  -- gives us equality of records
+  eqMonAdj : {X Y : Poset ℓ ℓ'} → (f g : MonFunAdj X Y) →
+    f .morphism ≡ g .morphism →
+    fst (f .left-adj) ≡ fst (g .left-adj) →
+    fst (f .right-adj) ≡ fst (g . right-adj) →
+    f ≡ g
+  morphism (eqMonAdj f g fm≡gm fl≡gl fr≡gr i) = fm≡gm i
+  left-adj (eqMonAdj {X} {Y} f g fm≡gm fl≡gl fr≡gr i) =
+    (ΣPathPProp
+      {A = λ _ → MonFun Y X}
+      {B = λ i l → ∥ l ⊣ (fm≡gm i) ∥₁ }
+      {u = (f .left-adj)}
+      {v = (g .left-adj)}
+      (λ l → isPropPropTrunc )
+      fl≡gl
+    ) i
+  right-adj (eqMonAdj {X} {Y} f g fm≡gm fl≡gl fr≡gr i) =
+    (ΣPathPProp
+      {A = λ _ → MonFun Y X}
+      {B = λ i r → ∥ (fm≡gm i) ⊣ r ∥₁ }
+      {u = (f .right-adj)}
+      {v = (g .right-adj)}
+      (λ r → isPropPropTrunc )
+      fr≡gr
+    ) i
+
+  MonFunAdjIsSet : {X Y : Poset ℓ ℓ'} → isSet (MonFunAdj X Y)
+  MonFunAdjIsSet {X} {Y}  x y p q = w
+    where
+      w : _
+      morphism (w i j) = MonFunIsSet (x .morphism) (y .morphism)
+        ( cong morphism p) (cong morphism q) i j
+      left-adj (w i j) = isSet→SquareP
+        (λ i j → (isSetΣSndProp
+          (MonFunIsSet {X = Y} {Y = X})
+          (λ L → isPropPropTrunc {A = L ⊣ morphism (w i j)})))
+        (cong left-adj p) (cong left-adj q)
+        refl refl i j
+      right-adj (w i j) = isSet→SquareP
+        (λ i j → (isSetΣSndProp (MonFunIsSet {X = Y} {Y = X})
+          (λ R → isPropPropTrunc {A = morphism (w i j) ⊣ R})))
+        (cong right-adj p) (cong right-adj q)
+        refl refl i j


### PR DESCRIPTION
- Stole Eric's def'n of monotone functions and connected it to Cubical `Poset`. 
- Added notion of adjoint for monotone functions (same has HomBijection definition)
- Added `MonFunAdj` which is a monotone function with left and right adjoints
- Defined `POSET` and `POSETADJ`, categories with posets and monotone functions (w/ and w/o adjoints)
- Defined Hyperdoctrine from `Category` with `BinProds` to `POSETADJ` with Beck-Chevally Condition