### PR TITLE
Displayed Universal Properties

### DIFF
--- a/Cubical/Categories/Adjoint/UniversalElements.agda
+++ b/Cubical/Categories/Adjoint/UniversalElements.agda
@@ -3,9 +3,13 @@
 module Cubical.Categories.Adjoint.UniversalElements where
 
 open import Cubical.Foundations.Prelude
+open import Cubical.Foundations.Isomorphism
 open import Cubical.Categories.Category
 open import Cubical.Categories.Functor
 open import Cubical.Categories.Profunctor.General
+open import Cubical.Categories.Presheaf.More
+open import Cubical.Categories.Presheaf.Representable
+open import Cubical.Categories.Instances.Sets
 
 private
   variable
@@ -23,6 +27,35 @@ RightAdjointAt : (C : Category ℓC ℓC')
                  (F : Functor C D)
                  (d : D .ob) → Type _
 RightAdjointAt C D F = UniversalElementAt D C (Functor→Profo-* C D F)
+
+-- Uh Oh
+RightAdjointAt' : (C : Category ℓC ℓC')
+                  (D : Category ℓD ℓD')
+                  (F : Functor C D) (d : D .ob)
+                → Type _
+RightAdjointAt' C D F d  =
+  UniversalElement C ((D [-, d ]) ∘F (F ^opF))
+
+RightAdjointAt→Prime : (C : Category ℓC ℓC')
+                 (D : Category ℓD ℓD')
+                 (F : Functor C D)
+                 (d : D .ob)
+                 → RightAdjointAt C D F d → RightAdjointAt' C D F d
+RightAdjointAt→Prime C D F d x .UniversalElement.vertex = UniversalElement.vertex x
+RightAdjointAt→Prime C D F d x .UniversalElement.element = UniversalElement.element x
+RightAdjointAt→Prime C D F d x .UniversalElement.universal = UniversalElement.universal x
+
+RightAdjoint' : (C : Category ℓC ℓC')
+                (D : Category ℓD ℓD')
+                (F : Functor C D)
+              → Type _
+RightAdjoint' C D F = ∀ d → RightAdjointAt' C D F d
+
+IdRightAdj' : (C : Category ℓC ℓC')
+      → RightAdjoint' C C Id
+IdRightAdj' C c .UniversalElement.vertex = c
+IdRightAdj' C c .UniversalElement.element = id C
+IdRightAdj' C c .UniversalElement.universal c' = isoToIsEquiv (iso _ (λ z → z) (C .⋆IdR) (C .⋆IdR))
 
 LeftAdjoint : (C : Category ℓC ℓC')
               (D : Category ℓD ℓD')

--- a/Cubical/Categories/Adjoint/UniversalElements.agda
+++ b/Cubical/Categories/Adjoint/UniversalElements.agda
@@ -41,9 +41,12 @@ RightAdjointAt→Prime : (C : Category ℓC ℓC')
                  (F : Functor C D)
                  (d : D .ob)
                  → RightAdjointAt C D F d → RightAdjointAt' C D F d
-RightAdjointAt→Prime C D F d x .UniversalElement.vertex = UniversalElement.vertex x
-RightAdjointAt→Prime C D F d x .UniversalElement.element = UniversalElement.element x
-RightAdjointAt→Prime C D F d x .UniversalElement.universal = UniversalElement.universal x
+RightAdjointAt→Prime C D F d x .UniversalElement.vertex =
+  UniversalElement.vertex x
+RightAdjointAt→Prime C D F d x .UniversalElement.element =
+  UniversalElement.element x
+RightAdjointAt→Prime C D F d x .UniversalElement.universal =
+  UniversalElement.universal x
 
 RightAdjoint' : (C : Category ℓC ℓC')
                 (D : Category ℓD ℓD')
@@ -55,7 +58,8 @@ IdRightAdj' : (C : Category ℓC ℓC')
       → RightAdjoint' C C Id
 IdRightAdj' C c .UniversalElement.vertex = c
 IdRightAdj' C c .UniversalElement.element = id C
-IdRightAdj' C c .UniversalElement.universal c' = isoToIsEquiv (iso _ (λ z → z) (C .⋆IdR) (C .⋆IdR))
+IdRightAdj' C c .UniversalElement.universal c' =
+  isoToIsEquiv (iso _ (λ z → z) (C .⋆IdR) (C .⋆IdR))
 
 LeftAdjoint : (C : Category ℓC ℓC')
               (D : Category ℓD ℓD')

--- a/Cubical/Categories/Displayed/Adjoint/More.agda
+++ b/Cubical/Categories/Displayed/Adjoint/More.agda
@@ -1,0 +1,45 @@
+{-
+  Definition of an adjoint pair displayed over another adjoint pair
+-}
+{-# OPTIONS --safe #-}
+module Cubical.Categories.Displayed.Adjoint.More where
+
+open import Cubical.Foundations.Prelude
+open import Cubical.Categories.Category.Base
+open import Cubical.Categories.Functor.Base
+open import Cubical.Categories.Adjoint
+open import Cubical.Categories.Adjoint.UniversalElements
+open import Cubical.Categories.Displayed.Base
+open import Cubical.Categories.Displayed.Category.More
+open import Cubical.Categories.Displayed.Functor
+open import Cubical.Categories.Displayed.Instances.Sets
+open import Cubical.Categories.Instances.Sets
+open import Cubical.Categories.Displayed.Presheaf
+open import Cubical.Categories.Presheaf.Representable
+
+private
+  variable
+    ℓC ℓC' ℓCᴰ ℓCᴰ' ℓD ℓD' ℓDᴰ ℓDᴰ' : Level
+
+open Category
+open Categoryᴰ
+
+-- TODO: eventually reformulate in terms of profunctors
+RightAdjointAtᴰ : {C : Category ℓC ℓC'} {D : Category ℓD ℓD'}
+                  {F : Functor C D}
+                  {Cᴰ : Categoryᴰ C ℓCᴰ ℓCᴰ'} {Dᴰ : Categoryᴰ D ℓDᴰ ℓDᴰ'}
+                  (Fᴰ : Functorᴰ F Cᴰ Dᴰ) {d : D .ob} (dᴰ : Categoryᴰ.ob[_] Dᴰ d)
+                  (R⟅d⟆ : UniversalElement C ((D [-, d ]) ∘F (F ^opF)))
+                → Type (ℓ-max (ℓ-max (ℓ-max (ℓ-max ℓC ℓC') ℓCᴰ) ℓCᴰ') ℓDᴰ')
+RightAdjointAtᴰ {Cᴰ = Cᴰ}{Dᴰ = Dᴰ} Fᴰ dᴰ R⟅d⟆ =
+  UniversalElementᴰ Cᴰ ((Dᴰ [-][-, dᴰ ]) ∘Fᴰ (Fᴰ ^opFᴰ)) R⟅d⟆
+
+RightAdjointᴰ : {C : Category ℓC ℓC'} {D : Category ℓD ℓD'}
+                {F : Functor C D}
+                {Cᴰ : Categoryᴰ C ℓCᴰ ℓCᴰ'} {Dᴰ : Categoryᴰ D ℓDᴰ ℓDᴰ'}
+                (Fᴰ : Functorᴰ F Cᴰ Dᴰ)
+                (R : ∀ d → UniversalElement C ((D [-, d ]) ∘F (F ^opF)))
+              → Type (ℓ-max
+                        (ℓ-max (ℓ-max (ℓ-max (ℓ-max (ℓ-max ℓC ℓC') ℓD) ℓCᴰ) ℓCᴰ') ℓDᴰ)
+                        ℓDᴰ')
+RightAdjointᴰ Fᴰ R = ∀ {d} dᴰ → RightAdjointAtᴰ Fᴰ dᴰ (R d)

--- a/Cubical/Categories/Displayed/Adjoint/More.agda
+++ b/Cubical/Categories/Displayed/Adjoint/More.agda
@@ -41,9 +41,7 @@ RightAdjointᴰ : {C : Category ℓC ℓC'} {D : Category ℓD ℓD'}
                 {Cᴰ : Categoryᴰ C ℓCᴰ ℓCᴰ'} {Dᴰ : Categoryᴰ D ℓDᴰ ℓDᴰ'}
                 (Fᴰ : Functorᴰ F Cᴰ Dᴰ)
                 (R : RightAdjoint' C D F)
-              → Type (ℓ-max
-                        (ℓ-max (ℓ-max (ℓ-max (ℓ-max (ℓ-max ℓC ℓC') ℓD) ℓCᴰ) ℓCᴰ') ℓDᴰ)
-                        ℓDᴰ')
+              → Type _
 RightAdjointᴰ Fᴰ R = ∀ {d} dᴰ → RightAdjointAtᴰ Fᴰ (R d) dᴰ
 
 -- should this be called vertical instead?

--- a/Cubical/Categories/Displayed/Adjoint/More.agda
+++ b/Cubical/Categories/Displayed/Adjoint/More.agda
@@ -28,18 +28,35 @@ open Categoryᴰ
 RightAdjointAtᴰ : {C : Category ℓC ℓC'} {D : Category ℓD ℓD'}
                   {F : Functor C D}
                   {Cᴰ : Categoryᴰ C ℓCᴰ ℓCᴰ'} {Dᴰ : Categoryᴰ D ℓDᴰ ℓDᴰ'}
-                  (Fᴰ : Functorᴰ F Cᴰ Dᴰ) {d : D .ob} (dᴰ : Categoryᴰ.ob[_] Dᴰ d)
-                  (R⟅d⟆ : UniversalElement C ((D [-, d ]) ∘F (F ^opF)))
+                  (Fᴰ : Functorᴰ F Cᴰ Dᴰ)
+                  {d : D .ob}
+                  (R⟅d⟆ : RightAdjointAt' C D F d)
+                  (dᴰ : Categoryᴰ.ob[_] Dᴰ d)
                 → Type (ℓ-max (ℓ-max (ℓ-max (ℓ-max ℓC ℓC') ℓCᴰ) ℓCᴰ') ℓDᴰ')
-RightAdjointAtᴰ {Cᴰ = Cᴰ}{Dᴰ = Dᴰ} Fᴰ dᴰ R⟅d⟆ =
+RightAdjointAtᴰ {Cᴰ = Cᴰ}{Dᴰ = Dᴰ} Fᴰ R⟅d⟆ dᴰ =
   UniversalElementᴰ Cᴰ ((Dᴰ [-][-, dᴰ ]) ∘Fᴰ (Fᴰ ^opFᴰ)) R⟅d⟆
 
 RightAdjointᴰ : {C : Category ℓC ℓC'} {D : Category ℓD ℓD'}
                 {F : Functor C D}
                 {Cᴰ : Categoryᴰ C ℓCᴰ ℓCᴰ'} {Dᴰ : Categoryᴰ D ℓDᴰ ℓDᴰ'}
                 (Fᴰ : Functorᴰ F Cᴰ Dᴰ)
-                (R : ∀ d → UniversalElement C ((D [-, d ]) ∘F (F ^opF)))
+                (R : RightAdjoint' C D F)
               → Type (ℓ-max
                         (ℓ-max (ℓ-max (ℓ-max (ℓ-max (ℓ-max ℓC ℓC') ℓD) ℓCᴰ) ℓCᴰ') ℓDᴰ)
                         ℓDᴰ')
-RightAdjointᴰ Fᴰ R = ∀ {d} dᴰ → RightAdjointAtᴰ Fᴰ dᴰ (R d)
+RightAdjointᴰ Fᴰ R = ∀ {d} dᴰ → RightAdjointAtᴰ Fᴰ (R d) dᴰ
+
+-- should this be called vertical instead?
+LocalRightAdjointAtᴰ : {C : Category ℓC ℓC'}
+                     {Cᴰ : Categoryᴰ C ℓCᴰ ℓCᴰ'} {Dᴰ : Categoryᴰ C ℓDᴰ ℓDᴰ'}
+                     (Fᴰ : Functorᴰ Id Cᴰ Dᴰ)
+                     {c : C .ob}
+                     (cᴰ : Categoryᴰ.ob[_] Dᴰ c)
+                     → Type _
+LocalRightAdjointAtᴰ Fᴰ = RightAdjointAtᴰ Fᴰ (IdRightAdj' _ _)
+
+LocalRightAdjointᴰ : {C : Category ℓC ℓC'}
+                     {Cᴰ : Categoryᴰ C ℓCᴰ ℓCᴰ'} {Dᴰ : Categoryᴰ C ℓDᴰ ℓDᴰ'}
+                     (Fᴰ : Functorᴰ Id Cᴰ Dᴰ)
+                   → Type _
+LocalRightAdjointᴰ Fᴰ = RightAdjointᴰ Fᴰ (IdRightAdj' _)

--- a/Cubical/Categories/Displayed/Adjoint/More.agda
+++ b/Cubical/Categories/Displayed/Adjoint/More.agda
@@ -10,7 +10,7 @@ open import Cubical.Categories.Functor.Base
 open import Cubical.Categories.Adjoint
 open import Cubical.Categories.Adjoint.UniversalElements
 open import Cubical.Categories.Displayed.Base
-open import Cubical.Categories.Displayed.Category.More
+open import Cubical.Categories.Displayed.Base.More
 open import Cubical.Categories.Displayed.Functor
 open import Cubical.Categories.Displayed.Instances.Sets
 open import Cubical.Categories.Instances.Sets

--- a/Cubical/Categories/Displayed/Base/More.agda
+++ b/Cubical/Categories/Displayed/Base/More.agda
@@ -9,10 +9,11 @@ open import Cubical.Categories.Category.Base
 open import Cubical.Categories.Functor
 
 open import Cubical.Categories.Displayed.Base
+open import Cubical.Categories.Displayed.Functor
 
 private
   variable
-    ℓC ℓC' ℓCᴰ ℓCᴰ' : Level
+    ℓC ℓC' ℓCᴰ ℓCᴰ' ℓD ℓD' ℓDᴰ ℓDᴰ' : Level
 
 module _ {C : Category ℓC ℓC'} {Cᴰ : Categoryᴰ C ℓCᴰ ℓCᴰ'} where
   open Functor
@@ -26,14 +27,37 @@ module _ {C : Category ℓC ℓC'} {Cᴰ : Categoryᴰ C ℓCᴰ ℓCᴰ'} where
 
 module _ {C : Category ℓC ℓC'} (Cᴰ : Categoryᴰ C ℓCᴰ ℓCᴰ') where
   open Category
-  open Categoryᴰ Cᴰ
+  private
+    module Cᴰ = Categoryᴰ Cᴰ
 
   base-path-irr : ∀ {x y xᴰ yᴰ} {f g : C [ x , y ]}
-                → {fᴰ : Hom[ f ][ xᴰ , yᴰ ]}
+                → {fᴰ : Cᴰ.Hom[ f ][ xᴰ , yᴰ ]}
                 → {p : f ≡ g}
-                → {gᴰ : Hom[ g ][ xᴰ , yᴰ ]}
+                → {gᴰ : Cᴰ.Hom[ g ][ xᴰ , yᴰ ]}
                 → {q : f ≡ g}
-                → fᴰ ≡[ p ] gᴰ
-                → fᴰ ≡[ q ] gᴰ
+                → fᴰ Cᴰ.≡[ p ] gᴰ
+                → fᴰ Cᴰ.≡[ q ] gᴰ
   base-path-irr {fᴰ = fᴰ}{p}{gᴰ}{q} = transport λ i →
-    fᴰ ≡[ C .isSetHom _ _ p q i ] gᴰ
+    fᴰ Cᴰ.≡[ C .isSetHom _ _ p q i ] gᴰ
+
+  open Categoryᴰ
+  _^opᴰ : Categoryᴰ (C ^op) ℓCᴰ ℓCᴰ'
+  _^opᴰ .ob[_] x = Cᴰ.ob[ x ]
+  _^opᴰ .Hom[_][_,_] f xᴰ yᴰ = Cᴰ.Hom[ f ][ yᴰ , xᴰ ]
+  _^opᴰ .idᴰ = Cᴰ.idᴰ
+  _^opᴰ ._⋆ᴰ_ fᴰ gᴰ = gᴰ Cᴰ.⋆ᴰ fᴰ
+  _^opᴰ .⋆IdLᴰ = Cᴰ .⋆IdRᴰ
+  _^opᴰ .⋆IdRᴰ = Cᴰ .⋆IdLᴰ
+  _^opᴰ .⋆Assocᴰ fᴰ gᴰ hᴰ = symP (Cᴰ.⋆Assocᴰ _ _ _)
+  _^opᴰ .isSetHomᴰ = Cᴰ .isSetHomᴰ
+
+module _ {C : Category ℓC ℓC'} {D : Category ℓD ℓD'}
+  {F : Functor C D} {Cᴰ : Categoryᴰ C ℓCᴰ ℓCᴰ'} {Dᴰ : Categoryᴰ D ℓDᴰ ℓDᴰ'}
+  (Fᴰ : Functorᴰ F Cᴰ Dᴰ)
+  where
+  open Functorᴰ
+  _^opFᴰ : Functorᴰ (F ^opF) (Cᴰ ^opᴰ) (Dᴰ ^opᴰ)
+  _^opFᴰ .F-obᴰ = Fᴰ .F-obᴰ
+  _^opFᴰ .F-homᴰ = Fᴰ .F-homᴰ
+  _^opFᴰ .F-idᴰ = Fᴰ .F-idᴰ
+  _^opFᴰ .F-seqᴰ fᴰ gᴰ = Fᴰ .F-seqᴰ gᴰ fᴰ

--- a/Cubical/Categories/Displayed/Constructions/BinProduct/More.agda
+++ b/Cubical/Categories/Displayed/Constructions/BinProduct/More.agda
@@ -1,0 +1,36 @@
+{-# OPTIONS --safe #-}
+module Cubical.Categories.Displayed.Constructions.BinProduct.More where
+
+open import Cubical.Foundations.Prelude
+open import Cubical.Foundations.HLevels
+open import Cubical.Data.Sigma
+open import Cubical.Categories.Category.Base
+open import Cubical.Categories.Functor.Base
+open import Cubical.Categories.Constructions.BinProduct
+open import Cubical.Categories.Constructions.BinProduct.More
+open import Cubical.Categories.Displayed.Base
+open import Cubical.Categories.Displayed.Functor
+open import Cubical.Categories.Displayed.BinProduct
+
+private
+  variable
+    ℓC ℓC' ℓD ℓD' : Level
+
+module _ {C : Category ℓC ℓC'} (D : Categoryᴰ C ℓD ℓD')
+  where
+
+  open Functorᴰ
+  private
+    module D = Categoryᴰ D
+
+  ΔCᴰ : Functorᴰ (Δ C) D (D ×Cᴰ D)
+  ΔCᴰ .F-obᴰ xᴰ = xᴰ , xᴰ
+  ΔCᴰ .F-homᴰ fᴰ = fᴰ , fᴰ
+  ΔCᴰ .F-idᴰ = refl
+  ΔCᴰ .F-seqᴰ fᴰ gᴰ = refl
+
+  Δᴰ : Functorᴰ Id D (D ×ᴰ D)
+  Δᴰ .F-obᴰ xᴰ = xᴰ , xᴰ
+  Δᴰ .F-homᴰ fᴰ = fᴰ , fᴰ
+  Δᴰ .F-idᴰ = refl
+  Δᴰ .F-seqᴰ fᴰ gᴰ = refl

--- a/Cubical/Categories/Displayed/Constructions/Slice.agda
+++ b/Cubical/Categories/Displayed/Constructions/Slice.agda
@@ -11,7 +11,6 @@ open import Cubical.Categories.Category.Base
 open import Cubical.Categories.Functor.Base
 open import Cubical.Categories.Displayed.Base
 open import Cubical.Categories.Displayed.Base.More
-open import Cubical.Categories.Displayed.Category.More
 open import Cubical.Categories.Displayed.Functor
 
 open import Cubical.Tactics.CategorySolver.Reflection

--- a/Cubical/Categories/Displayed/Constructions/Slice.agda
+++ b/Cubical/Categories/Displayed/Constructions/Slice.agda
@@ -1,0 +1,55 @@
+{-
+  Definition of an adjoint pair displayed over another adjoint pair
+-}
+{-# OPTIONS --safe #-}
+module Cubical.Categories.Displayed.Constructions.Slice where
+
+open import Cubical.Foundations.Prelude
+open import Cubical.Foundations.HLevels
+open import Cubical.Data.Sigma
+open import Cubical.Categories.Category.Base
+open import Cubical.Categories.Functor.Base
+open import Cubical.Categories.Displayed.Base
+open import Cubical.Categories.Displayed.Base.More
+open import Cubical.Categories.Displayed.Category.More
+open import Cubical.Categories.Displayed.Functor
+
+open import Cubical.Tactics.CategorySolver.Reflection
+open import Cubical.Tactics.FunctorSolver.Reflection
+
+private
+  variable
+    ℓC ℓC' ℓCᴰ ℓCᴰ' ℓD ℓD' ℓDᴰ ℓDᴰ' : Level
+
+open Category
+open Categoryᴰ
+open Functor
+
+module _ (C : Category ℓC ℓC') {D : Category ℓD ℓD'} (p : Functor D C) where
+  -- The slice category over a functor, viewed as a displayed category
+  -- over the domain
+  _/C_ : Categoryᴰ C (ℓ-max ℓC' ℓD) (ℓ-max ℓC' ℓD')
+  _/C_ .ob[_] x = Σ[ d ∈ D .ob ] (C [ x , p ⟅ d ⟆ ])
+  _/C_ .Hom[_][_,_] f xᴰ yᴰ = Σ[ g ∈ D [ xᴰ .fst , yᴰ .fst ] ]
+    p ⟪ g ⟫ ∘⟨ C ⟩ xᴰ .snd ≡ yᴰ .snd ∘⟨ C ⟩ f 
+  _/C_ .idᴰ = (D .id) , solveFunctor! D C p 
+  _/C_ ._⋆ᴰ_ fᴰ gᴰ = (fᴰ .fst ⋆⟨ D ⟩ gᴰ .fst) ,
+    cong₂ (comp' C) (p .F-seq _ _) refl
+    ∙ sym (C .⋆Assoc _ _ _)
+    ∙ cong₂ (comp' C) refl (fᴰ .snd)
+    ∙ C .⋆Assoc _ _ _
+    ∙ cong₂ (comp' C) (gᴰ .snd) refl
+    ∙ sym (C .⋆Assoc _ _ _)
+  _/C_ .⋆IdLᴰ fᴰ = ΣPathPProp (λ _ → C .isSetHom _ _) (D .⋆IdL _)
+  _/C_ .⋆IdRᴰ fᴰ = ΣPathPProp (λ _ → C .isSetHom _ _) (D .⋆IdR _)
+  _/C_ .⋆Assocᴰ fᴰ gᴰ hᴰ = ΣPathPProp (λ _ → C .isSetHom _ _) (D .⋆Assoc _ _ _)
+  _/C_ .isSetHomᴰ =
+    isSetΣ (D .isSetHom) (λ _ → isProp→isSet (C .isSetHom _ _))
+
+module _ {C : Category ℓC ℓC'} (D : Categoryᴰ C ℓD ℓD') where
+  open Functorᴰ
+  cod : Functorᴰ Id D (C /C (Fst {Cᴰ = D}))
+  cod .F-obᴰ x = (_ , x) , C .id
+  cod .F-homᴰ fᴰ = (_ , fᴰ) , solveCat! C
+  cod .F-idᴰ = ΣPathPProp (λ _ → C .isSetHom _ _) refl
+  cod .F-seqᴰ fᴰ gᴰ = ΣPathPProp (λ _ → C .isSetHom _ _) refl

--- a/Cubical/Categories/Displayed/Constructions/Slice.agda
+++ b/Cubical/Categories/Displayed/Constructions/Slice.agda
@@ -1,5 +1,6 @@
 {-
-  Definition of an adjoint pair displayed over another adjoint pair
+  The slice category over a functor, viewed as a displayed category
+  over the domain.
 -}
 {-# OPTIONS --safe #-}
 module Cubical.Categories.Displayed.Constructions.Slice where
@@ -25,8 +26,6 @@ open Categoryᴰ
 open Functor
 
 module _ (C : Category ℓC ℓC') {D : Category ℓD ℓD'} (p : Functor D C) where
-  -- The slice category over a functor, viewed as a displayed category
-  -- over the domain
   _/C_ : Categoryᴰ C (ℓ-max ℓC' ℓD) (ℓ-max ℓC' ℓD')
   _/C_ .ob[_] x = Σ[ d ∈ D .ob ] (C [ x , p ⟅ d ⟆ ])
   _/C_ .Hom[_][_,_] f xᴰ yᴰ = Σ[ g ∈ D [ xᴰ .fst , yᴰ .fst ] ]

--- a/Cubical/Categories/Displayed/Constructions/Slice.agda
+++ b/Cubical/Categories/Displayed/Constructions/Slice.agda
@@ -29,8 +29,8 @@ module _ (C : Category ℓC ℓC') {D : Category ℓD ℓD'} (p : Functor D C) w
   _/C_ : Categoryᴰ C (ℓ-max ℓC' ℓD) (ℓ-max ℓC' ℓD')
   _/C_ .ob[_] x = Σ[ d ∈ D .ob ] (C [ x , p ⟅ d ⟆ ])
   _/C_ .Hom[_][_,_] f xᴰ yᴰ = Σ[ g ∈ D [ xᴰ .fst , yᴰ .fst ] ]
-    p ⟪ g ⟫ ∘⟨ C ⟩ xᴰ .snd ≡ yᴰ .snd ∘⟨ C ⟩ f 
-  _/C_ .idᴰ = (D .id) , solveFunctor! D C p 
+    p ⟪ g ⟫ ∘⟨ C ⟩ xᴰ .snd ≡ yᴰ .snd ∘⟨ C ⟩ f
+  _/C_ .idᴰ = (D .id) , solveFunctor! D C p
   _/C_ ._⋆ᴰ_ fᴰ gᴰ = (fᴰ .fst ⋆⟨ D ⟩ gᴰ .fst) ,
     cong₂ (comp' C) (p .F-seq _ _) refl
     ∙ sym (C .⋆Assoc _ _ _)

--- a/Cubical/Categories/Displayed/Fibration.agda
+++ b/Cubical/Categories/Displayed/Fibration.agda
@@ -1,0 +1,24 @@
+{-# OPTIONS --safe #-}
+module Cubical.Categories.Displayed.Fibration where
+
+open import Cubical.Foundations.Prelude
+
+open import Cubical.Categories.Category.Base
+open import Cubical.Categories.Adjoint.UniversalElements
+open import Cubical.Categories.Displayed.Base
+open import Cubical.Categories.Displayed.Base.More
+open import Cubical.Categories.Displayed.Adjoint.More
+open import Cubical.Categories.Displayed.Constructions.Slice
+
+private
+  variable
+    ℓC ℓC' ℓCᴰ ℓCᴰ' ℓD ℓD' ℓDᴰ ℓDᴰ' : Level
+
+open Category
+
+module _ {C : Category ℓC ℓC'} (D : Categoryᴰ C ℓD ℓD') where
+  CartesianLift : (∫C (C /C (Fst {Cᴰ = D}))) .ob → Type _
+  CartesianLift (c , (d , f)) = LocalRightAdjointAtᴰ (cod D) (d , f)
+
+  isFibration : Type _
+  isFibration = LocalRightAdjointᴰ (cod D)

--- a/Cubical/Categories/Displayed/Instances/Sets.agda
+++ b/Cubical/Categories/Displayed/Instances/Sets.agda
@@ -11,7 +11,7 @@ open import Cubical.Data.Sigma
 open import Cubical.Categories.Category
 open import Cubical.Categories.Instances.Sets
 open import Cubical.Categories.Displayed.Base
-open import Cubical.Categories.Displayed.Category.More
+open import Cubical.Categories.Displayed.Base.More
 open import Cubical.Categories.Displayed.Functor
 
 private

--- a/Cubical/Categories/Displayed/Instances/Sets.agda
+++ b/Cubical/Categories/Displayed/Instances/Sets.agda
@@ -1,0 +1,55 @@
+{-# OPTIONS --safe #-}
+module Cubical.Categories.Displayed.Instances.Sets where
+
+open import Cubical.Foundations.Prelude
+open import Cubical.Foundations.Function
+open import Cubical.Foundations.HLevels
+open import Cubical.Foundations.Equiv
+open import Cubical.Foundations.Structure
+open import Cubical.Data.Sigma
+
+open import Cubical.Categories.Category
+open import Cubical.Categories.Instances.Sets
+open import Cubical.Categories.Displayed.Base
+open import Cubical.Categories.Displayed.Category.More
+open import Cubical.Categories.Displayed.Functor
+
+private
+  variable
+    ℓ ℓ' ℓ'' ℓ''' : Level
+    ℓC ℓC' ℓD ℓD' : Level
+
+module _ ℓ ℓ' where
+  open Categoryᴰ
+  SETS : Categoryᴰ (SET ℓ) (ℓ-max ℓ (ℓ-suc ℓ')) (ℓ-max ℓ ℓ')
+  SETS .ob[_] X = ⟨ X ⟩ → hSet ℓ'
+  SETS .Hom[_][_,_] f P Q = ∀ x → ⟨ P x ⟩ → ⟨ Q (f x) ⟩
+  SETS .idᴰ = λ x z → z
+  SETS ._⋆ᴰ_ {f = f} {g} fᴰ gᴰ x p = gᴰ (f x) (fᴰ x p)
+  SETS .⋆IdLᴰ fᴰ = refl
+  SETS .⋆IdRᴰ fᴰ = refl
+  SETS .⋆Assocᴰ fᴰ gᴰ hᴰ = refl
+  SETS .isSetHomᴰ {yᴰ = Q} = isSetΠ λ x → isSetΠ λ xᴰ → Q _ .snd
+
+open Category
+open Functorᴰ
+-- Displayed representable
+_[-][-,_] : {C : Category ℓC ℓC'} (D : Categoryᴰ C ℓD ℓD')
+          → {c : C .ob}
+          → Categoryᴰ.ob[_] D c
+          → Functorᴰ (C [-, c ]) (D ^opᴰ) (SETS ℓC' ℓD')
+_[-][-,_] {C = C} D {c} d .F-obᴰ d' f =
+  (D [ f ][ d' , d ]) , Categoryᴰ.isSetHomᴰ D
+_[-][-,_] {C = C} D {c} d .F-homᴰ fᴰ g gᴰ = Categoryᴰ._⋆ᴰ_ D fᴰ gᴰ
+_[-][-,_] {C = C} D {c} d .F-idᴰ i g gᴰ = Categoryᴰ.⋆IdLᴰ D gᴰ i
+_[-][-,_] {C = C} D {c} d .F-seqᴰ fᴰ gᴰ i h hᴰ = Categoryᴰ.⋆Assocᴰ D gᴰ fᴰ hᴰ i
+
+-- Displayed representable
+_[-][_,-] : {C : Category ℓC ℓC'} (D : Categoryᴰ C ℓD ℓD')
+          → {c : C .ob}
+          → Categoryᴰ.ob[_] D c
+          → Functorᴰ (C [ c ,-]) D (SETS ℓC' ℓD')
+(D [-][ d ,-]) .F-obᴰ d' f = (D [ f ][ d , d' ]) , Categoryᴰ.isSetHomᴰ D
+(D [-][ d ,-]) .F-homᴰ fᴰ g gᴰ = Categoryᴰ._⋆ᴰ_ D gᴰ fᴰ
+(D [-][ d ,-]) .F-idᴰ i f fᴰ = Categoryᴰ.⋆IdRᴰ D fᴰ i
+(D [-][ d ,-]) .F-seqᴰ fᴰ gᴰ i h hᴰ = Categoryᴰ.⋆Assocᴰ D hᴰ fᴰ gᴰ (~ i)

--- a/Cubical/Categories/Displayed/Instances/Sets.agda
+++ b/Cubical/Categories/Displayed/Instances/Sets.agda
@@ -21,15 +21,15 @@ private
 
 module _ ℓ ℓ' where
   open Categoryᴰ
-  SETS : Categoryᴰ (SET ℓ) (ℓ-max ℓ (ℓ-suc ℓ')) (ℓ-max ℓ ℓ')
-  SETS .ob[_] X = ⟨ X ⟩ → hSet ℓ'
-  SETS .Hom[_][_,_] f P Q = ∀ x → ⟨ P x ⟩ → ⟨ Q (f x) ⟩
-  SETS .idᴰ = λ x z → z
-  SETS ._⋆ᴰ_ {f = f} {g} fᴰ gᴰ x p = gᴰ (f x) (fᴰ x p)
-  SETS .⋆IdLᴰ fᴰ = refl
-  SETS .⋆IdRᴰ fᴰ = refl
-  SETS .⋆Assocᴰ fᴰ gᴰ hᴰ = refl
-  SETS .isSetHomᴰ {yᴰ = Q} = isSetΠ λ x → isSetΠ λ xᴰ → Q _ .snd
+  SETᴰ : Categoryᴰ (SET ℓ) (ℓ-max ℓ (ℓ-suc ℓ')) (ℓ-max ℓ ℓ')
+  SETᴰ .ob[_] X = ⟨ X ⟩ → hSet ℓ'
+  SETᴰ .Hom[_][_,_] f P Q = ∀ x → ⟨ P x ⟩ → ⟨ Q (f x) ⟩
+  SETᴰ .idᴰ = λ x z → z
+  SETᴰ ._⋆ᴰ_ {f = f} {g} fᴰ gᴰ x p = gᴰ (f x) (fᴰ x p)
+  SETᴰ .⋆IdLᴰ fᴰ = refl
+  SETᴰ .⋆IdRᴰ fᴰ = refl
+  SETᴰ .⋆Assocᴰ fᴰ gᴰ hᴰ = refl
+  SETᴰ .isSetHomᴰ {yᴰ = Q} = isSetΠ λ x → isSetΠ λ xᴰ → Q _ .snd
 
 open Category
 open Functorᴰ
@@ -37,7 +37,7 @@ open Functorᴰ
 _[-][-,_] : {C : Category ℓC ℓC'} (D : Categoryᴰ C ℓD ℓD')
           → {c : C .ob}
           → Categoryᴰ.ob[_] D c
-          → Functorᴰ (C [-, c ]) (D ^opᴰ) (SETS ℓC' ℓD')
+          → Functorᴰ (C [-, c ]) (D ^opᴰ) (SETᴰ ℓC' ℓD')
 _[-][-,_] {C = C} D {c} d .F-obᴰ d' f =
   (D [ f ][ d' , d ]) , Categoryᴰ.isSetHomᴰ D
 _[-][-,_] {C = C} D {c} d .F-homᴰ fᴰ g gᴰ = Categoryᴰ._⋆ᴰ_ D fᴰ gᴰ
@@ -48,7 +48,7 @@ _[-][-,_] {C = C} D {c} d .F-seqᴰ fᴰ gᴰ i h hᴰ = Categoryᴰ.⋆Assocᴰ
 _[-][_,-] : {C : Category ℓC ℓC'} (D : Categoryᴰ C ℓD ℓD')
           → {c : C .ob}
           → Categoryᴰ.ob[_] D c
-          → Functorᴰ (C [ c ,-]) D (SETS ℓC' ℓD')
+          → Functorᴰ (C [ c ,-]) D (SETᴰ ℓC' ℓD')
 (D [-][ d ,-]) .F-obᴰ d' f = (D [ f ][ d , d' ]) , Categoryᴰ.isSetHomᴰ D
 (D [-][ d ,-]) .F-homᴰ fᴰ g gᴰ = Categoryᴰ._⋆ᴰ_ D gᴰ fᴰ
 (D [-][ d ,-]) .F-idᴰ i f fᴰ = Categoryᴰ.⋆IdRᴰ D fᴰ i

--- a/Cubical/Categories/Displayed/Instances/Terminal.agda
+++ b/Cubical/Categories/Displayed/Instances/Terminal.agda
@@ -1,0 +1,31 @@
+{-# OPTIONS --safe #-}
+module Cubical.Categories.Displayed.Instances.Terminal where
+
+open import Cubical.Foundations.Prelude
+open import Cubical.Foundations.HLevels
+open import Cubical.Data.Sigma
+open import Cubical.Data.Unit
+open import Cubical.Categories.Category.Base
+open import Cubical.Categories.Instances.Terminal
+open import Cubical.Categories.Displayed.Base
+
+private
+  variable
+    ℓC ℓC' ℓD ℓD' : Level
+
+open Category
+open Categoryᴰ
+-- Terminal category over a base category
+Unitᴰ : (C : Category ℓC ℓC') → Categoryᴰ C ℓ-zero ℓ-zero
+Unitᴰ C .ob[_] x = Unit
+Unitᴰ C .Hom[_][_,_] f tt tt = Unit
+Unitᴰ C .idᴰ = tt
+Unitᴰ C ._⋆ᴰ_ = λ _ _ → tt
+Unitᴰ C .⋆IdLᴰ fᴰ i = tt
+Unitᴰ C .⋆IdRᴰ fᴰ i = tt
+Unitᴰ C .⋆Assocᴰ fᴰ gᴰ hᴰ i = tt
+Unitᴰ C .isSetHomᴰ x y x₁ y₁ i i₁ = tt
+
+-- Terminal category over the terminal category
+UnitCᴰ : Categoryᴰ UnitC ℓ-zero ℓ-zero
+UnitCᴰ = Unitᴰ UnitC

--- a/Cubical/Categories/Displayed/Limits/BinProduct.agda
+++ b/Cubical/Categories/Displayed/Limits/BinProduct.agda
@@ -1,0 +1,34 @@
+{-# OPTIONS --safe #-}
+module Cubical.Categories.Displayed.Limits.BinProduct where
+
+open import Cubical.Foundations.Prelude
+open import Cubical.Data.Sigma
+
+open import Cubical.Categories.Category.Base
+open import Cubical.Categories.Adjoint.UniversalElements
+open import Cubical.Categories.Limits.BinProduct.More
+open import Cubical.Categories.Displayed.Base
+open import Cubical.Categories.Displayed.Base.More
+open import Cubical.Categories.Displayed.Adjoint.More
+open import Cubical.Categories.Displayed.Constructions.Slice
+open import Cubical.Categories.Displayed.Constructions.BinProduct.More
+
+private
+  variable
+    ℓC ℓC' ℓCᴰ ℓCᴰ' ℓD ℓD' ℓDᴰ ℓDᴰ' : Level
+
+open Category
+
+module _ {C : Category ℓC ℓC'} (D : Categoryᴰ C ℓD ℓD') where
+  module D = Categoryᴰ D
+  BinProductᴰ : ∀ {c12} → BinProduct' C c12 → (D.ob[ c12 .fst ] × D.ob[ c12 .snd ]) → Type _
+  BinProductᴰ = RightAdjointAtᴰ (ΔCᴰ D)
+
+  BinProductsᴰ : BinProducts' C → Type _
+  BinProductsᴰ = RightAdjointᴰ (ΔCᴰ D)
+
+  FibBinProductsAtᴰ : ∀ {c} → (D.ob[ c ] × D.ob[ c ]) → Type _
+  FibBinProductsAtᴰ = LocalRightAdjointAtᴰ (Δᴰ D)
+
+  FibBinProductsᴰ : Type _
+  FibBinProductsᴰ = LocalRightAdjointᴰ (Δᴰ D)

--- a/Cubical/Categories/Displayed/Limits/BinProduct.agda
+++ b/Cubical/Categories/Displayed/Limits/BinProduct.agda
@@ -21,7 +21,9 @@ open Category
 
 module _ {C : Category ℓC ℓC'} (D : Categoryᴰ C ℓD ℓD') where
   module D = Categoryᴰ D
-  BinProductᴰ : ∀ {c12} → BinProduct' C c12 → (D.ob[ c12 .fst ] × D.ob[ c12 .snd ]) → Type _
+  BinProductᴰ : ∀ {c12} → BinProduct' C c12
+              → (D.ob[ c12 .fst ] × D.ob[ c12 .snd ])
+              → Type _
   BinProductᴰ = RightAdjointAtᴰ (ΔCᴰ D)
 
   BinProductsᴰ : BinProducts' C → Type _

--- a/Cubical/Categories/Displayed/Limits/Terminal.agda
+++ b/Cubical/Categories/Displayed/Limits/Terminal.agda
@@ -50,9 +50,9 @@ module _ {C : Category ℓC ℓC'} (D : Categoryᴰ C ℓD ℓD') where
   module _ (c : C .ob) where
     -- Terminal object of the fiber of a fixed object
 
-    -- TODO:
-    -- Is this equivalent to the more "obvious" definition that Fiber
-    -- c have a terminal object?
+    -- TODO: Is this equivalent to the more "obvious" definition that
+    -- Fiber c have a terminal object?
+    -- No.
     FibTerminalᴰSpec : Presheafᴰ D (C [-, c ]) ℓ-zero
     FibTerminalᴰSpec = TerminalPresheafᴰ _
 

--- a/Cubical/Categories/Displayed/Limits/Terminal.agda
+++ b/Cubical/Categories/Displayed/Limits/Terminal.agda
@@ -1,0 +1,71 @@
+{-# OPTIONS --safe #-}
+module Cubical.Categories.Displayed.Limits.Terminal where
+
+open import Cubical.Foundations.Prelude
+open import Cubical.Foundations.Function
+open import Cubical.Foundations.HLevels
+open import Cubical.Foundations.Equiv
+
+open import Cubical.Data.Sigma
+open import Cubical.Data.Unit
+
+open import Cubical.Categories.Category
+open import Cubical.Categories.Presheaf
+open import Cubical.Categories.Instances.Sets
+open import Cubical.Categories.Displayed.Base
+open import Cubical.Categories.Displayed.Presheaf
+open import Cubical.Categories.Displayed.Functor
+open import Cubical.Categories.Limits.Terminal
+open import Cubical.Categories.Limits.Terminal.More
+open import Cubical.Categories.Presheaf.More
+
+-- There are multiple definitions of terminal object in a displayed category:
+-- 1. A terminal object in the total category, which is preserved by projection
+-- 2. A terminal object in the *fiber* of an object
+
+private
+  variable
+    ℓC ℓC' ℓD ℓD' ℓP : Level
+
+open Category
+open Categoryᴰ
+open Functorᴰ
+
+module _ {C : Category ℓC ℓC'} (D : Categoryᴰ C ℓD ℓD') where
+  module D = Categoryᴰ D
+  TerminalPresheafᴰ : (P : Presheaf C ℓP) → Presheafᴰ D P ℓ-zero
+  TerminalPresheafᴰ P .F-obᴰ x x₁ = Unit , isSetUnit
+  TerminalPresheafᴰ P .F-homᴰ = λ _ x _ → tt
+  TerminalPresheafᴰ P .F-idᴰ i = λ x x₁ → tt
+  TerminalPresheafᴰ P .F-seqᴰ fᴰ gᴰ i = λ x _ → tt
+
+  -- Terminal object over a terminal object
+  -- TODO: refactor using Constant Functorᴰ eventually
+  TerminalᴰSpec : Presheafᴰ D (TerminalPresheaf {C = C}) ℓ-zero
+  TerminalᴰSpec = TerminalPresheafᴰ _
+
+  Terminalᴰ : (term : Terminal' C) → Type (ℓ-max (ℓ-max (ℓ-max ℓC ℓC') ℓD) ℓD')
+  Terminalᴰ term = UniversalElementᴰ _ TerminalᴰSpec term
+
+  module _ (c : C .ob) where
+    -- Terminal object of the fiber of a fixed object
+
+    -- TODO:
+    -- Is this equivalent to the more "obvious" definition that Fiber
+    -- c have a terminal object?
+    FibTerminalᴰSpec : Presheafᴰ D (C [-, c ]) ℓ-zero
+    FibTerminalᴰSpec = TerminalPresheafᴰ _
+
+    -- This says that for every morphism f : c' → c in C and
+    -- d ∈ D.ob[ c' ] there is a unique lift to fᴰ : D [ f ][ d' , 1c ]
+    -- In program logic terms this is the "trivial postcondition"
+    FibTerminalᴰ : Type (ℓ-max (ℓ-max (ℓ-max ℓC ℓC') ℓD) ℓD')
+    FibTerminalᴰ = UniversalElementᴰ D FibTerminalᴰSpec (selfUnivElt C c)
+
+    module FibTerminalᴰNotation (fibTermᴰ : FibTerminalᴰ) where
+      open UniversalElementᴰ
+      1ᴰ : D.ob[ c ]
+      1ᴰ = fibTermᴰ .vertexᴰ
+
+      !tᴰ : ∀ {c'}(f : C [ c' , c ]) (d' : D.ob[ c' ]) → D [ f ][ d' , 1ᴰ ]
+      !tᴰ f d' = invIsEq (fibTermᴰ .universalᴰ) tt

--- a/Cubical/Categories/Displayed/Presheaf.agda
+++ b/Cubical/Categories/Displayed/Presheaf.agda
@@ -15,7 +15,7 @@ open import Cubical.Categories.Presheaf
 open import Cubical.Categories.Presheaf.Representable
 open import Cubical.Categories.Functor
 open import Cubical.Categories.Displayed.Base
-open import Cubical.Categories.Displayed.Category.More
+open import Cubical.Categories.Displayed.Base.More
 open import Cubical.Categories.Displayed.Instances.Sets
 open import Cubical.Categories.Displayed.Functor
 

--- a/Cubical/Categories/Displayed/Presheaf.agda
+++ b/Cubical/Categories/Displayed/Presheaf.agda
@@ -33,7 +33,7 @@ Presheafᴰ : {C : Category ℓC ℓC'} (D : Categoryᴰ C ℓD ℓD')
           → (P : Presheaf C ℓP) → (ℓP' : Level)
           → Type (ℓ-max (ℓ-max (ℓ-max (ℓ-max (ℓ-max ℓC ℓC') ℓD) ℓD') (ℓ-suc ℓP))
                     (ℓ-suc ℓP'))
-Presheafᴰ {ℓP = ℓP} D P ℓP' = Functorᴰ P (D ^opᴰ) (SETS ℓP ℓP')
+Presheafᴰ {ℓP = ℓP} D P ℓP' = Functorᴰ P (D ^opᴰ) (SETᴰ ℓP ℓP')
 
 module _ {C : Category ℓC ℓC'} (D : Categoryᴰ C ℓD ℓD')
          {P : Presheaf C ℓP} (Pᴰ : Presheafᴰ D P ℓP') where

--- a/Cubical/Categories/Displayed/Presheaf.agda
+++ b/Cubical/Categories/Displayed/Presheaf.agda
@@ -1,0 +1,52 @@
+{-# OPTIONS --safe #-}
+module Cubical.Categories.Displayed.Presheaf where
+
+open import Cubical.Foundations.Prelude
+open import Cubical.Foundations.Equiv
+open import Cubical.Foundations.Isomorphism
+open import Cubical.Foundations.HLevels
+open import Cubical.Foundations.Structure
+
+open import Cubical.Data.Sigma
+
+open import Cubical.Categories.Category
+open import Cubical.Categories.Instances.Sets
+open import Cubical.Categories.Presheaf
+open import Cubical.Categories.Presheaf.Representable
+open import Cubical.Categories.Functor
+open import Cubical.Categories.Displayed.Base
+open import Cubical.Categories.Displayed.Category.More
+open import Cubical.Categories.Displayed.Instances.Sets
+open import Cubical.Categories.Displayed.Functor
+
+private
+  variable
+    ℓB ℓB' ℓC ℓC' ℓD ℓD' ℓP ℓP' : Level
+
+open Category
+open Functor
+open Functorᴰ
+
+-- equivalent to the data of a presheaf Pᴰ over ∫ D and a natural transformation
+-- Pᴰ → P ∘ Fst
+Presheafᴰ : {C : Category ℓC ℓC'} (D : Categoryᴰ C ℓD ℓD')
+          → (P : Presheaf C ℓP) → (ℓP' : Level)
+          → Type (ℓ-max (ℓ-max (ℓ-max (ℓ-max (ℓ-max ℓC ℓC') ℓD) ℓD') (ℓ-suc ℓP))
+                    (ℓ-suc ℓP'))
+Presheafᴰ {ℓP = ℓP} D P ℓP' = Functorᴰ P (D ^opᴰ) (SETS ℓP ℓP')
+
+module _ {C : Category ℓC ℓC'} (D : Categoryᴰ C ℓD ℓD')
+         {P : Presheaf C ℓP} (Pᴰ : Presheafᴰ D P ℓP') where
+
+  -- equivalent to the data of a universal element of Pᴰ such that the
+  -- projection preserves the universality
+  record UniversalElementᴰ (ue : UniversalElement C P)
+    : Type (ℓ-max (ℓ-max (ℓ-max (ℓ-max ℓC ℓC') ℓD) ℓD') ℓP') where
+    open UniversalElement ue
+    open Categoryᴰ D
+    field
+      vertexᴰ : ob[ vertex ]
+      elementᴰ : ⟨ Pᴰ .F-obᴰ vertexᴰ element ⟩
+      universalᴰ : ∀ {x xᴰ}{f : C [ x , vertex ]}
+                 → isEquiv λ (fᴰ : Hom[ f ][ xᴰ , vertexᴰ ]) →
+                     Pᴰ .F-homᴰ fᴰ _ elementᴰ

--- a/Cubical/Categories/Instances/Terminal.agda
+++ b/Cubical/Categories/Instances/Terminal.agda
@@ -14,3 +14,13 @@ UnitC .Category.⋆IdL = λ _ → refl
 UnitC .Category.⋆IdR = λ _ → refl
 UnitC .Category.⋆Assoc = λ _ _ _ → refl
 UnitC .Category.isSetHom = λ x₁ y₁ x₂ y₂ i i₁ → tt
+
+UnitC* : ∀ ℓ ℓ' → Category ℓ ℓ'
+UnitC* ℓ ℓ' .Category.ob = Unit* {ℓ}
+UnitC* ℓ ℓ' .Category.Hom[_,_] x y = Unit* {ℓ'}
+UnitC* ℓ ℓ' .Category.id = tt*
+UnitC* ℓ ℓ' .Category._⋆_ = λ f g → tt*
+UnitC* ℓ ℓ' .Category.⋆IdL f i = tt*
+UnitC* ℓ ℓ' .Category.⋆IdR f i = tt*
+UnitC* ℓ ℓ' .Category.⋆Assoc f g h i = tt*
+UnitC* ℓ ℓ' .Category.isSetHom x y x₁ y₁ i i₁ = tt*

--- a/Cubical/Categories/Limits/BinProduct/More.agda
+++ b/Cubical/Categories/Limits/BinProduct/More.agda
@@ -37,6 +37,9 @@ open Bifunctor
 open isEquiv
 
 module _ (C : Category ℓ ℓ') where
+  BinProduct' = RightAdjointAt' _ _ (Δ C)
+  BinProducts' = RightAdjoint' _ _ (Δ C)
+
   BinProductToRepresentable : ∀ {a b} → BinProduct C a b →
                               RightAdjointAt _ _ (Δ C) (a , b)
   BinProductToRepresentable bp .vertex = bp .binProdOb

--- a/Cubical/Categories/Limits/Terminal/More.agda
+++ b/Cubical/Categories/Limits/Terminal/More.agda
@@ -3,13 +3,20 @@ module Cubical.Categories.Limits.Terminal.More where
 
 open import Cubical.Foundations.Prelude
 open import Cubical.Foundations.HLevels
+open import Cubical.Foundations.Equiv
+open import Cubical.Foundations.Isomorphism
+open import Cubical.Foundations.Isomorphism.More
 open import Cubical.HITs.PropositionalTruncation.Base
 open import Cubical.Data.Sigma
+open import Cubical.Data.Unit
 
 open import Cubical.Categories.Category
 open import Cubical.Categories.Functor
+open import Cubical.Categories.Functors.Constant
 open import Cubical.Categories.Isomorphism
 open import Cubical.Categories.Limits.Terminal
+open import Cubical.Categories.Presheaf
+open import Cubical.Categories.Presheaf.Representable
 
 private
   variable
@@ -29,6 +36,22 @@ preserveOnePreservesAll C D F One D-preserves-One One' =
   isoToTerminal D
                 ((F ⟅ One .fst ⟆) , D-preserves-One) (F ⟅ One' .fst ⟆)
                 (F-Iso {F = F} (terminalToIso C One One'))
+
+open UniversalElement
+TerminalPresheaf : ∀ {C : Category ℓc ℓc'} → Presheaf C ℓ-zero
+TerminalPresheaf = Constant _ _ (Unit , isSetUnit)
+
+Terminal' :  ∀ (C : Category ℓc ℓc') → Type (ℓ-max ℓc ℓc')
+Terminal' C = UniversalElement C (TerminalPresheaf {C = C})
+
+terminalToUniversalElement : ∀ {C : Category ℓc ℓc'} (One : Terminal C)
+  → UniversalElement C (TerminalPresheaf {C = C})
+terminalToUniversalElement One .vertex = One .fst
+terminalToUniversalElement One .element = tt
+terminalToUniversalElement {C = C} One .universal x = isoToIsEquiv (iso (λ _ → tt)
+  (λ _ → terminalArrow C One _)
+  (λ b i → tt)
+  λ a → terminalArrowUnique C {T = One} a)
 
 module TerminalNotation (C : Category ℓ ℓ') (term : Terminal C) where
   𝟙 = term .fst

--- a/Cubical/Categories/Limits/Terminal/More.agda
+++ b/Cubical/Categories/Limits/Terminal/More.agda
@@ -48,7 +48,8 @@ terminalToUniversalElement : ∀ {C : Category ℓc ℓc'} (One : Terminal C)
   → UniversalElement C (TerminalPresheaf {C = C})
 terminalToUniversalElement One .vertex = One .fst
 terminalToUniversalElement One .element = tt
-terminalToUniversalElement {C = C} One .universal x = isoToIsEquiv (iso (λ _ → tt)
+terminalToUniversalElement {C = C} One .universal x = isoToIsEquiv (iso
+  (λ _ → tt)
   (λ _ → terminalArrow C One _)
   (λ b i → tt)
   λ a → terminalArrowUnique C {T = One} a)

--- a/Cubical/Categories/Presheaf/More.agda
+++ b/Cubical/Categories/Presheaf/More.agda
@@ -45,8 +45,27 @@ IdPshIso C P = idCatIso
 𝓟* : Category ℓ ℓ' → (ℓS : Level) → Type (ℓ-max (ℓ-max ℓ ℓ') (ℓ-suc ℓS))
 𝓟* C ℓS = Functor C (SET ℓS)
 
+module _ (C : Category ℓ ℓ') (c : C .ob) where
+  open Category
+  open UniversalElement
+
+  selfUnivElt :  UniversalElement C (C [-, c ])
+  selfUnivElt .vertex = c
+  selfUnivElt .element = C .id
+  selfUnivElt .universal A = isoToIsEquiv (iso _ (λ z → z)
+    (C .⋆IdR)
+    (C .⋆IdR))
+
+  selfUnivEltᵒᵖ : UniversalElement (C ^op) (C [ c ,-])
+  selfUnivEltᵒᵖ .vertex = c
+  selfUnivEltᵒᵖ .element = C .id
+  selfUnivEltᵒᵖ .universal _ = isoToIsEquiv (iso _ (λ z → z)
+    (C .⋆IdL)
+    (C .⋆IdL))
+
 module _ {ℓo}{ℓh}{ℓp} (C : Category ℓo ℓh) (P : Presheaf C ℓp) where
   open UniversalElement
+
   UniversalElementOn : C .ob → Type (ℓ-max (ℓ-max ℓo ℓh) ℓp)
   UniversalElementOn vertex =
     Σ[ element ∈ (P ⟅ vertex ⟆) .fst ] isUniversal C P vertex element


### PR DESCRIPTION
This is a start at defining universal properties for displayed categories in a similar manner to how we do it for ordinary categories. We define a displayed version of `SET`, displayed `Presheaf` over a presheaf, and a displayed universal element over a universal element. Then as specific examples, we define displayed right adjoints over a right adjoint and defined global and local binary and nullary products as well as cartesian lifts, which allows us to define when a displayed category is a fibration.

It's not quite lined up with what we are doing for categories because I don't have displayed profunctors or displayed functor comprehension yet, so I had to make a variant of RightAdjoint in the base to get things to line up definitionally for now.