### PR TITLE
Functor comprehension simplification

### DIFF
--- a/Cubical/Categories/Constructions/BinProduct/More.agda
+++ b/Cubical/Categories/Constructions/BinProduct/More.agda
@@ -27,6 +27,9 @@ open Functor
 Δ : ∀ (C : Category ℓC ℓC') → Functor C (C ×C C)
 Δ C = Id ,F Id
 
+Sym : {C : Category ℓC ℓC'}{D : Category ℓD ℓD'} → Functor (C ×C D) (D ×C C)
+Sym {C = C}{D = D} = Snd C D ,F Fst C D
+
 -- helpful decomposition of morphisms used in several proofs
 -- about product category
 module _ {C : Category ℓC ℓC'}{D : Category ℓD ℓD'}{E : Category ℓE ℓE'} where

--- a/Cubical/Categories/Constructions/FullImage.agda
+++ b/Cubical/Categories/Constructions/FullImage.agda
@@ -1,0 +1,73 @@
+{-
+
+The Full Image of a Functor
+
+-}
+{-# OPTIONS --safe #-}
+module Cubical.Categories.Constructions.FullImage where
+
+open import Cubical.Foundations.Prelude
+open import Cubical.Foundations.Equiv
+open import Cubical.Foundations.Equiv.Properties
+open import Cubical.Functions.Embedding
+open import Cubical.Data.Sigma
+open import Cubical.HITs.PropositionalTruncation as PropTrunc
+
+open import Cubical.Categories.Category
+open import Cubical.Categories.Functor
+open import Cubical.Categories.Constructions.FullSubcategory
+
+private
+  variable
+    ℓC ℓC' ℓD ℓD' : Level
+
+
+open Category
+open Functor
+
+module _
+  {C : Category ℓC ℓC'}{D : Category ℓD ℓD'}
+  (F : Functor C D) where
+
+  FullImage : Category ℓC ℓD'
+  FullImage .ob = C .ob
+  FullImage .Hom[_,_] c c' = D [ F ⟅ c ⟆ , F ⟅ c' ⟆ ]
+  FullImage .id = D .id
+  FullImage ._⋆_ = D ._⋆_
+  FullImage .⋆IdL = D .⋆IdL
+  FullImage .⋆IdR = D .⋆IdR
+  FullImage .⋆Assoc = D .⋆Assoc
+  FullImage .isSetHom = D .isSetHom
+
+  ToFullImage : Functor C FullImage
+  ToFullImage .F-ob = λ z → z
+  ToFullImage .F-hom = F-hom F
+  ToFullImage .F-id = F-id F
+  ToFullImage .F-seq = F-seq F
+
+  FromFullImage : Functor FullImage D
+  FromFullImage .F-ob = F-ob F
+  FromFullImage .F-hom = λ z → z
+  FromFullImage .F-id = refl
+  FromFullImage .F-seq f g = refl
+
+  CompFullImage : (FromFullImage ∘F ToFullImage ≡ F)
+  CompFullImage = Functor≡ (λ _ → refl) (λ _ → refl)
+
+module _
+  {C : Category ℓC ℓC'}{D : Category ℓD ℓD'}
+  {F : Functor C D}
+  (isFullyFaithfulF : isFullyFaithful F)
+  where
+  private
+    FC = FullImage F
+    FF≃  : ∀ {x y} → C [ x , y ] ≃ D [ _ , _ ]
+    FF≃ = _ , (isFullyFaithfulF _ _)
+
+  inv : Functor FC C
+  inv .F-ob = λ z → z
+  inv .F-hom = invIsEq (isFullyFaithfulF _ _)
+  inv .F-id = sym (invEq (equivAdjointEquiv FF≃) (F .F-id))
+  inv .F-seq f g =
+    sym (invEq (equivAdjointEquiv FF≃)
+    (F .F-seq _ _ ∙ cong₂ (seq' D) (secEq FF≃ _) (secEq FF≃ _)))

--- a/Cubical/Categories/Displayed/Base/DisplayOverProjections.agda
+++ b/Cubical/Categories/Displayed/Base/DisplayOverProjections.agda
@@ -54,25 +54,6 @@ module _
   Fstᴰsr .Functorᴰ.F-idᴰ = refl
   Fstᴰsr .Functorᴰ.F-seqᴰ = λ fᴰ gᴰ → refl
 
-  -- s for "simple" because C is not dependent on D
-  -- l for "left" because C is on the left of the product
-  ∫Cᴰsl : Categoryᴰ D (ℓ-max ℓC ℓCᴰ) (ℓ-max ℓC' ℓCᴰ')
-  ∫Cᴰsl .ob[_] d = Σ[ c ∈ C .ob ] Cᴰ.ob[ c , d ]
-  ∫Cᴰsl .Hom[_][_,_] g (c , cᴰ) (c' , cᴰ') =
-    Σ[ f ∈ C [ c , c' ] ] Cᴰ.Hom[ f , g ][ cᴰ , cᴰ' ]
-  ∫Cᴰsl .idᴰ = (C .id) , Cᴰ.idᴰ
-  ∫Cᴰsl ._⋆ᴰ_ (f , fᴰ) (g , gᴰ) = (f ⋆⟨ C ⟩ g) , (fᴰ Cᴰ.⋆ᴰ gᴰ)
-  ∫Cᴰsl .⋆IdLᴰ (f , fᴰ) = ΣPathP (_ , Cᴰ.⋆IdLᴰ _)
-  ∫Cᴰsl .⋆IdRᴰ _ = ΣPathP (_ , Cᴰ.⋆IdRᴰ _)
-  ∫Cᴰsl .⋆Assocᴰ _ _ _ = ΣPathP (_ , Cᴰ.⋆Assocᴰ _ _ _)
-  ∫Cᴰsl .isSetHomᴰ = isSetΣ (C .isSetHom) (λ _ → Cᴰ .isSetHomᴰ)
-
-  Fstᴰsl : Functorᴰ Id ∫Cᴰsl (weaken D C)
-  Fstᴰsl .Functorᴰ.F-obᴰ = fst
-  Fstᴰsl .Functorᴰ.F-homᴰ = fst
-  Fstᴰsl .Functorᴰ.F-idᴰ = refl
-  Fstᴰsl .Functorᴰ.F-seqᴰ = λ _ _ → refl
-
   module _
     {E : Category ℓE ℓE'}
     (F : Functor E C)
@@ -130,3 +111,43 @@ module _
     Assc' .F-homᴰ {_}{_}{f} _ = f .snd .snd
     Assc' .F-idᴰ = refl
     Assc' .F-seqᴰ _ _ = refl
+
+module _
+  {C : Category ℓC ℓC'} {D : Category ℓD ℓD'}
+  (Cᴰ : Categoryᴰ (C ×C D) ℓCᴰ ℓCᴰ')
+  where
+  open Category
+
+  private
+    module Cᴰ = Categoryᴰ Cᴰ
+
+  private
+    -- can't use reindex bc transport hell
+    Cᴰ' : Categoryᴰ (D ×C C) _ _
+    ob[ Cᴰ' ] (d , c) = Cᴰ.ob[ c , d ]
+    Cᴰ' .Hom[_][_,_] (g , f) cᴰ cᴰ' = Cᴰ.Hom[ f , g ][ cᴰ , cᴰ' ]
+    Cᴰ' .idᴰ = Cᴰ.idᴰ
+    Cᴰ' ._⋆ᴰ_ = Cᴰ._⋆ᴰ_
+    Cᴰ' .⋆IdLᴰ = Cᴰ.⋆IdLᴰ
+    Cᴰ' .⋆IdRᴰ = Cᴰ.⋆IdRᴰ
+    Cᴰ' .⋆Assocᴰ = Cᴰ.⋆Assocᴰ
+    Cᴰ' .isSetHomᴰ = Cᴰ.isSetHomᴰ
+
+  -- s for "simple" because C is not dependent on D
+  -- l for "left" because C is on the left of the product
+  ∫Cᴰsl : Categoryᴰ D (ℓ-max ℓC ℓCᴰ) (ℓ-max ℓC' ℓCᴰ')
+  ∫Cᴰsl = ∫Cᴰsr {D = C} Cᴰ'
+
+  Fstᴰsl : Functorᴰ Id ∫Cᴰsl (weaken D C)
+  Fstᴰsl = Fstᴰsr Cᴰ'
+
+  module _
+    {E : Category ℓE ℓE'}
+    (F : Functor E D)
+    {Eᴰ : Categoryᴰ E ℓEᴰ ℓEᴰ'}
+    (Fᴰ : Functorᴰ F Eᴰ (weaken D C))
+    (Gᴰ : Functorᴰ (∫F Fᴰ) (Unitᴰ (∫C Eᴰ)) Cᴰ')
+    where
+
+    mk∫ᴰslFunctorᴰ : Functorᴰ F Eᴰ ∫Cᴰsl
+    mk∫ᴰslFunctorᴰ = mk∫ᴰsrFunctorᴰ Cᴰ' F Fᴰ Gᴰ

--- a/Cubical/Categories/Displayed/Base/DisplayOverProjections.agda
+++ b/Cubical/Categories/Displayed/Base/DisplayOverProjections.agda
@@ -9,9 +9,11 @@ open import Cubical.Data.Sigma
 open import Cubical.Categories.Category.Base
 open import Cubical.Categories.Constructions.BinProduct
   renaming (Fst to FstBP ; Snd to SndBP)
+open import Cubical.Categories.Constructions.BinProduct.More
 open import Cubical.Categories.Functor
 
 open import Cubical.Categories.Displayed.Base
+open import Cubical.Categories.Displayed.Reasoning
 open import Cubical.Categories.Displayed.Properties
 open import Cubical.Categories.Displayed.Functor
 open import Cubical.Categories.Displayed.Instances.Terminal
@@ -19,7 +21,7 @@ open import Cubical.Categories.Displayed.Base.More
 
 private
   variable
-    ℓC ℓC' ℓCᴰ ℓCᴰ' ℓD ℓD' ℓDᴰ ℓDᴰ' ℓE ℓE' ℓEᴰ ℓEᴰ' : Level
+    ℓB ℓB' ℓBᴰ ℓBᴰ' ℓC ℓC' ℓCᴰ ℓCᴰ' ℓD ℓD' ℓDᴰ ℓDᴰ' ℓE ℓE' ℓEᴰ ℓEᴰ' : Level
 
 open Categoryᴰ
 
@@ -146,8 +148,50 @@ module _
     (F : Functor E D)
     {Eᴰ : Categoryᴰ E ℓEᴰ ℓEᴰ'}
     (Fᴰ : Functorᴰ F Eᴰ (weaken D C))
-    (Gᴰ : Functorᴰ (∫F Fᴰ) (Unitᴰ (∫C Eᴰ)) Cᴰ')
+    (Gᴰ : Functorᴰ (Sym {C = D}{D = C} ∘F ∫F Fᴰ) (Unitᴰ (∫C Eᴰ)) Cᴰ)
     where
 
     mk∫ᴰslFunctorᴰ : Functorᴰ F Eᴰ ∫Cᴰsl
-    mk∫ᴰslFunctorᴰ = mk∫ᴰsrFunctorᴰ Cᴰ' F Fᴰ Gᴰ
+    mk∫ᴰslFunctorᴰ = mk∫ᴰsrFunctorᴰ Cᴰ' F Fᴰ Gᴰ' where
+      module Gᴰ = Functorᴰ Gᴰ
+      Gᴰ' : Functorᴰ (∫F Fᴰ) (Unitᴰ (∫C Eᴰ)) Cᴰ'
+      Gᴰ' .Functorᴰ.F-obᴰ  _ = Gᴰ.F-obᴰ _
+      Gᴰ' .Functorᴰ.F-homᴰ _ = Gᴰ.F-homᴰ _
+      Gᴰ' .Functorᴰ.F-idᴰ {x}{xᴰ} = ≡[]-rectify Cᴰ Gᴰ.F-idᴰ
+      Gᴰ' .Functorᴰ.F-seqᴰ _ _ = ≡[]-rectify Cᴰ (Gᴰ.F-seqᴰ _ _)
+  Assoc-sl⁻ : Functor (∫C ∫Cᴰsl) (∫C Cᴰ)
+  Assoc-sl⁻ = mk∫Functor Assc Assc' where
+    open Functor
+    open Functorᴰ
+    -- Might want this at the top level
+    Assc : Functor (∫C ∫Cᴰsl) (C ×C D)
+    Assc .F-ob (d , (c , _)) = c , d
+    Assc .F-hom (g , (f , _)) = f , g
+    Assc .F-id = refl
+    Assc .F-seq _ _ = refl
+
+    Assc' : Functorᴰ Assc _ Cᴰ
+    Assc' .F-obᴰ {x}        _ = x .snd .snd
+    Assc' .F-homᴰ {_}{_}{f} _ = f .snd .snd
+    Assc' .F-idᴰ = refl
+    Assc' .F-seqᴰ _ _ = refl
+
+module _
+  {B : Category ℓB ℓB'}{C : Category ℓC ℓC'}
+  {D : Category ℓD ℓD'}
+  {E : Category ℓE ℓE'}
+  {Bᴰ : Categoryᴰ (B ×C D) ℓBᴰ ℓBᴰ'}
+  {Cᴰ : Categoryᴰ (C ×C E) ℓCᴰ ℓCᴰ'}
+  {F : Functor D E}
+  {G : Functor B C}
+  (FGᴰ : Functorᴰ (G ×F F) Bᴰ Cᴰ)
+  where
+  private
+    module G = Functor G
+    module FGᴰ = Functorᴰ FGᴰ
+  -- ideally this would be implemented using mk∫ᴰslFunctorᴰ
+  ∫ᴰslF : Functorᴰ F (∫Cᴰsl {C = B}{D = D} Bᴰ) (∫Cᴰsl {C = C}{D = E} Cᴰ)
+  ∫ᴰslF .Functorᴰ.F-obᴰ {d} (b , bᴰ) = (G ⟅ b ⟆) , (FGᴰ.F-obᴰ bᴰ)
+  ∫ᴰslF .Functorᴰ.F-homᴰ {g} (f , fᴰ) = (G ⟪ f ⟫) , (FGᴰ.F-homᴰ fᴰ)
+  ∫ᴰslF .Functorᴰ.F-idᴰ = ΣPathP (G.F-id , (≡[]-rectify Cᴰ FGᴰ.F-idᴰ))
+  ∫ᴰslF .Functorᴰ.F-seqᴰ _ _ = ΣPathP ((G.F-seq _ _) , (≡[]-rectify Cᴰ (FGᴰ.F-seqᴰ _ _)))

--- a/Cubical/Categories/Displayed/Base/DisplayOverProjections.agda
+++ b/Cubical/Categories/Displayed/Base/DisplayOverProjections.agda
@@ -194,4 +194,5 @@ module _
   ∫ᴰslF .Functorᴰ.F-obᴰ {d} (b , bᴰ) = (G ⟅ b ⟆) , (FGᴰ.F-obᴰ bᴰ)
   ∫ᴰslF .Functorᴰ.F-homᴰ {g} (f , fᴰ) = (G ⟪ f ⟫) , (FGᴰ.F-homᴰ fᴰ)
   ∫ᴰslF .Functorᴰ.F-idᴰ = ΣPathP (G.F-id , (≡[]-rectify Cᴰ FGᴰ.F-idᴰ))
-  ∫ᴰslF .Functorᴰ.F-seqᴰ _ _ = ΣPathP ((G.F-seq _ _) , (≡[]-rectify Cᴰ (FGᴰ.F-seqᴰ _ _)))
+  ∫ᴰslF .Functorᴰ.F-seqᴰ _ _ =
+    ΣPathP ((G.F-seq _ _) , (≡[]-rectify Cᴰ (FGᴰ.F-seqᴰ _ _)))

--- a/Cubical/Categories/Displayed/Base/HLevel1Homs.agda
+++ b/Cubical/Categories/Displayed/Base/HLevel1Homs.agda
@@ -73,3 +73,16 @@ module _
   mkFunctorᴰContrHoms contrHoms F-obᴰ =
     mkFunctorᴰPropHoms (hasContrHoms→hasPropHoms Dᴰ contrHoms) F-obᴰ
     λ _ → contrHoms _ _ _ .fst
+
+  -- Alternate version: maybe Dᴰ.Hom[_][_,_] isn't always contractible, but it is in the image of F-obᴰ
+  mkFunctorᴰContrHoms' : (F-obᴰ  : {x : C .ob} → Cᴰ.ob[ x ] → Dᴰ.ob[ F .F-ob x ])
+                       → (F-homᴰ : {x y : C .ob}
+                         {f : C [ x , y ]} {xᴰ : Cᴰ.ob[ x ]} {yᴰ : Cᴰ.ob[ y ]}
+                         → Cᴰ [ f ][ xᴰ , yᴰ ] → isContr (Dᴰ [ F .F-hom f ][ F-obᴰ xᴰ , F-obᴰ yᴰ ]))
+                       → Functorᴰ F Cᴰ Dᴰ
+  mkFunctorᴰContrHoms' F-obᴰ F-homᴰ .Functorᴰ.F-obᴰ = F-obᴰ
+  mkFunctorᴰContrHoms' F-obᴰ F-homᴰ .Functorᴰ.F-homᴰ fᴰ = F-homᴰ fᴰ .fst
+  mkFunctorᴰContrHoms' F-obᴰ F-homᴰ .Functorᴰ.F-idᴰ =
+    symP (toPathP (isProp→PathP (λ i → isContr→isProp (F-homᴰ Cᴰ.idᴰ)) _ _))
+  mkFunctorᴰContrHoms' F-obᴰ F-homᴰ .Functorᴰ.F-seqᴰ fᴰ gᴰ =
+    symP (toPathP (isProp→PathP (λ i → isContr→isProp (F-homᴰ (fᴰ Cᴰ.⋆ᴰ gᴰ))) _ _))

--- a/Cubical/Categories/Displayed/Base/HLevel1Homs.agda
+++ b/Cubical/Categories/Displayed/Base/HLevel1Homs.agda
@@ -74,15 +74,19 @@ module _
     mkFunctorᴰPropHoms (hasContrHoms→hasPropHoms Dᴰ contrHoms) F-obᴰ
     λ _ → contrHoms _ _ _ .fst
 
-  -- Alternate version: maybe Dᴰ.Hom[_][_,_] isn't always contractible, but it is in the image of F-obᴰ
-  mkFunctorᴰContrHoms' : (F-obᴰ  : {x : C .ob} → Cᴰ.ob[ x ] → Dᴰ.ob[ F .F-ob x ])
-                       → (F-homᴰ : {x y : C .ob}
-                         {f : C [ x , y ]} {xᴰ : Cᴰ.ob[ x ]} {yᴰ : Cᴰ.ob[ y ]}
-                         → Cᴰ [ f ][ xᴰ , yᴰ ] → isContr (Dᴰ [ F .F-hom f ][ F-obᴰ xᴰ , F-obᴰ yᴰ ]))
-                       → Functorᴰ F Cᴰ Dᴰ
+  -- Alternate version: maybe Dᴰ.Hom[_][_,_] isn't always
+  -- contractible, but it is in the image of F-obᴰ
+  mkFunctorᴰContrHoms'
+    : (F-obᴰ  : {x : C .ob} → Cᴰ.ob[ x ] → Dᴰ.ob[ F .F-ob x ])
+    → (F-homᴰ : {x y : C .ob}
+      {f : C [ x , y ]} {xᴰ : Cᴰ.ob[ x ]} {yᴰ : Cᴰ.ob[ y ]}
+    → Cᴰ [ f ][ xᴰ , yᴰ ]
+    → isContr (Dᴰ [ F .F-hom f ][ F-obᴰ xᴰ , F-obᴰ yᴰ ]))
+    → Functorᴰ F Cᴰ Dᴰ
   mkFunctorᴰContrHoms' F-obᴰ F-homᴰ .Functorᴰ.F-obᴰ = F-obᴰ
   mkFunctorᴰContrHoms' F-obᴰ F-homᴰ .Functorᴰ.F-homᴰ fᴰ = F-homᴰ fᴰ .fst
   mkFunctorᴰContrHoms' F-obᴰ F-homᴰ .Functorᴰ.F-idᴰ =
     symP (toPathP (isProp→PathP (λ i → isContr→isProp (F-homᴰ Cᴰ.idᴰ)) _ _))
   mkFunctorᴰContrHoms' F-obᴰ F-homᴰ .Functorᴰ.F-seqᴰ fᴰ gᴰ =
-    symP (toPathP (isProp→PathP (λ i → isContr→isProp (F-homᴰ (fᴰ Cᴰ.⋆ᴰ gᴰ))) _ _))
+    symP (toPathP (isProp→PathP
+      (λ i → isContr→isProp (F-homᴰ (fᴰ Cᴰ.⋆ᴰ gᴰ))) _ _))

--- a/Cubical/Categories/Displayed/Base/More.agda
+++ b/Cubical/Categories/Displayed/Base/More.agda
@@ -64,6 +64,20 @@ module _ {C : Category ℓC ℓC'} {Cᴰ : Categoryᴰ C ℓCᴰ ℓCᴰ'} where
     mk∫Functor .F-seq f g = ΣPathP (F .F-seq f g , Fᴰ .F-seqᴰ _ _)
 
 module _ {C : Category ℓC ℓC'}
+         {Cᴰ : Categoryᴰ C ℓCᴰ ℓCᴰ'}
+         {Dᴰ : Categoryᴰ C ℓDᴰ ℓDᴰ'}
+         (Fᴰ : Functorᴰ Id Dᴰ Cᴰ)
+           where
+    mk∫Functor' : Functor (∫C Dᴰ) (∫C Cᴰ)
+    mk∫Functor' = mk∫Functor (Fst {Cᴰ = Dᴰ})  Fᴰ' where
+      module Fᴰ = Functorᴰ Fᴰ
+      Fᴰ' : Functorᴰ Fst (Unitᴰ (∫C Dᴰ)) Cᴰ
+      Fᴰ' .Functorᴰ.F-obᴰ {x = (_ , dᴰ)} tt = Fᴰ.F-obᴰ dᴰ
+      Fᴰ' .Functorᴰ.F-homᴰ {f = (_ , fᴰ)} tt = Fᴰ.F-homᴰ fᴰ
+      Fᴰ' .Functorᴰ.F-idᴰ = Fᴰ.F-idᴰ
+      Fᴰ' .Functorᴰ.F-seqᴰ _ _ = Fᴰ.F-seqᴰ _ _
+
+module _ {C : Category ℓC ℓC'}
   {Cᴰ : Categoryᴰ C ℓCᴰ ℓCᴰ'}
   (Dᴰ : Categoryᴰ (∫C Cᴰ) ℓDᴰ ℓDᴰ')
   where

--- a/Cubical/Categories/Displayed/Base/More.agda
+++ b/Cubical/Categories/Displayed/Base/More.agda
@@ -64,20 +64,6 @@ module _ {C : Category ℓC ℓC'} {Cᴰ : Categoryᴰ C ℓCᴰ ℓCᴰ'} where
     mk∫Functor .F-seq f g = ΣPathP (F .F-seq f g , Fᴰ .F-seqᴰ _ _)
 
 module _ {C : Category ℓC ℓC'}
-         {Cᴰ : Categoryᴰ C ℓCᴰ ℓCᴰ'}
-         {Dᴰ : Categoryᴰ C ℓDᴰ ℓDᴰ'}
-         (Fᴰ : Functorᴰ Id Dᴰ Cᴰ)
-           where
-    mk∫Functor' : Functor (∫C Dᴰ) (∫C Cᴰ)
-    mk∫Functor' = mk∫Functor (Fst {Cᴰ = Dᴰ})  Fᴰ' where
-      module Fᴰ = Functorᴰ Fᴰ
-      Fᴰ' : Functorᴰ Fst (Unitᴰ (∫C Dᴰ)) Cᴰ
-      Fᴰ' .Functorᴰ.F-obᴰ {x = (_ , dᴰ)} tt = Fᴰ.F-obᴰ dᴰ
-      Fᴰ' .Functorᴰ.F-homᴰ {f = (_ , fᴰ)} tt = Fᴰ.F-homᴰ fᴰ
-      Fᴰ' .Functorᴰ.F-idᴰ = Fᴰ.F-idᴰ
-      Fᴰ' .Functorᴰ.F-seqᴰ _ _ = Fᴰ.F-seqᴰ _ _
-
-module _ {C : Category ℓC ℓC'}
   {Cᴰ : Categoryᴰ C ℓCᴰ ℓCᴰ'}
   (Dᴰ : Categoryᴰ (∫C Cᴰ) ℓDᴰ ℓDᴰ')
   where

--- a/Cubical/Categories/Displayed/Constructions/Comma.agda
+++ b/Cubical/Categories/Displayed/Constructions/Comma.agda
@@ -16,6 +16,7 @@ open import Cubical.Data.Unit
 
 open import Cubical.Categories.Category.Base
 open import Cubical.Categories.Constructions.FullSubcategory
+open import Cubical.Categories.Displayed.Constructions.FullSubcategory
 open import Cubical.Categories.Bifunctor.Redundant
 open import Cubical.Categories.Constructions.BinProduct as BinProduct
 open import Cubical.Categories.Functor.Base
@@ -69,13 +70,7 @@ module _ {C : Category ℓC ℓC'} {D : Category ℓD ℓD'}{E : Category ℓE �
   Commaᴰ₁ = ∫Cᴰsr Commaᴰ
 
   IsoCommaᴰ : Categoryᴰ (C ×C D) (ℓ-max ℓE' ℓE') ℓE'
-  IsoCommaᴰ = ∫Cᴰ Commaᴰ (Preorderᴰ→Catᴰ IsoCommaᴰ') where
-    IsoCommaᴰ' : Preorderᴰ Comma ℓE' ℓ-zero
-    IsoCommaᴰ' .ob[_] ((c , d) , f)= isIso E f
-    IsoCommaᴰ' .Hom[_][_,_] _ _ _ = Unit
-    IsoCommaᴰ' .idᴰ = tt
-    IsoCommaᴰ' ._⋆ᴰ_ _ _ = tt
-    IsoCommaᴰ' .isPropHomᴰ = isPropUnit
+  IsoCommaᴰ = ∫Cᴰ Commaᴰ (FullSubcategoryᴰ _ (λ (_ , f) → isIso E f))
 
   -- Not following from a gneral result about ∫Cᴰ but works
   hasPropHomsIsoCommaᴰ : hasPropHoms IsoCommaᴰ
@@ -83,38 +78,58 @@ module _ {C : Category ℓC ℓC'} {D : Category ℓD ℓD'}{E : Category ℓE �
   -- TODO generalize this as a reasoning principle for ∫Cᴰ
     isPropΣ
       (hasPropHomsCommaᴰ f (cᴰ .fst) (cᴰ' .fst))
-      λ x → hasPropHomsPreorderᴰ _ (f , x) (cᴰ .snd) (cᴰ' .snd)
+      λ x → hasPropHomsFullSubcategory _ _ (f , x) (cᴰ .snd) (cᴰ' .snd)
 
   IsoComma : Category _ _
   IsoComma = ∫C IsoCommaᴰ
 
-  IsoCommaᴰ₁ : Categoryᴰ C (ℓ-max ℓD ℓE') (ℓ-max ℓD' ℓE')
+  IsoCommaᴰ₁ : Categoryᴰ C _ _
   IsoCommaᴰ₁ = ∫Cᴰsr IsoCommaᴰ
+
+  IsoCommaᴰ₂ : Categoryᴰ D _ _
+  IsoCommaᴰ₂ = ∫Cᴰsl IsoCommaᴰ
 
   open isIso
   -- Characterization of HLevel of Commaᴰ₁ homs
+  private
+    module IC₁ = Categoryᴰ IsoCommaᴰ₁
+    module _ {c c'}(f : C [ c , c' ])
+             (c≅d : IC₁.ob[ c ])
+             (c'≅d' : IC₁.ob[ c' ]) where
+      AltHom : Type _
+      AltHom = fiber (G .F-hom)
+        (c≅d .snd .snd .inv ⋆⟨ E ⟩ F .F-hom f ⋆⟨ E ⟩ c'≅d' .snd .fst)
+
+      ICHom = IC₁.Hom[ f ][ c≅d , c'≅d' ]
+
+      Hom→Alt : ICHom → AltHom
+      Hom→Alt (g , sq , _) = g , ⋆InvLMove (c≅d .snd) (sym sq) ∙ sym (E .⋆Assoc _ _ _)
+
+      Alt→Hom : AltHom → ICHom
+      Alt→Hom (g , sq) = g , sym (⋆InvLMove⁻ (c≅d .snd) (sq ∙ E .⋆Assoc _ _ _)), tt
+
+      AltHomRetr : (x : ICHom) → Alt→Hom (Hom→Alt x) ≡ x
+      AltHomRetr _ = Σ≡Prop (λ g' → hasPropHomsIsoCommaᴰ _ _ _) refl
+
+      AltHomProp : isFaithful G → isProp AltHom
+      AltHomProp G-faithful = isEmbedding→hasPropFibers
+        (injEmbedding (E .isSetHom) (λ {g} {g'} → G-faithful _ _ _ _))
+        _
+
+      AltHomContr : isFullyFaithful G → isContr AltHom
+      AltHomContr G-ff = G-ff _ _ .equiv-proof _
+
+      HomProp : isFaithful G → isProp ICHom
+      HomProp G-faithful = isPropRetract Hom→Alt Alt→Hom AltHomRetr (AltHomProp G-faithful)
+
+      HomContr : isFullyFaithful G → isContr ICHom
+      HomContr G-ff = isContrRetract Hom→Alt Alt→Hom AltHomRetr (AltHomContr G-ff)
+
   hasPropHomsIsoCommaᴰ₁ : isFaithful G → hasPropHoms IsoCommaᴰ₁
-  hasPropHomsIsoCommaᴰ₁ G-faithful f (d , iso) (d' , iso') =
-    isPropRetract
-      (λ (g , sq , _) → g , ⋆InvLMove iso (sym sq) ∙ sym (E .⋆Assoc _ _ _))
-      (λ (g , sq) → g , sym (⋆InvLMove⁻ iso (sq ∙ E .⋆Assoc _ _ _)), tt)
-      ((λ (g , sq , _) → Σ≡Prop (λ g' → hasPropHomsIsoCommaᴰ _ _ _) refl))
-      (isEmbedding→hasPropFibers
-        (injEmbedding (E .isSetHom) (λ {g} {g'} → G-faithful d d' g g'))
-       (iso .snd .inv ⋆⟨ E ⟩ F .F-hom f ⋆⟨ E ⟩ iso' .fst))
+  hasPropHomsIsoCommaᴰ₁ G-faithful f diso diso' = HomProp f diso diso' G-faithful
 
   hasContrHomsIsoCommaᴰ₁ : isFullyFaithful G → hasContrHoms IsoCommaᴰ₁
-  hasContrHomsIsoCommaᴰ₁ Gff f (d , e) (d' , e') =
-    inhProp→isContr
-      (g .fst .fst
-      , sym (⋆InvLMove⁻ e (g .fst .snd ∙ E .⋆Assoc _ _ _))
-      , tt)
-      (hasPropHomsIsoCommaᴰ₁
-        (isFullyFaithful→Faithful {F = G} Gff) f (d , e) (d' , e'))
-      where
-        G⟪g⟫ : E [ G .F-ob d , G .F-ob d' ]
-        G⟪g⟫ = e .snd .inv ⋆⟨ E ⟩ F ⟪ f ⟫ ⋆⟨ E ⟩ e' .fst
-        g = Gff d d' .equiv-proof G⟪g⟫
+  hasContrHomsIsoCommaᴰ₁ G-ff f diso diso' = HomContr f diso diso' G-ff
 
   πⁱ1 : Functor IsoComma C
   πⁱ1 = BinProduct.Fst C D ∘F Displayed.Fst {Cᴰ = IsoCommaᴰ}
@@ -126,6 +141,44 @@ module _ {C : Category ℓC ℓC'} {D : Category ℓD ℓD'}{E : Category ℓE �
   π≅ .NatIso.trans .N-ob (_ , f , _) = f
   π≅ .NatIso.trans .N-hom (_ , sq , _) = sq
   π≅ .NatIso.nIso (_ , _ , isIso) = isIso
+
+module _ {C : Category ℓC ℓC'} {D : Category ℓD ℓD'}{E : Category ℓE ℓE'}
+         (F : Functor C E) (G : Functor D E) where
+
+  private
+    module IC₂ = Categoryᴰ (IsoCommaᴰ₂ F G)
+    module IC₁ = Categoryᴰ (IsoCommaᴰ₁ G F)
+    module _ {d d'}(g : D [ d , d' ])
+             (d≅c   : IC₂.ob[ d ])
+             (d'≅c' : IC₂.ob[ d' ]) where
+      c≅d : IC₁.ob[ d ]
+      c≅d = (d≅c .fst) , (invIso (d≅c .snd))
+      c'≅d' : IC₁.ob[ d' ]
+      c'≅d' = (d'≅c' .fst) , (invIso (d'≅c' .snd))
+      IC2Hom = IC₂.Hom[ g ][ d≅c , d'≅c' ]
+      IC1Hom = IC₁.Hom[ g ][ c≅d , c'≅d' ]
+
+      isOfHLevelIC2Hom : ∀ n → isOfHLevel n IC1Hom → isOfHLevel n IC2Hom
+      isOfHLevelIC2Hom n =
+        isOfHLevelRetract n
+          -- this proof would be better if it was an iff directly
+          (λ (f , sq2 , tt) → f ,
+          sym (⋆InvRMove (d'≅c' .snd)
+            (E .⋆Assoc _ _ _ ∙ sym (⋆InvLMove (d≅c .snd) (sym sq2))))
+          , tt)
+          (λ (f , sq1 , tt) → f ,
+            sym (⋆InvRMove (c'≅d' .snd)
+            (E .⋆Assoc _ _ _ ∙ sym (⋆InvLMove (c≅d .snd) (sym sq1))))
+            , tt)
+          λ sq2 → Σ≡Prop (λ _ → hasPropHomsIsoCommaᴰ F G _ _ _) refl
+    
+  hasPropHomsIsoCommaᴰ₂ : isFaithful F → hasPropHoms (IsoCommaᴰ₂ F G)
+  hasPropHomsIsoCommaᴰ₂ F-faithful f diso diso' =
+    isOfHLevelIC2Hom _ _ _ 1 (hasPropHomsIsoCommaᴰ₁ G F F-faithful _ _ _)
+
+  hasContrHomsIsoCommaᴰ₂ : isFullyFaithful F → hasContrHoms (IsoCommaᴰ₂ F G)
+  hasContrHomsIsoCommaᴰ₂ F-ff f diso diso' =
+    isOfHLevelIC2Hom _ _ _ 0 (hasContrHomsIsoCommaᴰ₁ G F F-ff _ _ _)
 
 module _ {C : Category ℓC ℓC'} {D : Category ℓD ℓD'}{E : Category ℓE ℓE'}
          {F : Functor C E} {G : Functor D E}

--- a/Cubical/Categories/Displayed/Constructions/Comma.agda
+++ b/Cubical/Categories/Displayed/Constructions/Comma.agda
@@ -103,10 +103,12 @@ module _ {C : Category ℓC ℓC'} {D : Category ℓD ℓD'}{E : Category ℓE �
       ICHom = IC₁.Hom[ f ][ c≅d , c'≅d' ]
 
       Hom→Alt : ICHom → AltHom
-      Hom→Alt (g , sq , _) = g , ⋆InvLMove (c≅d .snd) (sym sq) ∙ sym (E .⋆Assoc _ _ _)
+      Hom→Alt (g , sq , _) = g ,
+        ⋆InvLMove (c≅d .snd) (sym sq) ∙ sym (E .⋆Assoc _ _ _)
 
       Alt→Hom : AltHom → ICHom
-      Alt→Hom (g , sq) = g , sym (⋆InvLMove⁻ (c≅d .snd) (sq ∙ E .⋆Assoc _ _ _)), tt
+      Alt→Hom (g , sq) = g ,
+        sym (⋆InvLMove⁻ (c≅d .snd) (sq ∙ E .⋆Assoc _ _ _)), tt
 
       AltHomRetr : (x : ICHom) → Alt→Hom (Hom→Alt x) ≡ x
       AltHomRetr _ = Σ≡Prop (λ g' → hasPropHomsIsoCommaᴰ _ _ _) refl
@@ -120,13 +122,16 @@ module _ {C : Category ℓC ℓC'} {D : Category ℓD ℓD'}{E : Category ℓE �
       AltHomContr G-ff = G-ff _ _ .equiv-proof _
 
       HomProp : isFaithful G → isProp ICHom
-      HomProp G-faithful = isPropRetract Hom→Alt Alt→Hom AltHomRetr (AltHomProp G-faithful)
+      HomProp G-faithful =
+        isPropRetract Hom→Alt Alt→Hom AltHomRetr (AltHomProp G-faithful)
 
       HomContr : isFullyFaithful G → isContr ICHom
-      HomContr G-ff = isContrRetract Hom→Alt Alt→Hom AltHomRetr (AltHomContr G-ff)
+      HomContr G-ff =
+        isContrRetract Hom→Alt Alt→Hom AltHomRetr (AltHomContr G-ff)
 
   hasPropHomsIsoCommaᴰ₁ : isFaithful G → hasPropHoms IsoCommaᴰ₁
-  hasPropHomsIsoCommaᴰ₁ G-faithful f diso diso' = HomProp f diso diso' G-faithful
+  hasPropHomsIsoCommaᴰ₁ G-faithful f diso diso' =
+    HomProp f diso diso' G-faithful
 
   hasContrHomsIsoCommaᴰ₁ : isFullyFaithful G → hasContrHoms IsoCommaᴰ₁
   hasContrHomsIsoCommaᴰ₁ G-ff f diso diso' = HomContr f diso diso' G-ff
@@ -171,7 +176,7 @@ module _ {C : Category ℓC ℓC'} {D : Category ℓD ℓD'}{E : Category ℓE �
             (E .⋆Assoc _ _ _ ∙ sym (⋆InvLMove (c≅d .snd) (sym sq1))))
             , tt)
           λ sq2 → Σ≡Prop (λ _ → hasPropHomsIsoCommaᴰ F G _ _ _) refl
-    
+
   hasPropHomsIsoCommaᴰ₂ : isFaithful F → hasPropHoms (IsoCommaᴰ₂ F G)
   hasPropHomsIsoCommaᴰ₂ F-faithful f diso diso' =
     isOfHLevelIC2Hom _ _ _ 1 (hasPropHomsIsoCommaᴰ₁ G F F-faithful _ _ _)

--- a/Cubical/Categories/Displayed/Constructions/FullSubcategory.agda
+++ b/Cubical/Categories/Displayed/Constructions/FullSubcategory.agda
@@ -59,6 +59,9 @@ module _ (C : Category ℓC ℓC') (P : Category.ob C → Type ℓP) where
   hasContrHomsFullSubcategory : hasContrHoms FullSubcategoryᴰ
   hasContrHomsFullSubcategory _ _ _ = isContrUnit
 
+  hasPropHomsFullSubcategory : hasPropHoms FullSubcategoryᴰ
+  hasPropHomsFullSubcategory _ _ _ = isPropUnit
+
   module _ {D : Category ℓD ℓD'} {Dᴰ : Categoryᴰ D ℓDᴰ ℓDᴰ'}
            (F : Functor D C)
            (F-obᴰ : {x : D .ob} →

--- a/Cubical/Categories/Functors/More.agda
+++ b/Cubical/Categories/Functors/More.agda
@@ -3,9 +3,12 @@
 module Cubical.Categories.Functors.More where
 
 open import Cubical.Foundations.Prelude
+open import Cubical.Data.Sigma
 open import Cubical.Categories.Category
 open import Cubical.Categories.Functor.Base
+open import Cubical.Categories.Functor.Compose
 open import Cubical.Categories.Functors.Constant
+open import Cubical.Categories.NaturalTransformation
 open import Cubical.Foundations.Equiv
 open import Cubical.Foundations.Equiv.Properties
 open import Cubical.Functions.Embedding
@@ -58,6 +61,40 @@ ActionOnMorphisms→Functor {F₀ = F₀} F₁ .F-ob = F₀
 ActionOnMorphisms→Functor {F₀ = F₀} F₁ .F-hom = F₁ .F-hom
 ActionOnMorphisms→Functor {F₀ = F₀} F₁ .F-id = F₁ .F-id
 ActionOnMorphisms→Functor {F₀ = F₀} F₁ .F-seq = F₁ .F-seq
+
+module _ {ℓC ℓC' ℓD ℓD' ℓE ℓE'}
+  {C : Category ℓC ℓC'} {D : Category ℓD ℓD'} {E : Category ℓE ℓE'}
+  {G : Functor D E}
+  (isFullyFaithfulG : isFullyFaithful G)
+  where
+
+  private
+    GFF : ∀ {x y} → D [ x , y ] ≃ E [ G ⟅ x ⟆ , G ⟅ y ⟆ ]
+    GFF = _ , (isFullyFaithfulG _ _)
+
+    GFaith : ∀ {x y} → (D [ x , y ]) ↪ (E [ G ⟅ x ⟆ , G ⟅ y ⟆ ])
+    GFaith = _ , isEquiv→isEmbedding (GFF .snd)
+    -- this would be convenient as FF.Reasoning
+    G-hom⁻ : ∀ {x y} → E [ G ⟅ x ⟆ , G ⟅ y ⟆ ] → D [ x , y ]
+    G-hom⁻ = invIsEq (isFullyFaithfulG _ _)
+
+
+  isFullyFaithfulPostcomposeF : isFullyFaithful (postcomposeF C G)
+  isFullyFaithfulPostcomposeF F F' .equiv-proof α =
+    uniqueExists
+      (natTrans (λ x → G-hom⁻ (α ⟦ x ⟧)) λ f →
+        isEmbedding→Inj (GFaith .snd) _ _
+        ( G .F-seq _ _
+        ∙ cong₂ (seq' E) refl (secEq GFF _)
+        ∙ α.N-hom _
+        ∙ sym (cong₂ (seq' E) (secEq GFF _) refl)
+        ∙ sym (G .F-seq _ _)))
+      (makeNatTransPath (funExt λ c → secIsEq (isFullyFaithfulG _ _) (α ⟦ c ⟧)))
+      (λ _ → isSetNatTrans _ _)
+      λ β G∘β≡α → makeNatTransPath (funExt λ c → isEmbedding→Inj (isEquiv→isEmbedding (isFullyFaithfulG _ _)) _ _
+        (secIsEq (isFullyFaithfulG _ _) _ ∙ sym (cong (_⟦ c ⟧) G∘β≡α)))
+
+    where module α = NatTrans α
 
 module _ {F : Functor C D} {G : Functor D E} where
   open Category

--- a/Cubical/Categories/Functors/More.agda
+++ b/Cubical/Categories/Functors/More.agda
@@ -91,7 +91,8 @@ module _ {ℓC ℓC' ℓD ℓD' ℓE ℓE'}
         ∙ sym (G .F-seq _ _)))
       (makeNatTransPath (funExt λ c → secIsEq (isFullyFaithfulG _ _) (α ⟦ c ⟧)))
       (λ _ → isSetNatTrans _ _)
-      λ β G∘β≡α → makeNatTransPath (funExt λ c → isEmbedding→Inj (isEquiv→isEmbedding (isFullyFaithfulG _ _)) _ _
+      λ β G∘β≡α → makeNatTransPath (funExt λ c →
+        isEmbedding→Inj (isEquiv→isEmbedding (isFullyFaithfulG _ _)) _ _
         (secIsEq (isFullyFaithfulG _ _) _ ∙ sym (cong (_⟦ c ⟧) G∘β≡α)))
 
     where module α = NatTrans α

--- a/Cubical/Categories/Instances/Sets/More.agda
+++ b/Cubical/Categories/Instances/Sets/More.agda
@@ -47,3 +47,7 @@ module _ {A}{B} (f : CatIso (SET ℓ) A B) a where
     ∙ transportRefl _
     ∙ transportRefl _
     ∙ cong (f .fst) (transportRefl _ ∙ transportRefl _ ))
+
+isFullyFaithfulLiftF : ∀ {ℓ ℓ'} → isFullyFaithful (LiftF {ℓ}{ℓ'})
+isFullyFaithfulLiftF x y =
+  isoToIsEquiv (iso _ (λ f x → f (lift x) .lower) (λ b → refl) λ _ → refl)

--- a/Cubical/Categories/NaturalTransformation/More.agda
+++ b/Cubical/Categories/NaturalTransformation/More.agda
@@ -96,6 +96,7 @@ module _ {B : Category ℓB ℓB'} {C : Category ℓC ℓC'} {D : Category ℓD 
   _∘ˡⁱ_ {G} {H} α F .trans = α .trans ∘ˡ F
   _∘ˡⁱ_ {G} {H} α F .nIso x = α .nIso (F ⟅ x ⟆)
 
-module _ {C : Category ℓC ℓC'} {D : Category ℓD ℓD'} {F G : Functor C D} (α : NatTrans F G) where
+module _ {C : Category ℓC ℓC'} {D : Category ℓD ℓD'} {F G : Functor C D}
+         (α : NatTrans F G) where
   isNatIso : Type _
   isNatIso = ∀ x → isIsoC D (α .N-ob x)

--- a/Cubical/Categories/NaturalTransformation/More.agda
+++ b/Cubical/Categories/NaturalTransformation/More.agda
@@ -95,3 +95,7 @@ module _ {B : Category ℓB ℓB'} {C : Category ℓC ℓC'} {D : Category ℓD 
         → NatIso (G ∘F F) (H ∘F F)
   _∘ˡⁱ_ {G} {H} α F .trans = α .trans ∘ˡ F
   _∘ˡⁱ_ {G} {H} α F .nIso x = α .nIso (F ⟅ x ⟆)
+
+module _ {C : Category ℓC ℓC'} {D : Category ℓD ℓD'} {F G : Functor C D} (α : NatTrans F G) where
+  isNatIso : Type _
+  isNatIso = ∀ x → isIsoC D (α .N-ob x)

--- a/Cubical/Categories/Presheaf/More.agda
+++ b/Cubical/Categories/Presheaf/More.agda
@@ -80,7 +80,7 @@ module UniversalElementNotation {ℓo}{ℓh}
        {C : Category ℓo ℓh} {ℓp} {P : Presheaf C ℓp}
        (ue : UniversalElement C P)
        where
-  open UniversalElement ue
+  open UniversalElement ue public
   open NatTrans
   open NatIso
   REPR : Representation C P

--- a/Cubical/Categories/Profunctor/FunctorComprehension.agda
+++ b/Cubical/Categories/Profunctor/FunctorComprehension.agda
@@ -24,6 +24,7 @@
 module Cubical.Categories.Profunctor.FunctorComprehension where
 
 open import Cubical.Foundations.Prelude
+open import Cubical.Foundations.Equiv
 open import Cubical.Foundations.HLevels
 
 open import Cubical.Data.Sigma
@@ -31,12 +32,15 @@ open import Cubical.Data.Unit
 
 open import Cubical.Categories.Category renaming (isIso to isIsoC)
 open import Cubical.Categories.Functor
+open import Cubical.Categories.Functors.More
 open import Cubical.Categories.Instances.Functors
 open import Cubical.Categories.NaturalTransformation
 open import Cubical.Categories.NaturalTransformation.More
 open import Cubical.Categories.Displayed.Constructions.FullSubcategory
 open import Cubical.Categories.Isomorphism.More
 open import Cubical.Categories.Instances.Sets
+open import Cubical.Categories.Instances.Sets.More
+open import Cubical.Categories.Constructions.BinProduct
 open import Cubical.Categories.Presheaf.Base
 open import Cubical.Categories.Presheaf.Properties
 open import Cubical.Categories.Presheaf.Representable
@@ -63,217 +67,274 @@ open Functor
 open UniversalElement
 open NatIso
 open NatTrans
+open isEquiv
 
 module _ (D : Category ℓD ℓD') (ℓS : Level) where
   private
     𝓟 = PresheafCategory D ℓS
     𝓟' = PresheafCategory D (ℓ-max ℓS ℓD')
-
-  -- Presheaves that have a universal element viewed as property
-  -- (morphisms ignore it).
-  --
-  -- A functor C → 𝓟up is equivalent to a functor R : C → 𝓟 and a
-  -- universal element for each R ⟅ c ⟆
-  --
-  -- An object over P is a universal element
-  -- Morphisms over nat trans. are trivial
-  𝓟up : Categoryᴰ 𝓟 (ℓ-max (ℓ-max ℓD ℓD') ℓS) ℓ-zero
-  𝓟up = FullSubcategoryᴰ 𝓟 (UniversalElement D)
-
-  hasContrHoms𝓟up : hasContrHoms 𝓟up
-  hasContrHoms𝓟up = hasContrHomsFullSubcategory _ _
-
-  App : D o-[ ℓS ]-* 𝓟
-  App = Profunctor→Relator Id
-
-  𝓟elt : Categoryᴰ 𝓟 _ _
-  𝓟elt = ∫Cᴰsl (Graph App)
-
-  𝓟usᴰ : Categoryᴰ (∫C 𝓟elt) _ _
-  𝓟usᴰ = FullSubcategoryᴰ _
-     (λ elt → isUniversal D (elt .fst)
-                            (elt .snd .fst)
-                            (elt .snd .snd))
-
-  -- Presheaves equipped with a universal element as structure
-  -- (morphisms preserve it)
-  --
-  -- A functor C → 𝓟us is the data of
-  -- 1. A functor R : C → 𝓟
-  -- 2. A functor F : C → D
-
-  -- 3. A *natural* choice of elements for R c (F c) with F c as
-  --    vertex
-  --
-  -- An object over P is a universal element η
-  --
-  -- Morphisms over nat trans α : P , η → Q , η' are morphisms
-  -- f : η .vertex → η' .vertex
-  -- That that "represent" α.
-  -- Since η, η' are universal, this type is contractible.
-  𝓟us : Categoryᴰ 𝓟 _ _
-  𝓟us = ∫Cᴰ 𝓟elt 𝓟usᴰ
-
-  -- | TODO: this should be definable as some composition of
-  -- | reassociativity and projection but need to implement those
-  -- | functors
-  ForgetUniversal : Functor (∫C 𝓟us) (∫C (Graph App))
-  ForgetUniversal .F-ob x =
-    ((x .snd .fst .fst) , (x .fst)) , (x .snd .fst .snd)
-  ForgetUniversal .F-hom α =
-    ((α .snd .fst .fst) , (α .fst)) , (α .snd .fst .snd)
-  ForgetUniversal .F-id = refl
-  ForgetUniversal .F-seq _ _ = refl
-
-  𝓟us→D : Functor (∫C 𝓟us) D
-  𝓟us→D = π₁ App ∘F ForgetUniversal
-
-  hasContrHoms𝓟us : hasContrHoms 𝓟us
-  hasContrHoms𝓟us {c' = Q} α ((d , η) , univ) ((d' , η') , univ') =
-    (((ue'.intro ((α ⟦ _ ⟧) η)) , ue'.β) , _)
-    , λ ((g , sq) , tt) → Σ≡Prop (λ _ → isPropUnit)
-      (Σ≡Prop (λ _ → (Q ⟅ _ ⟆) .snd _ _)
-      (sym (ue'.η ∙ cong ue'.intro sq)))
-    where
-      module ue  = UniversalElementNotation
-        (record { vertex = d ; element = η ; universal = univ })
-      module ue' = UniversalElementNotation
-        (record { vertex = d' ; element = η' ; universal = univ' })
-
-  coherence : Functorᴰ Id 𝓟up 𝓟us
-  coherence = mkFunctorᴰContrHoms hasContrHoms𝓟us
-    (λ ue → (ue .vertex , (ue .element)) , (ue .universal))
-
-  -- Presheaves equipped with a representation viewed as
-  -- structure
-  --
-  -- A functor C → 𝓟rs is the data of
-  -- 1. A functor R : C → 𝓟
-  -- 2. A functor F : C → D
-  -- 3. A natural iso LiftF ∘F R ≅ LiftF ∘F Yo ∘F F
-  --
-  -- An object over P is an iso P ≅ Yo c
-  --
-  -- Morphisms over nat trans α : P , iso → Q , iso' are morphisms
-  -- f : iso .cod → iso' .cod
-  -- That that commute: iso' ∘ Yo f ≡ α ∘ iso
-  -- because Yo is fully faithful, this is contractible.
-  private
     LiftPsh = (postcomposeF (D ^op) (LiftF {ℓS}{ℓD'}))
     YO* = (postcomposeF (D ^op) (LiftF {ℓD'}{ℓS}) ∘F YO)
+    isFullyFaithfulYO* : isFullyFaithful YO*
+    isFullyFaithfulYO* = isFullyFaithfulG∘F
+      {G = postcomposeF (D ^op) (LiftF {ℓD'}{ℓS})}
+      isFullyFaithfulYO
+      (isFullyFaithfulPostcomposeF isFullyFaithfulLiftF)
+    Elt : Categoryᴰ (D ×C 𝓟) _ _
+    Elt = Graph (Profunctor→Relator Id)
 
-  𝓟r : Categoryᴰ 𝓟 _ _
-  𝓟r = IsoCommaᴰ₁ LiftPsh YO*
+    UElt : Categoryᴰ (D ×C 𝓟) _ _
+    UElt = ∫Cᴰ Elt (FullSubcategoryᴰ _ λ ((d , p), e) → isUniversal D p d e)
 
-  open Functorᴰ
+    module UElt = Categoryᴰ UElt
 
-  𝓟us→𝓟r : Functorᴰ Id 𝓟us 𝓟r
-  𝓟us→𝓟r =
-    mk∫ᴰsrFunctorᴰ
-      _
-      Id
-      𝓟us→Weaken𝓟D
-      Unitᴰ∫C𝓟us→IsoCommaᴰ
-    where
-    𝓟us→Weaken𝓟D : Functorᴰ Id 𝓟us (weaken 𝓟 D)
-    𝓟us→Weaken𝓟D .F-obᴰ xᴰ = xᴰ .fst .fst
-    𝓟us→Weaken𝓟D .F-homᴰ fᴰ = fᴰ .fst .fst
-    𝓟us→Weaken𝓟D .F-idᴰ = refl
-    𝓟us→Weaken𝓟D .F-seqᴰ _ _ = refl
+    Y⇒  : Categoryᴰ (D ×C 𝓟) _ _
+    Y⇒  = Graph (HomBif 𝓟' ∘Flr ((YO* ^opF) , LiftPsh))
 
-    Unitᴰ∫C𝓟us→IsoCommaᴰ :
-      Functorᴰ (∫F 𝓟us→Weaken𝓟D) _ _
-    Unitᴰ∫C𝓟us→IsoCommaᴰ = mkFunctorᴰPropHoms (hasPropHomsIsoCommaᴰ _ _)
-      (λ {(P , ((vert , elt) , isUniversal))} tt →
-        let open UniversalElementNotation (record { vertex = vert ;
-                                                    element = elt ;
-                                                    universal = isUniversal })
-        in NatIso→FUNCTORIso _ _ introNI)
-      λ {(P , ((vertP , eltP) , isUniversalP))
-        ((Q , ((vertQ , eltQ) , isUniversalQ))) (α , ((f , sq) , tt)) _ _} tt →
-        let module ueP = UniversalElementNotation (record {
-                                                    vertex = vertP ;
-                                                    element = eltP ;
-                                                    universal = isUniversalP })
-            module ueQ = UniversalElementNotation (record {
-                                                    vertex = vertQ ;
-                                                    element = eltQ ;
-                                                    universal = isUniversalQ })
-        in
-        -- The goal is
-        -- α ⋆ ueQ.introNI .trans ≡ ueP.introNI .trans ⋆ Yo* ⟪ f ⟫
-        -- It is easier to prove in the equivalent form
-        -- inv ueP.introNI ⋆ α ≡ Yo* ⟪ f ⟫ ⋆ inv ueQ.introNI
-        sym (⋆InvsFlipSq⁻ {C = 𝓟'} (NatIso→FUNCTORIso _ _ ueP.introNI)
-          {LiftPsh ⟪ α ⟫}{YO* ⟪ f ⟫} (NatIso→FUNCTORIso _ _ ueQ.introNI)
-          (makeNatTransPath (funExt λ d → funExt λ (lift g) → cong lift
-            (funExt⁻ (Q .F-seq _ _) eltQ
-            ∙ cong (Q .F-hom g) sq
-            ∙ sym (funExt⁻ (α .N-hom _) _)))))
-        , tt
+    Y≅  : Categoryᴰ (D ×C 𝓟) _ _
+    Y≅  = ∫Cᴰ Y⇒ (FullSubcategoryᴰ _ λ ((d , p), α) → isNatIso α)
 
-module _ {C : Category ℓC ℓC'}{D : Category ℓD ℓD'}
-         {P : Profunctor C D ℓS}
-         (ues : UniversalElements P)
-         where
-  private
-    Pup : Functor C (∫C (𝓟up D ℓS))
-    Pup = mk∫Functor P (mkFullSubcategoryᴰFunctorᴰ _ _ _ (λ _ → ues _))
+    IncoherentElt : Categoryᴰ (D ×C 𝓟) _ _
+    IncoherentElt = FullSubcategoryᴰ _ UElt.ob[_]
 
-    Pus : Functor C (∫C (𝓟us D ℓS))
-    Pus = ∫F (coherence D ℓS) ∘F Pup
+    HasUniversalElt : Categoryᴰ 𝓟 _ _
+    HasUniversalElt = ∫Cᴰsl IncoherentElt
 
-    Pr : Functor C (∫C (𝓟r D ℓS))
-    Pr = ∫F (𝓟us→𝓟r D ℓS) ∘F Pus
+    WithUniversalElt : Categoryᴰ 𝓟 _ _
+    WithUniversalElt = ∫Cᴰsl UElt
 
-    P-elt : Functor C (∫C (Graph (App D ℓS)))
-    P-elt = ForgetUniversal D ℓS ∘F Pus
+    hasContrHomsWUE : hasContrHoms WithUniversalElt
+    hasContrHomsWUE {P}{Q} α ueP ueQ =
+      uniqueExists
+        (ueQ.intro ((α ⟦ _ ⟧) ueP.element))
+        (ueQ.β , tt)
+        (λ _ → {!!})
+        λ f (f◃α , tt) → sym (ueQ.η ∙ cong ueQ.intro f◃α)
+      where
+        ueP' : UniversalElement _ P
+        ueP' = record { vertex = ueP .fst ; element = ueP .snd .fst ; universal = ueP .snd .snd }
+        module ueP = UniversalElementNotation ueP'
+        ueQ' : UniversalElement _ Q
+        ueQ' = record { vertex = ueQ .fst ; element = ueQ .snd .fst ; universal = ueQ .snd .snd }
+        module ueQ = UniversalElementNotation ueQ'
 
-    -- We define R (d , c) := P c d
-    R = Profunctor→Relator P
+    Representation' : Categoryᴰ 𝓟 _ _
+    Representation' = ∫Cᴰsl Y≅
 
-  FunctorComprehension : Functor C D
-  FunctorComprehension = π₁ (App D ℓS) ∘F P-elt
+    hasContrHomsRepr : hasContrHoms Representation'
+    hasContrHomsRepr {P}{Q} α d≅P d'≅Q =
+      -- This is equivalent to the type of 
+      isContrRetract
+        {!!}
+        {!!}
+        {!!}
+        (isFullyFaithfulYO* (d≅P .fst) (d'≅Q .fst) .equiv-proof
+          (d⇒P ⋆⟨ 𝓟' ⟩ LiftPsh ⟪ α ⟫ ⋆⟨ 𝓟' ⟩ d'⇐Q) )
+      where d⇒P = d≅P .snd .fst
+            d'⇐Q = symNatIso (record { trans = d'≅Q .snd .fst ; nIso = d'≅Q .snd .snd }) .trans
 
-  -- The profunctor here is definitionally iso to R(F -, =), as we see below
-  counit-elt' : NatElt ((App D ℓS) ∘Flr ((π₁ (App D ℓS) ^opF) ,
-                        π₂ (App D ℓS)) ∘Flr ((P-elt ^opF) , P-elt))
-  counit-elt' = whisker (πElt (App D ℓS)) P-elt
+--   -- Presheaves that have a universal element viewed as property
+--   -- (morphisms ignore it).
+--   --
+--   -- A functor C → 𝓟up is equivalent to a functor R : C → 𝓟 and a
+--   -- universal element for each R ⟅ c ⟆
+--   --
+--   -- An object over P is a universal element
+--   -- Morphisms over nat trans. are trivial
+--   𝓟up : Categoryᴰ 𝓟 (ℓ-max (ℓ-max ℓD ℓD') ℓS) ℓ-zero
+--   𝓟up = FullSubcategoryᴰ 𝓟 (UniversalElement D)
 
-  open NatElt
-  -- ∀ c . R (F ⟅ c ⟆) c, naturally
-  counit-elt : NatElt (R ∘Fl (FunctorComprehension ^opF))
-  counit-elt .N-ob = counit-elt' .N-ob
-  counit-elt .N-hom× = counit-elt' .N-hom×
-  counit-elt .N-ob-hom×-agree = counit-elt' .N-ob-hom×-agree
-  counit-elt .N-natL = counit-elt' .N-natL
-  counit-elt .N-natR = counit-elt' .N-natR
+--   hasContrHoms𝓟up : hasContrHoms 𝓟up
+--   hasContrHoms𝓟up = hasContrHomsFullSubcategory _ _
 
-  private
-    -- Test to show that counit-elt matches the original universal element
+--   App : D o-[ ℓS ]-* 𝓟
+--   App = Profunctor→Relator Id
 
-    -- This demonstrates that the selection of universal elements is
-    -- natural with respect to the functorial action constructed from
-    -- universality
-    test-counit-elt-def : ∀ c → counit-elt .N-ob c ≡ ues c .element
-    test-counit-elt-def c = refl
+--   𝓟elt : Categoryᴰ 𝓟 _ _
+--   𝓟elt = ∫Cᴰsl (Graph App)
 
-    LiftPsh = (postcomposeF (D ^op) (LiftF {ℓS}{ℓD'}))
-    YO* = (postcomposeF (D ^op) (LiftF {ℓD'}{ℓS}) ∘F YO)
+--   𝓟usᴰ : Categoryᴰ (∫C 𝓟elt) _ _
+--   𝓟usᴰ = FullSubcategoryᴰ _
+--      (λ elt → isUniversal D (elt .fst)
+--                             (elt .snd .fst)
+--                             (elt .snd .snd))
 
-    ReAssoc : Functor (∫C (𝓟r D ℓS)) (IsoComma LiftPsh YO*)
-    ReAssoc = Assoc-sr⁻ (IsoCommaᴰ LiftPsh YO*)
+--   -- Presheaves equipped with a universal element as structure
+--   -- (morphisms preserve it)
+--   --
+--   -- A functor C → 𝓟us is the data of
+--   -- 1. A functor R : C → 𝓟
+--   -- 2. A functor F : C → D
 
-    P-iso : Functor C (∫C (IsoCommaᴰ LiftPsh YO*))
-    P-iso =
-      Assoc-sr⁻ (IsoCommaᴰ LiftPsh YO*)
-      ∘F ∫F (𝓟us→𝓟r D ℓS)
-      ∘F Pus
+--   -- 3. A *natural* choice of elements for R c (F c) with F c as
+--   --    vertex
+--   --
+--   -- An object over P is a universal element η
+--   --
+--   -- Morphisms over nat trans α : P , η → Q , η' are morphisms
+--   -- f : η .vertex → η' .vertex
+--   -- That that "represent" α.
+--   -- Since η, η' are universal, this type is contractible.
+--   𝓟us : Categoryᴰ 𝓟 _ _
+--   𝓟us = ∫Cᴰ 𝓟elt 𝓟usᴰ
 
-  ProfIso' : NatIso _ _
-  ProfIso' = π≅ LiftPsh YO* ∘ˡⁱ P-iso
+--   -- | TODO: this should be definable as some composition of
+--   -- | reassociativity and projection but need to implement those
+--   -- | functors
+--   ForgetUniversal : Functor (∫C 𝓟us) (∫C (Graph App))
+--   ForgetUniversal .F-ob x =
+--     ((x .snd .fst .fst) , (x .fst)) , (x .snd .fst .snd)
+--   ForgetUniversal .F-hom α =
+--     ((α .snd .fst .fst) , (α .fst)) , (α .snd .fst .snd)
+--   ForgetUniversal .F-id = refl
+--   ForgetUniversal .F-seq _ _ = refl
 
-  ProfIso : NatIso (LiftPsh ∘F P) (YO* ∘F FunctorComprehension)
-  ProfIso .trans .N-ob = ProfIso' .trans .N-ob
-  ProfIso .trans .N-hom = ProfIso' .trans .N-hom
-  ProfIso .nIso = ProfIso' .nIso
+--   𝓟us→D : Functor (∫C 𝓟us) D
+--   𝓟us→D = π₁ App ∘F ForgetUniversal
+
+--   hasContrHoms𝓟us : hasContrHoms 𝓟us
+--   hasContrHoms𝓟us {c' = Q} α ((d , η) , univ) ((d' , η') , univ') =
+--     (((ue'.intro ((α ⟦ _ ⟧) η)) , ue'.β) , _)
+--     , λ ((g , sq) , tt) → Σ≡Prop (λ _ → isPropUnit)
+--       (Σ≡Prop (λ _ → (Q ⟅ _ ⟆) .snd _ _)
+--       (sym (ue'.η ∙ cong ue'.intro sq)))
+--     where
+--       module ue  = UniversalElementNotation
+--         (record { vertex = d ; element = η ; universal = univ })
+--       module ue' = UniversalElementNotation
+--         (record { vertex = d' ; element = η' ; universal = univ' })
+
+--   coherence : Functorᴰ Id 𝓟up 𝓟us
+--   coherence = mkFunctorᴰContrHoms hasContrHoms𝓟us
+--     (λ ue → (ue .vertex , (ue .element)) , (ue .universal))
+
+--   -- Presheaves equipped with a representation viewed as
+--   -- structure
+--   --
+--   -- A functor C → 𝓟rs is the data of
+--   -- 1. A functor R : C → 𝓟
+--   -- 2. A functor F : C → D
+--   -- 3. A natural iso LiftF ∘F R ≅ LiftF ∘F Yo ∘F F
+--   --
+--   -- An object over P is an iso P ≅ Yo c
+--   --
+--   -- Morphisms over nat trans α : P , iso → Q , iso' are morphisms
+--   -- f : iso .cod → iso' .cod
+--   -- That that commute: iso' ∘ Yo f ≡ α ∘ iso
+--   -- because Yo is fully faithful, this is contractible.
+
+--   𝓟r : Categoryᴰ 𝓟 _ _
+--   𝓟r = IsoCommaᴰ₁ LiftPsh YO*
+
+--   open Functorᴰ
+
+--   𝓟us→𝓟r : Functorᴰ Id 𝓟us 𝓟r
+--   𝓟us→𝓟r =
+--     mk∫ᴰsrFunctorᴰ
+--       _
+--       Id
+--       𝓟us→Weaken𝓟D
+--       Unitᴰ∫C𝓟us→IsoCommaᴰ
+--     where
+--     𝓟us→Weaken𝓟D : Functorᴰ Id 𝓟us (weaken 𝓟 D)
+--     𝓟us→Weaken𝓟D .F-obᴰ xᴰ = xᴰ .fst .fst
+--     𝓟us→Weaken𝓟D .F-homᴰ fᴰ = fᴰ .fst .fst
+--     𝓟us→Weaken𝓟D .F-idᴰ = refl
+--     𝓟us→Weaken𝓟D .F-seqᴰ _ _ = refl
+
+--     Unitᴰ∫C𝓟us→IsoCommaᴰ :
+--       Functorᴰ (∫F 𝓟us→Weaken𝓟D) _ _
+--     Unitᴰ∫C𝓟us→IsoCommaᴰ = mkFunctorᴰPropHoms (hasPropHomsIsoCommaᴰ _ _)
+--       (λ {(P , ((vert , elt) , isUniversal))} tt →
+--         let open UniversalElementNotation (record { vertex = vert ;
+--                                                     element = elt ;
+--                                                     universal = isUniversal })
+--         in NatIso→FUNCTORIso _ _ introNI)
+--       λ {(P , ((vertP , eltP) , isUniversalP))
+--         ((Q , ((vertQ , eltQ) , isUniversalQ))) (α , ((f , sq) , tt)) _ _} tt →
+--         let module ueP = UniversalElementNotation (record {
+--                                                     vertex = vertP ;
+--                                                     element = eltP ;
+--                                                     universal = isUniversalP })
+--             module ueQ = UniversalElementNotation (record {
+--                                                     vertex = vertQ ;
+--                                                     element = eltQ ;
+--                                                     universal = isUniversalQ })
+--         in
+--         -- The goal is
+--         -- α ⋆ ueQ.introNI .trans ≡ ueP.introNI .trans ⋆ Yo* ⟪ f ⟫
+--         -- It is easier to prove in the equivalent form
+--         -- inv ueP.introNI ⋆ α ≡ Yo* ⟪ f ⟫ ⋆ inv ueQ.introNI
+--         sym (⋆InvsFlipSq⁻ {C = 𝓟'} (NatIso→FUNCTORIso _ _ ueP.introNI)
+--           {LiftPsh ⟪ α ⟫}{YO* ⟪ f ⟫} (NatIso→FUNCTORIso _ _ ueQ.introNI)
+--           (makeNatTransPath (funExt λ d → funExt λ (lift g) → cong lift
+--             (funExt⁻ (Q .F-seq _ _) eltQ
+--             ∙ cong (Q .F-hom g) sq
+--             ∙ sym (funExt⁻ (α .N-hom _) _)))))
+--         , tt
+
+-- module _ {C : Category ℓC ℓC'}{D : Category ℓD ℓD'}
+--          {P : Profunctor C D ℓS}
+--          (ues : UniversalElements P)
+--          where
+--   private
+--     Pup : Functor C (∫C (𝓟up D ℓS))
+--     Pup = mk∫Functor P (mkFullSubcategoryᴰFunctorᴰ _ _ _ (λ _ → ues _))
+
+--     Pus : Functor C (∫C (𝓟us D ℓS))
+--     Pus = ∫F (coherence D ℓS) ∘F Pup
+
+--     Pr : Functor C (∫C (𝓟r D ℓS))
+--     Pr = ∫F (𝓟us→𝓟r D ℓS) ∘F Pus
+
+--     P-elt : Functor C (∫C (Graph (App D ℓS)))
+--     P-elt = ForgetUniversal D ℓS ∘F Pus
+
+--     -- We define R (d , c) := P c d
+--     R = Profunctor→Relator P
+
+--   FunctorComprehension : Functor C D
+--   FunctorComprehension = π₁ (App D ℓS) ∘F P-elt
+
+--   -- The profunctor here is definitionally iso to R(F -, =), as we see below
+--   counit-elt' : NatElt ((App D ℓS) ∘Flr ((π₁ (App D ℓS) ^opF) ,
+--                         π₂ (App D ℓS)) ∘Flr ((P-elt ^opF) , P-elt))
+--   counit-elt' = whisker (πElt (App D ℓS)) P-elt
+
+--   open NatElt
+--   -- ∀ c . R (F ⟅ c ⟆) c, naturally
+--   counit-elt : NatElt (R ∘Fl (FunctorComprehension ^opF))
+--   counit-elt .N-ob = counit-elt' .N-ob
+--   counit-elt .N-hom× = counit-elt' .N-hom×
+--   counit-elt .N-ob-hom×-agree = counit-elt' .N-ob-hom×-agree
+--   counit-elt .N-natL = counit-elt' .N-natL
+--   counit-elt .N-natR = counit-elt' .N-natR
+
+--   private
+--     -- Test to show that counit-elt matches the original universal element
+
+--     -- This demonstrates that the selection of universal elements is
+--     -- natural with respect to the functorial action constructed from
+--     -- universality
+--     test-counit-elt-def : ∀ c → counit-elt .N-ob c ≡ ues c .element
+--     test-counit-elt-def c = refl
+
+--     LiftPsh = (postcomposeF (D ^op) (LiftF {ℓS}{ℓD'}))
+--     YO* = (postcomposeF (D ^op) (LiftF {ℓD'}{ℓS}) ∘F YO)
+
+--     ReAssoc : Functor (∫C (𝓟r D ℓS)) (IsoComma LiftPsh YO*)
+--     ReAssoc = Assoc-sr⁻ (IsoCommaᴰ LiftPsh YO*)
+
+--     P-iso : Functor C (∫C (IsoCommaᴰ LiftPsh YO*))
+--     P-iso =
+--       Assoc-sr⁻ (IsoCommaᴰ LiftPsh YO*)
+--       ∘F ∫F (𝓟us→𝓟r D ℓS)
+--       ∘F Pus
+
+--   ProfIso' : NatIso _ _
+--   ProfIso' = π≅ LiftPsh YO* ∘ˡⁱ P-iso
+
+--   ProfIso : NatIso (LiftPsh ∘F P) (YO* ∘F FunctorComprehension)
+--   ProfIso .trans .N-ob = ProfIso' .trans .N-ob
+--   ProfIso .trans .N-hom = ProfIso' .trans .N-hom
+--   ProfIso .nIso = ProfIso' .nIso

--- a/Cubical/Categories/Profunctor/FunctorComprehension.agda
+++ b/Cubical/Categories/Profunctor/FunctorComprehension.agda
@@ -129,9 +129,7 @@ module _ (D : Category ℓD ℓD') (ℓS : Level) where
     Representation' = IsoCommaᴰ₂ YO* LiftPsh
 
     hasContrHomsRepr : hasContrHoms Representation'
-    hasContrHomsRepr =
-      hasContrHomsIsoCommaᴰ₂ YO* LiftPsh isFullyFaithfulYO*
-
+    hasContrHomsRepr = hasContrHomsIsoCommaᴰ₂ YO* LiftPsh isFullyFaithfulYO*
 
   -- Presheaves that have a universal element viewed as property
   -- (morphisms ignore it).
@@ -186,10 +184,14 @@ module _ (D : Category ℓD ℓD') (ℓS : Level) where
   -- because Yo is fully faithful, this is contractible.
   𝓟rs = ∫C Representation'
 
+  -- Part 1: functoriality comes for free from contractibility
   coherence : Functor 𝓟up 𝓟us
   coherence = ∫F {F = Id} (mkFunctorᴰContrHoms hasContrHomsWUE λ ue →
     ue .vertex , ue .element , ue .universal)
 
+  -- Part 2: this is one direction of the equivalence between
+  -- universal elements and representations, extended to a functor.
+  --
   -- For this definition, we use mkFunctorᴰContrHoms' and
   -- change-contractum to ensure we get the "efficient" definition
   -- out.
@@ -226,8 +228,8 @@ module _ {C : Category ℓC ℓC'}{D : Category ℓD ℓD'}
     Pus : Functor C (𝓟us D ℓS)
     Pus = coherence D ℓS ∘F Pup
 
-    Pr : Functor C (𝓟rs D ℓS)
-    Pr = unYoneda D ℓS ∘F Pus
+    Prs : Functor C (𝓟rs D ℓS)
+    Prs = unYoneda D ℓS ∘F Pus
 
     P-elt : Functor C (∫C {C = D ×C PresheafCategory D ℓS}
                           (Graph (Profunctor→Relatoro* Id)))
@@ -235,7 +237,7 @@ module _ {C : Category ℓC ℓC'}{D : Category ℓD ℓD'}
 
     App : D o-[ ℓS ]-* 𝓟
     App = Profunctor→Relatoro* Id
-    -- We define R (d , c) := P c d
+
     R = Profunctor→Relatoro* P
 
   FunctorComprehension : Functor C D
@@ -271,7 +273,7 @@ module _ {C : Category ℓC ℓC'}{D : Category ℓD ℓD'}
     ReAssoc = Assoc-sl⁻ (IsoCommaᴰ YO* LiftPsh)
 
     P-iso : Functor C (∫C (IsoCommaᴰ YO* LiftPsh))
-    P-iso = Assoc-sl⁻ (IsoCommaᴰ YO* LiftPsh) ∘F Pr
+    P-iso = Assoc-sl⁻ (IsoCommaᴰ YO* LiftPsh) ∘F Prs
 
   ProfIso' : NatIso _ _
   ProfIso' = π≅ YO* LiftPsh ∘ˡⁱ P-iso

--- a/Cubical/Categories/Profunctor/FunctorComprehension.agda
+++ b/Cubical/Categories/Profunctor/FunctorComprehension.agda
@@ -159,15 +159,6 @@ module _ (D : Category ℓD ℓD') (ℓS : Level) where
   -- Since η, η' are universal, this type is contractible
   𝓟us = ∫C WithUniversalElt
 
-  -- | TODO: this should be definable as some composition of
-  -- | reassociativity and projection but need to implement those
-  -- | functors
-  ForgetUniversal : Functor 𝓟us (∫C Elt)
-  ForgetUniversal .F-ob x = (x .snd .fst , (x .fst)) , (x .snd .snd .fst)
-  ForgetUniversal .F-hom α = (α .snd .fst , (α .fst)) , (α .snd .snd .fst)
-  ForgetUniversal .F-id = refl
-  ForgetUniversal .F-seq _ _ = refl
-
   -- Presheaves equipped with a representation viewed as
   -- structure
   --
@@ -215,6 +206,15 @@ module _ (D : Category ℓD ℓD') (ℓS : Level) where
       change-contractum (hasContrHomsRepr α _ _) (f ,
         cong d-UE.intro ((cong (α ⟦ c ⟧) (funExt⁻ (P .F-id) ηP)) ∙ sym f-sq)
         ∙ sym d-UE.η))
+
+  -- | TODO: this should be definable as some composition of
+  -- | reassociativity and projection but need to implement those
+  -- | functors
+  ForgetUniversal : Functor 𝓟us (∫C Elt)
+  ForgetUniversal .F-ob x = (x .snd .fst , (x .fst)) , (x .snd .snd .fst)
+  ForgetUniversal .F-hom α = (α .snd .fst , (α .fst)) , (α .snd .snd .fst)
+  ForgetUniversal .F-id = refl
+  ForgetUniversal .F-seq _ _ = refl
 
 module _ {C : Category ℓC ℓC'}{D : Category ℓD ℓD'}
          {P : Profunctor C D ℓS}

--- a/Cubical/Categories/Profunctor/FunctorComprehension.agda
+++ b/Cubical/Categories/Profunctor/FunctorComprehension.agda
@@ -73,26 +73,24 @@ module _ (D : Category ℓD ℓD') (ℓS : Level) where
   private
     𝓟 = PresheafCategory D ℓS
     𝓟' = PresheafCategory D (ℓ-max ℓS ℓD')
+
+    -- This should probably be in Yoneda.agda
     LiftPsh = (postcomposeF (D ^op) (LiftF {ℓS}{ℓD'}))
     YO* = (postcomposeF (D ^op) (LiftF {ℓD'}{ℓS}) ∘F YO)
+
     isFullyFaithfulYO* : isFullyFaithful YO*
     isFullyFaithfulYO* = isFullyFaithfulG∘F
       {G = postcomposeF (D ^op) (LiftF {ℓD'}{ℓS})}
       isFullyFaithfulYO
       (isFullyFaithfulPostcomposeF isFullyFaithfulLiftF)
+
     Elt : Categoryᴰ (D ×C 𝓟) _ _
-    Elt = Graph (Profunctor→Relator Id)
+    Elt = Graph (Profunctor→Relatoro* Id)
 
     UElt : Categoryᴰ (D ×C 𝓟) _ _
     UElt = ∫Cᴰ Elt (FullSubcategoryᴰ _ λ ((d , p), e) → isUniversal D p d e)
 
     module UElt = Categoryᴰ UElt
-
-    Y⇒  : Categoryᴰ (D ×C 𝓟) _ _
-    Y⇒  = Graph (HomBif 𝓟' ∘Flr ((YO* ^opF) , LiftPsh))
-
-    Y≅  : Categoryᴰ (D ×C 𝓟) _ _
-    Y≅  = ∫Cᴰ Y⇒ (FullSubcategoryᴰ _ λ ((d , p), α) → isNatIso α)
 
     IncoherentElt : Categoryᴰ (D ×C 𝓟) _ _
     IncoherentElt = FullSubcategoryᴰ _ UElt.ob[_]
@@ -108,7 +106,7 @@ module _ (D : Category ℓD ℓD') (ℓS : Level) where
       uniqueExists
         (ueQ.intro ((α ⟦ _ ⟧) ueP.element))
         (ueQ.β , tt)
-        (λ _ → {!!})
+        (λ _ → isProp× (Q .F-ob _ .snd _ _) isPropUnit)
         λ f (f◃α , tt) → sym (ueQ.η ∙ cong ueQ.intro f◃α)
       where
         ueP' : UniversalElement _ P
@@ -119,19 +117,29 @@ module _ (D : Category ℓD ℓD') (ℓS : Level) where
         module ueQ = UniversalElementNotation ueQ'
 
     Representation' : Categoryᴰ 𝓟 _ _
-    Representation' = ∫Cᴰsl Y≅
+    Representation' = IsoCommaᴰ₂ YO* LiftPsh
 
     hasContrHomsRepr : hasContrHoms Representation'
-    hasContrHomsRepr {P}{Q} α d≅P d'≅Q =
-      -- This is equivalent to the type of 
-      isContrRetract
-        {!!}
-        {!!}
-        {!!}
-        (isFullyFaithfulYO* (d≅P .fst) (d'≅Q .fst) .equiv-proof
-          (d⇒P ⋆⟨ 𝓟' ⟩ LiftPsh ⟪ α ⟫ ⋆⟨ 𝓟' ⟩ d'⇐Q) )
-      where d⇒P = d≅P .snd .fst
-            d'⇐Q = symNatIso (record { trans = d'≅Q .snd .fst ; nIso = d'≅Q .snd .snd }) .trans
+    hasContrHomsRepr =
+      hasContrHomsIsoCommaᴰ₂ YO* LiftPsh isFullyFaithfulYO*
+
+    -- 𝓟up = ∫Cᴰsr IncoherentElt
+    -- hasContrHomsRepr : hasContrHoms Representation'
+    -- hasContrHomsRepr {P}{Q} α d≅P d'≅Q =
+    --   isContrRetract
+    --     (λ (f , sq⇒⇒)  → f , {!!})
+    --     (λ (f , inFib) → f , {!!})
+    --     (λ _ → Σ≡Prop (λ _ → hasPropHomsY≅ _ _ _) refl)
+    --     (isFullyFaithfulYO* (d≅P .fst) (d'≅Q .fst) .equiv-proof
+    --       (isodP .fst ⋆⟨ 𝓟' ⟩ LiftPsh ⟪ α ⟫ ⋆⟨ 𝓟' ⟩ d'⇐Q) )
+    --   where
+    --     isodP : CatIso 𝓟' (YO* ⟅ d≅P .fst ⟆) (LiftPsh ⟅ P ⟆ )
+    --     isodP = NatIso→FUNCTORIso (D ^op) _ (record { trans = d≅P .snd .fst ; nIso = d≅P .snd .snd })
+    --     module isIsodP = isIsoC (isodP .snd)
+    --     isodQ : CatIso 𝓟' (YO* ⟅ d'≅Q .fst ⟆) (LiftPsh ⟅ Q ⟆ )
+    --     isodQ = NatIso→FUNCTORIso (D ^op) _ (record { trans = d'≅Q .snd .fst ; nIso = d'≅Q .snd .snd })
+    --     d⇒P = d≅P .snd .fst
+    --     d'⇐Q = symNatIso (record { trans = d'≅Q .snd .fst ; nIso = d'≅Q .snd .snd }) .trans
 
 --   -- Presheaves that have a universal element viewed as property
 --   -- (morphisms ignore it).

--- a/Cubical/Categories/Profunctor/FunctorComprehension.agda
+++ b/Cubical/Categories/Profunctor/FunctorComprehension.agda
@@ -2,20 +2,23 @@
 {--
  -- Functor Comprehension
  -- ======================
- -- This module provides a method for constructing functors without
- -- providing the full functorial structure up front.
+ -- This module provides a method for constructing functors by showing
+ -- that they have a universal property.
  --
- -- The idea is that if you wish to define a functor F : C → D, via
- -- some universal property P. Instead of doing this process entirely
- -- manually, you can prove the functoriality of the universal property P
- -- and give for each c ∈ C some object F c ∈ D satisfying the property
- -- P c.
+ -- The idea is that if you wish to define a functor F : C → D via a
+ -- universal property (P c), then the functoriality of F comes for
+ -- free if the universal property P is given functorially, that is if
+ -- P is a functor P : C → Psh D
  --
- -- Conveniently, we need only provide an explicit action on objects. The
- -- functoriality of P induces a unique action on morphisms.
+ -- That is, if you construct for each c a universal element of P c,
+ -- then this can be *uniquely* extended to a functorial action on
+ -- morphisms, and furthermore you get that the universal elements so
+ -- constructed are natural with respect to this functorial action.
+ -- We provide this data in this module in two equivalent forms:
+ -- 1. A "natural element" ∀ c → P c (F c)
+ -- 2. A natural isomorphism (Y ∘ F ≅ P)
  --
- -- Putting all of this together, the action on objects can then
- -- uniquely be extended functorially to a functor F : C → D.
+ -- The fact is essentially a corollary of the Yoneda lemma, but we 
  --
  -- Constructing a functor in this method saves a lot of work in
  -- repeatedly demonstrating functoriality
@@ -28,11 +31,13 @@ open import Cubical.Foundations.Equiv
 open import Cubical.Foundations.HLevels
 
 open import Cubical.Data.Sigma
+open import Cubical.Data.Sigma.More
 open import Cubical.Data.Unit
 
 open import Cubical.Categories.Category renaming (isIso to isIsoC)
 open import Cubical.Categories.Functor
 open import Cubical.Categories.Functors.More
+open import Cubical.Categories.Isomorphism
 open import Cubical.Categories.Instances.Functors
 open import Cubical.Categories.NaturalTransformation
 open import Cubical.Categories.NaturalTransformation.More
@@ -95,10 +100,10 @@ module _ (D : Category ℓD ℓD') (ℓS : Level) where
     IncoherentElt : Categoryᴰ (D ×C 𝓟) _ _
     IncoherentElt = FullSubcategoryᴰ _ UElt.ob[_]
 
+
     HasUniversalElt : Categoryᴰ 𝓟 _ _
     HasUniversalElt = ∫Cᴰsl IncoherentElt
 
-    WithUniversalElt : Categoryᴰ 𝓟 _ _
     WithUniversalElt = ∫Cᴰsl UElt
 
     hasContrHomsWUE : hasContrHoms WithUniversalElt
@@ -123,163 +128,74 @@ module _ (D : Category ℓD ℓD') (ℓS : Level) where
     hasContrHomsRepr =
       hasContrHomsIsoCommaᴰ₂ YO* LiftPsh isFullyFaithfulYO*
 
-    -- 𝓟up = ∫Cᴰsr IncoherentElt
-    -- hasContrHomsRepr : hasContrHoms Representation'
-    -- hasContrHomsRepr {P}{Q} α d≅P d'≅Q =
-    --   isContrRetract
-    --     (λ (f , sq⇒⇒)  → f , {!!})
-    --     (λ (f , inFib) → f , {!!})
-    --     (λ _ → Σ≡Prop (λ _ → hasPropHomsY≅ _ _ _) refl)
-    --     (isFullyFaithfulYO* (d≅P .fst) (d'≅Q .fst) .equiv-proof
-    --       (isodP .fst ⋆⟨ 𝓟' ⟩ LiftPsh ⟪ α ⟫ ⋆⟨ 𝓟' ⟩ d'⇐Q) )
-    --   where
-    --     isodP : CatIso 𝓟' (YO* ⟅ d≅P .fst ⟆) (LiftPsh ⟅ P ⟆ )
-    --     isodP = NatIso→FUNCTORIso (D ^op) _ (record { trans = d≅P .snd .fst ; nIso = d≅P .snd .snd })
-    --     module isIsodP = isIsoC (isodP .snd)
-    --     isodQ : CatIso 𝓟' (YO* ⟅ d'≅Q .fst ⟆) (LiftPsh ⟅ Q ⟆ )
-    --     isodQ = NatIso→FUNCTORIso (D ^op) _ (record { trans = d'≅Q .snd .fst ; nIso = d'≅Q .snd .snd })
-    --     d⇒P = d≅P .snd .fst
-    --     d'⇐Q = symNatIso (record { trans = d'≅Q .snd .fst ; nIso = d'≅Q .snd .snd }) .trans
+  
+  -- Presheaves that have a universal element viewed as property
+  -- (morphisms ignore it).
+  --
+  -- A functor C → 𝓟up is equivalent to a functor R : C → 𝓟 and a
+  -- universal element for each R ⟅ c ⟆
+  --
+  -- An object over P is a universal element
+  -- Morphisms over nat trans. are trivial
+  𝓟up = ∫C HasUniversalElt
 
---   -- Presheaves that have a universal element viewed as property
---   -- (morphisms ignore it).
---   --
---   -- A functor C → 𝓟up is equivalent to a functor R : C → 𝓟 and a
---   -- universal element for each R ⟅ c ⟆
---   --
---   -- An object over P is a universal element
---   -- Morphisms over nat trans. are trivial
---   𝓟up : Categoryᴰ 𝓟 (ℓ-max (ℓ-max ℓD ℓD') ℓS) ℓ-zero
---   𝓟up = FullSubcategoryᴰ 𝓟 (UniversalElement D)
+  -- Presheaves equipped with a universal element as structure
+  -- (morphisms preserve it)
+  --
+  -- A functor C → 𝓟us is the data of
+  -- 1. A functor R : C → 𝓟
+  -- 2. A functor F : C → D
 
---   hasContrHoms𝓟up : hasContrHoms 𝓟up
---   hasContrHoms𝓟up = hasContrHomsFullSubcategory _ _
+  -- 3. A *natural* choice of elements for R c (F c) with F c as
+  --    vertex
+  --
+  -- An object over P is a universal element η
+  --
+  -- Morphisms over nat trans α : P , η → Q , η' are morphisms
+  -- f : η .vertex → η' .vertex
+  -- That that "represent" α.
+  -- Since η, η' are universal, this type is contractible
+  𝓟us = ∫C WithUniversalElt
 
---   App : D o-[ ℓS ]-* 𝓟
---   App = Profunctor→Relator Id
+  -- Presheaves equipped with a representation viewed as
+  -- structure
+  --
+  -- A functor C → 𝓟rs is the data of
+  -- 1. A functor R : C → 𝓟
+  -- 2. A functor F : C → D
+  -- 3. A natural iso LiftF ∘F R ≅ LiftF ∘F Yo ∘F F
+  --
+  -- An object over P is an iso P ≅ Yo c
+  --
+  -- Morphisms over nat trans α : P , iso → Q , iso' are morphisms
+  -- f : iso .cod → iso' .cod
+  -- That that commute: iso' ∘ Yo f ≡ α ∘ iso
+  -- because Yo is fully faithful, this is contractible.
+  𝓟rs = ∫C Representation'
 
---   𝓟elt : Categoryᴰ 𝓟 _ _
---   𝓟elt = ∫Cᴰsl (Graph App)
+  coherence : Functor 𝓟up 𝓟us
+  coherence = mk∫Functor' (mkFunctorᴰContrHoms hasContrHomsWUE (λ z → z))
 
---   𝓟usᴰ : Categoryᴰ (∫C 𝓟elt) _ _
---   𝓟usᴰ = FullSubcategoryᴰ _
---      (λ elt → isUniversal D (elt .fst)
---                             (elt .snd .fst)
---                             (elt .snd .snd))
-
---   -- Presheaves equipped with a universal element as structure
---   -- (morphisms preserve it)
---   --
---   -- A functor C → 𝓟us is the data of
---   -- 1. A functor R : C → 𝓟
---   -- 2. A functor F : C → D
-
---   -- 3. A *natural* choice of elements for R c (F c) with F c as
---   --    vertex
---   --
---   -- An object over P is a universal element η
---   --
---   -- Morphisms over nat trans α : P , η → Q , η' are morphisms
---   -- f : η .vertex → η' .vertex
---   -- That that "represent" α.
---   -- Since η, η' are universal, this type is contractible.
---   𝓟us : Categoryᴰ 𝓟 _ _
---   𝓟us = ∫Cᴰ 𝓟elt 𝓟usᴰ
-
---   -- | TODO: this should be definable as some composition of
---   -- | reassociativity and projection but need to implement those
---   -- | functors
---   ForgetUniversal : Functor (∫C 𝓟us) (∫C (Graph App))
---   ForgetUniversal .F-ob x =
---     ((x .snd .fst .fst) , (x .fst)) , (x .snd .fst .snd)
---   ForgetUniversal .F-hom α =
---     ((α .snd .fst .fst) , (α .fst)) , (α .snd .fst .snd)
---   ForgetUniversal .F-id = refl
---   ForgetUniversal .F-seq _ _ = refl
-
---   𝓟us→D : Functor (∫C 𝓟us) D
---   𝓟us→D = π₁ App ∘F ForgetUniversal
-
---   hasContrHoms𝓟us : hasContrHoms 𝓟us
---   hasContrHoms𝓟us {c' = Q} α ((d , η) , univ) ((d' , η') , univ') =
---     (((ue'.intro ((α ⟦ _ ⟧) η)) , ue'.β) , _)
---     , λ ((g , sq) , tt) → Σ≡Prop (λ _ → isPropUnit)
---       (Σ≡Prop (λ _ → (Q ⟅ _ ⟆) .snd _ _)
---       (sym (ue'.η ∙ cong ue'.intro sq)))
---     where
---       module ue  = UniversalElementNotation
---         (record { vertex = d ; element = η ; universal = univ })
---       module ue' = UniversalElementNotation
---         (record { vertex = d' ; element = η' ; universal = univ' })
-
---   coherence : Functorᴰ Id 𝓟up 𝓟us
---   coherence = mkFunctorᴰContrHoms hasContrHoms𝓟us
---     (λ ue → (ue .vertex , (ue .element)) , (ue .universal))
-
---   -- Presheaves equipped with a representation viewed as
---   -- structure
---   --
---   -- A functor C → 𝓟rs is the data of
---   -- 1. A functor R : C → 𝓟
---   -- 2. A functor F : C → D
---   -- 3. A natural iso LiftF ∘F R ≅ LiftF ∘F Yo ∘F F
---   --
---   -- An object over P is an iso P ≅ Yo c
---   --
---   -- Morphisms over nat trans α : P , iso → Q , iso' are morphisms
---   -- f : iso .cod → iso' .cod
---   -- That that commute: iso' ∘ Yo f ≡ α ∘ iso
---   -- because Yo is fully faithful, this is contractible.
-
---   𝓟r : Categoryᴰ 𝓟 _ _
---   𝓟r = IsoCommaᴰ₁ LiftPsh YO*
-
---   open Functorᴰ
-
---   𝓟us→𝓟r : Functorᴰ Id 𝓟us 𝓟r
---   𝓟us→𝓟r =
---     mk∫ᴰsrFunctorᴰ
---       _
---       Id
---       𝓟us→Weaken𝓟D
---       Unitᴰ∫C𝓟us→IsoCommaᴰ
---     where
---     𝓟us→Weaken𝓟D : Functorᴰ Id 𝓟us (weaken 𝓟 D)
---     𝓟us→Weaken𝓟D .F-obᴰ xᴰ = xᴰ .fst .fst
---     𝓟us→Weaken𝓟D .F-homᴰ fᴰ = fᴰ .fst .fst
---     𝓟us→Weaken𝓟D .F-idᴰ = refl
---     𝓟us→Weaken𝓟D .F-seqᴰ _ _ = refl
-
---     Unitᴰ∫C𝓟us→IsoCommaᴰ :
---       Functorᴰ (∫F 𝓟us→Weaken𝓟D) _ _
---     Unitᴰ∫C𝓟us→IsoCommaᴰ = mkFunctorᴰPropHoms (hasPropHomsIsoCommaᴰ _ _)
---       (λ {(P , ((vert , elt) , isUniversal))} tt →
---         let open UniversalElementNotation (record { vertex = vert ;
---                                                     element = elt ;
---                                                     universal = isUniversal })
---         in NatIso→FUNCTORIso _ _ introNI)
---       λ {(P , ((vertP , eltP) , isUniversalP))
---         ((Q , ((vertQ , eltQ) , isUniversalQ))) (α , ((f , sq) , tt)) _ _} tt →
---         let module ueP = UniversalElementNotation (record {
---                                                     vertex = vertP ;
---                                                     element = eltP ;
---                                                     universal = isUniversalP })
---             module ueQ = UniversalElementNotation (record {
---                                                     vertex = vertQ ;
---                                                     element = eltQ ;
---                                                     universal = isUniversalQ })
---         in
---         -- The goal is
---         -- α ⋆ ueQ.introNI .trans ≡ ueP.introNI .trans ⋆ Yo* ⟪ f ⟫
---         -- It is easier to prove in the equivalent form
---         -- inv ueP.introNI ⋆ α ≡ Yo* ⟪ f ⟫ ⋆ inv ueQ.introNI
---         sym (⋆InvsFlipSq⁻ {C = 𝓟'} (NatIso→FUNCTORIso _ _ ueP.introNI)
---           {LiftPsh ⟪ α ⟫}{YO* ⟪ f ⟫} (NatIso→FUNCTORIso _ _ ueQ.introNI)
---           (makeNatTransPath (funExt λ d → funExt λ (lift g) → cong lift
---             (funExt⁻ (Q .F-seq _ _) eltQ
---             ∙ cong (Q .F-hom g) sq
---             ∙ sym (funExt⁻ (α .N-hom _) _)))))
---         , tt
+  -- For this definition, we use mkFunctorᴰContrHoms' and
+  -- change-contractum to ensure we get the "efficient" definition out
+  unYoneda : Functor 𝓟us 𝓟rs
+  unYoneda = mk∫Functor' (mkFunctorᴰContrHoms'
+    (λ {x = P} (d , η , η-isUniv) →
+        let r = universalElementToRepresentation D P (record
+              { vertex = d
+              ; element = η
+              ; universal = η-isUniv }) in
+        d , NatIso→FUNCTORIso (D ^op) _ (r .snd))
+    λ {x = P}{y = Q}{f = α} {xᴰ = c-UE} {yᴰ = d-UE} (f , f-sq , tt) →
+      let (c , ηP , _) = c-UE
+          module d-UE = UniversalElementNotation (record
+            { vertex = d-UE .fst
+            ; element = d-UE .snd .fst
+            ; universal = d-UE .snd .snd
+            }) in
+      change-contractum (hasContrHomsRepr α _ _) (f ,
+        cong d-UE.intro ((cong (α ⟦ c ⟧) (funExt⁻ (P .F-id) ηP)) ∙ sym f-sq)
+        ∙ sym d-UE.η))
 
 -- module _ {C : Category ℓC ℓC'}{D : Category ℓD ℓD'}
 --          {P : Profunctor C D ℓS}

--- a/Cubical/Categories/Profunctor/Relator.agda
+++ b/Cubical/Categories/Profunctor/Relator.agda
@@ -50,12 +50,21 @@ private
 _o-[_]-*_ : (C : Category ℓC ℓC') → ∀ ℓS → (D : Category ℓD ℓD') → Type _
 C o-[ ℓS ]-* D = Bifunctor (C ^op) D (SET ℓS)
 
+_*-[_]-o_ : (C : Category ℓC ℓC') → ∀ ℓS → (D : Category ℓD ℓD') → Type _
+C *-[ ℓS ]-o D = Bifunctor C (D ^op) (SET ℓS)
+
 Relatoro* : (C : Category ℓC ℓC') → ∀ ℓS → (D : Category ℓD ℓD') → Type _
 Relatoro* C ℓS D = C o-[ ℓS ]-* D
 
 module _ {C : Category ℓC ℓC'} {ℓS} {D : Category ℓD ℓD'} where
-  Profunctor→Relator : Profunctor C D ℓS → D o-[ ℓS ]-* C
-  Profunctor→Relator P = Sym (CurriedToBifunctor P)
+  Profunctor→Relatoro* : Profunctor C D ℓS → D o-[ ℓS ]-* C
+  Profunctor→Relatoro* P = Sym (CurriedToBifunctor P)
+
+  Profunctor→Relator*o : Profunctor C D ℓS → C *-[ ℓS ]-o D
+  Profunctor→Relator*o = CurriedToBifunctor
+
+  Profunctor→Relatoro*^op : Profunctor C D ℓS → (C ^op) o-[ ℓS ]-* (D ^op)
+  Profunctor→Relatoro*^op = CurriedToBifunctor
 
   Relator→Profunctor : D o-[ ℓS ]-* C → Profunctor C D ℓS
   Relator→Profunctor R = CurryBifunctor (Sym R)

--- a/Cubical/Categories/Profunctor/Relator.agda
+++ b/Cubical/Categories/Profunctor/Relator.agda
@@ -24,7 +24,7 @@ open import Cubical.Foundations.Function renaming (_∘_ to _∘f_)
 
 open import Cubical.Categories.Category renaming (isIso to isIsoC)
 open import Cubical.Categories.Functor
-open import Cubical.Categories.Bifunctor.Redundant
+open import Cubical.Categories.Bifunctor.Redundant as Bif
 open import Cubical.Categories.Instances.Functors
 open import Cubical.Categories.NaturalTransformation
 open import Cubical.Categories.NaturalTransformation.More
@@ -58,7 +58,7 @@ Relatoro* C ℓS D = C o-[ ℓS ]-* D
 
 module _ {C : Category ℓC ℓC'} {ℓS} {D : Category ℓD ℓD'} where
   Profunctor→Relatoro* : Profunctor C D ℓS → D o-[ ℓS ]-* C
-  Profunctor→Relatoro* P = Sym (CurriedToBifunctor P)
+  Profunctor→Relatoro* P = Bif.Sym (CurriedToBifunctor P)
 
   Profunctor→Relator*o : Profunctor C D ℓS → C *-[ ℓS ]-o D
   Profunctor→Relator*o = CurriedToBifunctor
@@ -67,7 +67,7 @@ module _ {C : Category ℓC ℓC'} {ℓS} {D : Category ℓD ℓD'} where
   Profunctor→Relatoro*^op = CurriedToBifunctor
 
   Relator→Profunctor : D o-[ ℓS ]-* C → Profunctor C D ℓS
-  Relator→Profunctor R = CurryBifunctor (Sym R)
+  Relator→Profunctor R = CurryBifunctor (Bif.Sym R)
 
 module _ {C : Category ℓC ℓC'} (R : C o-[ ℓS ]-* C) where
   private

--- a/Cubical/Data/Sigma/More.agda
+++ b/Cubical/Data/Sigma/More.agda
@@ -1,0 +1,35 @@
+{-
+
+-}
+{-# OPTIONS --safe #-}
+module Cubical.Data.Sigma.More where
+
+open import Cubical.Data.Sigma.Base
+
+open import Cubical.Core.Everything
+
+open import Cubical.Foundations.Prelude
+open import Cubical.Foundations.Function
+open import Cubical.Foundations.Isomorphism
+open import Cubical.Foundations.Equiv
+open import Cubical.Foundations.Equiv.HalfAdjoint
+open import Cubical.Foundations.GroupoidLaws
+open import Cubical.Foundations.Path
+open import Cubical.Foundations.Transport
+open import Cubical.Data.Sigma
+
+
+open Iso
+
+private
+  variable
+    ℓ ℓ' ℓ'' : Level
+    A A' : Type ℓ
+    B B' : (a : A) → Type ℓ
+    C : (a : A) (b : B a) → Type ℓ
+
+change-contractum : (p : ∃![ x₀ ∈ A ] B x₀) → singl (p .fst .fst)
+                  → ∃![ x ∈ A ] B x
+change-contractum {B = B} ((x₀ , p₀) , contr) (x , x₀≡x) =
+  (x , subst B x₀≡x p₀)
+  , (λ yq → ΣPathP ((sym x₀≡x) , symP (subst-filler B x₀≡x p₀)) ∙ contr yq)


### PR DESCRIPTION
This PR simplifies the FunctorComprehension proof, specifically the
part that constructs a representation from a universal element, in two
ways:

1. Use a principle `change-contractum` to get rid of some tedious
   reasoning about squares

2. Redefine the displayed category of representations so that its
   structure lines up more closely with the one for universal elements
   so there's fewer associativities

In the process I added a few more minor things:

1. several more useful constructions to displayed categories
2. cleaning up some stuff in the IsoComma HLevel proofs
3. define the FullImage of a functor (which I didn't end up needing).
4. proofs for when LiftF and postComposeF are FullyFaithful