### PR TITLE
Define 2Categories

### DIFF
--- a/Cubical/Categories/2Category/Base.agda
+++ b/Cubical/Categories/2Category/Base.agda
@@ -1,0 +1,226 @@
+module Cubical.Categories.2Category.Base where
+
+open import Cubical.Foundations.Prelude
+open import Cubical.Foundations.More
+open import Cubical.Foundations.Function
+open import Cubical.Foundations.HLevels
+
+open import Cubical.Data.Sigma
+import Cubical.Data.Equality as Eq
+open import Cubical.Data.Unit
+
+open import Cubical.Categories.Category
+open import Cubical.Categories.Functor
+open import Cubical.Categories.Functor.Properties
+open import Cubical.Categories.NaturalTransformation
+
+private
+  variable
+    ℓ ℓ' ℓ'' : Level
+
+record 2Category ℓ ℓ' ℓ'' :
+  Type (ℓ-max (ℓ-suc ℓ) (ℓ-max (ℓ-suc ℓ') (ℓ-suc ℓ''))) where
+  no-eta-equality
+  field
+    ob : Type ℓ
+    Hom₁[_,_] : ob → ob → Type ℓ'
+    Hom₂[_,_] : ∀ {x y} → Hom₁[ x , y ] → Hom₁[ x , y ] → Type ℓ''
+
+    id₁   : ∀ {x} → Hom₁[ x , x ]
+    id₂   : ∀ {x y} {f : Hom₁[ x , y ]} → Hom₂[ f , f ]
+
+    _⋆₁_  : ∀ {x y z} (f : Hom₁[ x , y ]) (g : Hom₁[ y , z ]) → Hom₁[ x , z ]
+    _⋆ⱽ_  : ∀ {x y} {f g h : Hom₁[ x , y ]} →
+      Hom₂[ f , g ] → Hom₂[ g , h ] → Hom₂[ f , h ]
+    _⋆ᴴ_  : ∀ {x y z} {f f' : Hom₁[ x , y ]} {g g' : Hom₁[ y , z ]} →
+      Hom₂[ f , f' ] → Hom₂[ g , g' ] → Hom₂[ (f ⋆₁ g) , (f' ⋆₁ g') ]
+
+    ⋆₁IdL : ∀ {x y} (f : Hom₁[ x , y ]) → id₁ ⋆₁ f ≡ f
+    ⋆₁IdR : ∀ {x y} (f : Hom₁[ x , y ]) → f ⋆₁ id₁ ≡ f
+    ⋆₁Assoc : ∀ {x y z w} (f : Hom₁[ x , y ]) (g : Hom₁[ y , z ]) (h : Hom₁[ z , w ])
+           → (f ⋆₁ g) ⋆₁ h ≡ f ⋆₁ (g ⋆₁ h)
+
+    ⋆ⱽIdL : ∀ {x y} {f g : Hom₁[ x , y ]} (α : Hom₂[ f , g ])
+          → id₂ ⋆ⱽ α ≡ α
+    ⋆ⱽIdR : ∀ {x y} {f g : Hom₁[ x , y ]} (α : Hom₂[ f , g ])
+          → α ⋆ⱽ id₂ ≡ α
+    ⋆ⱽAssoc : ∀ {x y} {f g h k : Hom₁[ x , y ]}
+              (α : Hom₂[ f , g ]) (β : Hom₂[ g , h ]) (γ : Hom₂[ h , k ])
+            → (α ⋆ⱽ β) ⋆ⱽ γ ≡ α ⋆ⱽ (β ⋆ⱽ γ)
+
+    ⋆ᴴIdL  : ∀ {x y} {f f' : Hom₁[ x , y ]} (α : Hom₂[ f , f' ]) →
+      PathP (λ i → Hom₂[ ⋆₁IdL f i , ⋆₁IdL f' i ]) (id₂ ⋆ᴴ α) α
+    ⋆ᴴIdR  : ∀ {x y} {f f' : Hom₁[ x , y ]} (α : Hom₂[ f , f' ]) →
+      PathP (λ i → Hom₂[ ⋆₁IdR f i , ⋆₁IdR f' i ]) (α ⋆ᴴ id₂) α
+    ⋆ᴴAssoc  : ∀ {x y z w}
+      {f f' : Hom₁[ x , y ]} {g g' : Hom₁[ y , z ]} {h h' : Hom₁[ z , w ]}
+      (α : Hom₂[ f , f' ]) (β : Hom₂[ g , g' ]) (γ : Hom₂[ h , h' ]) →
+      PathP (λ i → Hom₂[ ⋆₁Assoc f g h i , ⋆₁Assoc f' g' h' i ])
+        ((α ⋆ᴴ β) ⋆ᴴ γ) (α ⋆ᴴ β ⋆ᴴ γ)
+
+    interchange : ∀ {x y z} {f g h : Hom₁[ x , y ]} {k l m : Hom₁[ y , z ]}
+                  (α : Hom₂[ f , g ]) (β : Hom₂[ g , h ])
+                  (γ : Hom₂[ k , l ]) (δ : Hom₂[ l , m ])
+                → (α ⋆ⱽ β) ⋆ᴴ (γ ⋆ⱽ δ) ≡ (α ⋆ᴴ γ) ⋆ⱽ (β ⋆ᴴ δ)
+    isSetHom₂ : ∀ {x y} {f g : Hom₁[ x , y ]} → isSet (Hom₂[ f , g ])
+
+  infixr 9 _⋆₁_
+  infixr 9 _⋆ⱽ_
+  infixr 9 _⋆ᴴ_
+
+  ⟨_⟩⋆₁⟨_⟩ : ∀ {x y z} {f f' : Hom₁[ x , y ]} {g g' : Hom₁[ y , z ]} →
+    f ≡ f' → g ≡ g' → f ⋆₁ g ≡ f' ⋆₁ g'
+  ⟨ f≡ ⟩⋆₁⟨ g≡ ⟩ = cong₂ _⋆₁_ f≡ g≡
+
+  ⟨_⟩⋆ⱽ⟨_⟩ : ∀ {x y} {f g h : Hom₁[ x , y ]} →
+    {α α' : Hom₂[ f , g ]} {β β' : Hom₂[ g , h ]} →
+     α ≡ α' → β ≡ β' → α ⋆ⱽ β ≡ α' ⋆ⱽ β'
+  ⟨ α≡ ⟩⋆ⱽ⟨ β≡ ⟩ = cong₂ _⋆ⱽ_ α≡ β≡
+
+  ⟨_⟩⋆ᴴ⟨_⟩ : ∀ {x y z} {f f' : Hom₁[ x , y ]} {g g' : Hom₁[ y , z ]} →
+      {α α' : Hom₂[ f , f' ]} {β β' : Hom₂[ g , g' ]} →
+      α ≡ α' → β ≡ β' → α ⋆ᴴ β ≡ α' ⋆ᴴ β'
+  ⟨ α≡ ⟩⋆ᴴ⟨ β≡ ⟩ = cong₂ _⋆ᴴ_ α≡ β≡
+
+  module 2CatReasoning {x y} =
+    depReasoning (λ ((f , g) : Hom₁[ x , y ] × Hom₁[ x , y ]) → Hom₂[ f , g ])
+  open 2CatReasoning public
+
+  ∫⋆ᴴIdL  : ∀ {x y} {f f' : Hom₁[ x , y ]} (α : Hom₂[ f , f' ]) →
+    id₂ ⋆ᴴ α ∫≡ α
+  ∫⋆ᴴIdL α = ΣPathP (ΣPathP (⋆₁IdL _ , ⋆₁IdL _) , (⋆ᴴIdL α))
+
+  ∫⋆ᴴIdR  : ∀ {x y} {f f' : Hom₁[ x , y ]} (α : Hom₂[ f , f' ]) →
+    α ⋆ᴴ id₂ ∫≡ α
+  ∫⋆ᴴIdR α = ΣPathP (ΣPathP (⋆₁IdR _ , ⋆₁IdR _) , (⋆ᴴIdR α))
+
+  ∫⋆ᴴAssoc  : ∀ {x y z w}
+    {f f' : Hom₁[ x , y ]} {g g' : Hom₁[ y , z ]} {h h' : Hom₁[ z , w ]}
+    (α : Hom₂[ f , f' ]) (β : Hom₂[ g , g' ]) (γ : Hom₂[ h , h' ]) →
+    (α ⋆ᴴ β) ⋆ᴴ γ ∫≡ α ⋆ᴴ β ⋆ᴴ γ
+  ∫⋆ᴴAssoc α β γ =
+    ΣPathP ((ΣPathP ((⋆₁Assoc _ _ _) , ⋆₁Assoc _ _ _)) , (⋆ᴴAssoc α β γ))
+
+
+open 2Category
+open NatTrans
+open Functor
+open Category
+
+module _ {ℓC ℓC'} where
+  CAT : 2Category _ _ _
+  CAT .ob = Category ℓC ℓC'
+  CAT .Hom₁[_,_] = Functor
+  CAT .Hom₂[_,_] = NatTrans
+  CAT .id₁ = Id
+  CAT .id₂ = idTrans _
+  CAT ._⋆₁_ F G = G ∘F F
+  CAT ._⋆ⱽ_ = seqTrans
+  CAT ._⋆ᴴ_ α β = whiskerTrans β α
+  CAT .⋆₁IdL _ = F-lUnit
+  CAT .⋆₁IdR _ = F-rUnit
+  CAT .⋆₁Assoc _ _ _ = F-assoc
+  CAT .⋆ⱽIdL {y = D} _ =
+    makeNatTransPath (funExt λ _ → D.⋆IdL _ )
+    where module D = Category D
+  CAT .⋆ⱽIdR {y = D} _ =
+    makeNatTransPath (funExt λ _ → D.⋆IdR _ )
+    where module D = Category D
+  CAT .⋆ⱽAssoc {y = D} _ _ _ =
+    makeNatTransPath (funExt λ _ → D.⋆Assoc _ _ _ )
+    where module D = Category D
+  CAT .⋆ᴴIdL {y = D} {f = F} α =
+    makeNatTransPathP _ _ (funExt λ _ → cong₂ D._⋆_ (F .F-id) refl ∙ D.⋆IdL _)
+    where module D = Category D
+  CAT .⋆ᴴIdR {y = D} α =
+    makeNatTransPathP _ _ (funExt λ _ → D.⋆IdR _)
+    where module D = Category D
+  CAT .⋆ᴴAssoc {w = D} {f = F} {g = G} {h = H} _ _ _ =
+    makeNatTransPathP _ _
+      (funExt λ _ →
+        D.⟨ H .F-seq _ _ ⟩⋆⟨ refl ⟩
+        ∙ D.⋆Assoc _ _ _
+      )
+    where module D = Category D
+  CAT .interchange {z = D}{k = k} α β γ δ =
+    makeNatTransPath (funExt λ _ →
+      (sym $ D.⋆Assoc _ _ _)
+      ∙ D.⟨ D.⟨ k .F-seq _ _ ⟩⋆⟨ refl ⟩
+                ∙ D.⋆Assoc _ _ _
+                ∙ D.⟨ refl ⟩⋆⟨ N-hom γ (N-ob β _) ⟩
+                ∙ (sym $ D.⋆Assoc _ _ _)
+          ⟩⋆⟨ refl ⟩
+      ∙ D.⋆Assoc _ _ _)
+    where module D = Category D
+  CAT .isSetHom₂ = isSetNatTrans
+
+module _ {ℓC ℓC'} (C : Category ℓC ℓC') where
+  private
+    module C = Category C
+
+  Cat→2Cat : 2Category _ _ _
+  Cat→2Cat .ob = C.ob
+  Cat→2Cat .Hom₁[_,_] = C.Hom[_,_]
+  Cat→2Cat .Hom₂[_,_] f g = f ≡ g
+  Cat→2Cat .id₁ = C.id
+  Cat→2Cat .id₂ = refl
+  Cat→2Cat ._⋆₁_ = C._⋆_
+  Cat→2Cat ._⋆ⱽ_ = _∙_
+  Cat→2Cat ._⋆ᴴ_ = C.⟨_⟩⋆⟨_⟩
+  Cat→2Cat .⋆₁IdL = C.⋆IdL
+  Cat→2Cat .⋆₁IdR = C.⋆IdR
+  Cat→2Cat .⋆₁Assoc = C.⋆Assoc
+  Cat→2Cat .⋆ⱽIdL _ = C.isSetHom _ _ _ _
+  Cat→2Cat .⋆ⱽIdR _ = C.isSetHom _ _ _ _
+  Cat→2Cat .⋆ⱽAssoc _ _ _ = C.isSetHom _ _ _ _
+  Cat→2Cat .⋆ᴴIdL _ = isProp→PathP (λ _ → C.isSetHom _ _) _ _
+  Cat→2Cat .⋆ᴴIdR _ = isProp→PathP (λ _ → C.isSetHom _ _) _ _
+  Cat→2Cat .⋆ᴴAssoc _ _ _ = isProp→PathP (λ _ → C.isSetHom _ _) _ _
+  Cat→2Cat .interchange  _ _ _ _ = C.isSetHom _ _ _ _
+  Cat→2Cat .isSetHom₂ = isSet→isGroupoid C.isSetHom _ _
+
+  Cat→2CatEq : 2Category _ _ _
+  Cat→2CatEq .ob = C.ob
+  Cat→2CatEq .Hom₁[_,_] = C.Hom[_,_]
+  Cat→2CatEq .Hom₂[_,_] f g = f Eq.≡ g
+  Cat→2CatEq .id₁ = C.id
+  Cat→2CatEq .id₂ = Eq.refl
+  Cat→2CatEq ._⋆₁_ = C._⋆_
+  Cat→2CatEq ._⋆ⱽ_ = Eq._∙_
+  Cat→2CatEq ._⋆ᴴ_ Eq.refl Eq.refl = Eq.refl
+  Cat→2CatEq .⋆₁IdL = C.⋆IdL
+  Cat→2CatEq .⋆₁IdR = C.⋆IdR
+  Cat→2CatEq .⋆₁Assoc = C.⋆Assoc
+  Cat→2CatEq .⋆ⱽIdL _ = refl
+  Cat→2CatEq .⋆ⱽIdR Eq.refl = refl
+  Cat→2CatEq .⋆ⱽAssoc Eq.refl Eq.refl Eq.refl = refl
+  Cat→2CatEq .⋆ᴴIdR Eq.refl i = Eq.refl
+  Cat→2CatEq .⋆ᴴIdL Eq.refl i = Eq.refl
+  Cat→2CatEq .⋆ᴴAssoc Eq.refl Eq.refl Eq.refl i = Eq.refl
+  Cat→2CatEq .interchange Eq.refl Eq.refl Eq.refl Eq.refl = refl
+  Cat→2CatEq .isSetHom₂ = isSetRetract Eq.eqToPath Eq.pathToEq
+    Eq.pathToEq-eqToPath (isSet→isGroupoid C.isSetHom _ _)
+
+module _ {ℓC ℓC' ℓC''} (C : 2Category ℓC ℓC' ℓC'') where
+  private
+    module C = 2Category C
+  _^op2 : 2Category ℓC ℓC' ℓC''
+  _^op2 .ob = C.ob
+  _^op2 .Hom₁[_,_] x y = C.Hom₁[ y , x ]
+  _^op2 .Hom₂[_,_] f g = C.Hom₂[ g , f ]
+  _^op2 .id₁ = C.id₁
+  _^op2 .id₂ = C.id₂
+  _^op2 ._⋆₁_ = λ f g → g C.⋆₁ f
+  _^op2 ._⋆ⱽ_ = λ z z₁ → z₁ C.⋆ⱽ z
+  _^op2 ._⋆ᴴ_ = λ z₁ z₂ → z₂ C.⋆ᴴ z₁
+  _^op2 .⋆₁IdL = C.⋆₁IdR
+  _^op2 .⋆₁IdR = C.⋆₁IdL
+  _^op2 .⋆₁Assoc _ _ _ = sym $ C.⋆₁Assoc _ _ _
+  _^op2 .⋆ⱽIdL = C.⋆ⱽIdR
+  _^op2 .⋆ⱽIdR = C.⋆ⱽIdL
+  _^op2 .⋆ⱽAssoc _ _ _ = sym $ C.⋆ⱽAssoc _ _ _
+  _^op2 .⋆ᴴIdL = C.⋆ᴴIdR
+  _^op2 .⋆ᴴIdR = C.⋆ᴴIdL
+  _^op2 .⋆ᴴAssoc _ _ _ = symP $ C.⋆ᴴAssoc _ _ _
+  _^op2 .interchange = λ α β γ δ → C.interchange δ γ β α
+  _^op2 .isSetHom₂ = C.isSetHom₂

--- a/Cubical/Categories/2Functor/Base.agda
+++ b/Cubical/Categories/2Functor/Base.agda
@@ -1,0 +1,348 @@
+module Cubical.Categories.2Functor.Base where
+
+open import Cubical.Foundations.Prelude
+open import Cubical.Foundations.More
+open import Cubical.Foundations.Function
+open import Cubical.Foundations.Structure
+open import Cubical.Foundations.HLevels
+open import Cubical.Data.Sigma
+
+open import Cubical.Categories.2Category.Base
+open import Cubical.Categories.Category
+open import Cubical.Categories.Functor
+open import Cubical.Categories.NaturalTransformation
+
+private
+  variable
+    ℓ ℓ' ℓ'' ℓC ℓC' ℓC'' ℓD ℓD' ℓD'' ℓE ℓE' ℓE'' : Level
+
+record LaxFunctor (C : 2Category ℓC ℓC' ℓC'') (D : 2Category ℓD ℓD' ℓD'') :
+    Type (ℓ-max (ℓ-max (ℓ-max ℓC ℓC') ℓC'') (ℓ-max (ℓ-max ℓD ℓD') ℓD''))
+    where
+  no-eta-equality
+
+  private
+    module C = 2Category C
+    module D = 2Category D
+
+  field
+    F₀ : C.ob → D.ob
+    F₁ : ∀ {x y} → C.Hom₁[ x , y ] → D.Hom₁[ F₀ x , F₀ y ]
+    F₂ : ∀ {x y} {f g : C.Hom₁[ x , y ]}
+       → C.Hom₂[ f , g ] → D.Hom₂[ F₁ f , F₁ g ]
+
+    F-id : ∀ {x} → D.Hom₂[ D.id₁ , F₁ (C.id₁ {x}) ]
+
+    F-seq : ∀ {x y z} (f : C.Hom₁[ x , y ]) (g : C.Hom₁[ y , z ])
+          → D.Hom₂[ (F₁ f) D.⋆₁ (F₁ g) , F₁ (f C.⋆₁ g) ]
+
+    F-id₂ : ∀ {x y} {f : C.Hom₁[ x , y ]}
+          → F₂ (C.id₂ {f = f}) ≡ D.id₂ {f = F₁ f}
+
+    F-seqⱽ : ∀ {x y} {f g h : C.Hom₁[ x , y ]}
+             (α : C.Hom₂[ f , g ]) (β : C.Hom₂[ g , h ])
+           → F₂ (α C.⋆ⱽ β) ≡ (F₂ α) D.⋆ⱽ (F₂ β)
+
+    F-seqᴴ : ∀ {x y z} {f f' : C.Hom₁[ x , y ]} {g g' : C.Hom₁[ y , z ]}
+             (α : C.Hom₂[ f , f' ]) (β : C.Hom₂[ g , g' ])
+           → (F-seq f g) D.⋆ⱽ F₂ (α C.⋆ᴴ β)
+             ≡ ((F₂ α) D.⋆ᴴ (F₂ β)) D.⋆ⱽ (F-seq f' g')
+
+    F-unitality-l : ∀ {x y} (f : C.Hom₁[ x , y ])
+                  → PathP (λ i → D.Hom₂[ D.⋆₁IdL (F₁ f) i , F₁ (C.⋆₁IdL f i) ])
+                          ((F-id D.⋆ᴴ D.id₂) D.⋆ⱽ (F-seq C.id₁ f))
+                          (F₂ C.id₂)
+
+    F-unitality-r : ∀ {x y} (f : C.Hom₁[ x , y ])
+                  → PathP (λ i → D.Hom₂[ D.⋆₁IdR (F₁ f) i , F₁ (C.⋆₁IdR f i) ])
+                          ((D.id₂ D.⋆ᴴ F-id) D.⋆ⱽ (F-seq f C.id₁))
+                          (F₂ C.id₂)
+
+    F-associativity : ∀ {w x y z} (f : C.Hom₁[ w , x ])
+                        (g : C.Hom₁[ x , y ]) (h : C.Hom₁[ y , z ])
+                    → PathP (λ i → D.Hom₂[ D.⋆₁Assoc (F₁ f) (F₁ g) (F₁ h) i
+                                         , F₁ (C.⋆₁Assoc f g h i) ])
+                            ((F-seq f g D.⋆ᴴ D.id₂) D.⋆ⱽ F-seq (f C.⋆₁ g) h)
+                            ((D.id₂ D.⋆ᴴ (F-seq g h)) D.⋆ⱽ F-seq f (g C.⋆₁ h))
+
+open 2Category
+module _ (C : 2Category ℓ ℓ' ℓ'') where
+  private module C = 2Category C
+  record isIso2Cell {x y : C.ob}
+    {f g : C.Hom₁[ x , y ]} (α : C.Hom₂[ f , g ]) : Type ℓ'' where
+    field
+      inv : C.Hom₂[ g , f ]
+      sec : α C.⋆ⱽ inv ≡ C.id₂
+      ret : inv C.⋆ⱽ α ≡ C.id₂
+
+record isPseudo {C : 2Category ℓC ℓC' ℓC''} {D : 2Category ℓD ℓD' ℓD''}
+                (F : LaxFunctor C D) :
+    Type (ℓ-max (ℓ-max (ℓ-max ℓC ℓC') ℓC'') (ℓ-max (ℓ-max ℓD ℓD') ℓD'')) where
+  private
+    module F = LaxFunctor F
+    module C = 2Category C
+    module D = 2Category D
+  field
+    F-id-iso : ∀ {x} → isIso2Cell D (F.F-id {x})
+    F-seq-iso : ∀ {x y z} (f : C.Hom₁[ x , y ]) (g : C.Hom₁[ y , z ])
+              → isIso2Cell D (F.F-seq f g)
+
+record PseudoFunctor (C : 2Category ℓC ℓC' ℓC'') (D : 2Category ℓD ℓD' ℓD'') :
+    Type (ℓ-max (ℓ-max (ℓ-max ℓC ℓC') ℓC'') (ℓ-max (ℓ-max ℓD ℓD') ℓD'')) where
+  field
+    lax : LaxFunctor C D
+    pseudo : isPseudo lax
+  open LaxFunctor lax public
+
+open LaxFunctor
+
+module _
+  {C : 2Category ℓC ℓC' ℓC''}
+  {D : 2Category ℓD ℓD' ℓD''}
+  {E : 2Category ℓE ℓE' ℓE''}
+  (F : LaxFunctor C D)
+  (G : LaxFunctor D E)
+  where
+
+  private
+    module C = 2Category C
+    module D = 2Category D
+    module E = 2Category E
+    module F = LaxFunctor F
+    module G = LaxFunctor G
+
+  seqLaxFunctor : LaxFunctor C E
+  seqLaxFunctor .F₀ = λ z → G.F₀ (F.F₀ z)
+  seqLaxFunctor .F₁ = λ z → G.F₁ (F.F₁ z)
+  seqLaxFunctor .F₂ = λ z → G.F₂ (F.F₂ z)
+  seqLaxFunctor .F-id = G.F-id E.⋆ⱽ G.F₂ F.F-id
+  seqLaxFunctor .F-seq = λ f g → G.F-seq (F.F₁ f) (F.F₁ g) E.⋆ⱽ G.F₂ (F.F-seq f g)
+  seqLaxFunctor .F-id₂ = cong G.F₂ F.F-id₂ ∙ G.F-id₂
+  seqLaxFunctor .F-seqⱽ α β =
+    cong G.F₂ (F.F-seqⱽ α β)
+    ∙ G.F-seqⱽ (F.F₂ α) (F.F₂ β)
+  seqLaxFunctor .F-seqᴴ α β =
+    E.⋆ⱽAssoc _ _ _
+    ∙ cong₂ E._⋆ⱽ_ refl
+        ((sym $ G.F-seqⱽ _ _)
+         ∙ cong G.F₂ (F.F-seqᴴ α β))
+    ∙ cong₂ E._⋆ⱽ_ refl (G.F-seqⱽ _ _)
+    ∙ (sym $ E.⋆ⱽAssoc _ _ _)
+    ∙ cong₂ E._⋆ⱽ_ (G.F-seqᴴ (F.F₂ α) (F.F₂ β)) refl
+    ∙ E.⋆ⱽAssoc _ _ _
+  seqLaxFunctor .F-unitality-l f =
+    -- Gross proof that I outsourced to Claude
+    -- I would hope there is a better way to write this
+      unitality-l-pre
+    ◁ (λ i → G.F-unitality-l (F.F₁ f) i E.⋆ⱽ G.F₂ (F.F-unitality-l f i))
+    ▷ unitality-post
+    where
+    unitality-l-pre :
+        (((G.F-id E.⋆ⱽ G.F₂ F.F-id) E.⋆ᴴ E.id₂) E.⋆ⱽ
+         (G.F-seq (F.F₁ C.id₁) (F.F₁ f) E.⋆ⱽ G.F₂ (F.F-seq C.id₁ f)))
+      ≡ (((G.F-id E.⋆ᴴ E.id₂) E.⋆ⱽ G.F-seq D.id₁ (F.F₁ f)) E.⋆ⱽ
+         G.F₂ ((F.F-id D.⋆ᴴ D.id₂) D.⋆ⱽ F.F-seq C.id₁ f))
+    unitality-l-pre =
+        cong (λ δ → ((G.F-id E.⋆ⱽ G.F₂ F.F-id) E.⋆ᴴ δ) E.⋆ⱽ
+                    (G.F-seq (F.F₁ C.id₁) (F.F₁ f) E.⋆ⱽ
+                     G.F₂ (F.F-seq C.id₁ f)))
+             (sym (E.⋆ⱽIdL E.id₂))
+      ∙ cong (E._⋆ⱽ (G.F-seq (F.F₁ C.id₁) (F.F₁ f) E.⋆ⱽ
+                     G.F₂ (F.F-seq C.id₁ f)))
+             (E.interchange G.F-id (G.F₂ F.F-id) E.id₂ E.id₂)
+      ∙ E.⋆ⱽAssoc (G.F-id E.⋆ᴴ E.id₂) (G.F₂ F.F-id E.⋆ᴴ E.id₂)
+                  (G.F-seq (F.F₁ C.id₁) (F.F₁ f) E.⋆ⱽ
+                   G.F₂ (F.F-seq C.id₁ f))
+      ∙ cong ((G.F-id E.⋆ᴴ E.id₂) E.⋆ⱽ_)
+             (sym (E.⋆ⱽAssoc (G.F₂ F.F-id E.⋆ᴴ E.id₂)
+                             (G.F-seq (F.F₁ C.id₁) (F.F₁ f))
+                             (G.F₂ (F.F-seq C.id₁ f))))
+      ∙ cong (λ δ → (G.F-id E.⋆ᴴ E.id₂) E.⋆ⱽ
+                    (((G.F₂ F.F-id E.⋆ᴴ δ) E.⋆ⱽ
+                      G.F-seq (F.F₁ C.id₁) (F.F₁ f)) E.⋆ⱽ
+                     G.F₂ (F.F-seq C.id₁ f)))
+             (sym G.F-id₂)
+      ∙ cong (λ r → (G.F-id E.⋆ᴴ E.id₂) E.⋆ⱽ
+                    (r E.⋆ⱽ G.F₂ (F.F-seq C.id₁ f)))
+             (sym (G.F-seqᴴ F.F-id D.id₂))
+      ∙ cong ((G.F-id E.⋆ᴴ E.id₂) E.⋆ⱽ_)
+             (E.⋆ⱽAssoc (G.F-seq D.id₁ (F.F₁ f))
+                        (G.F₂ (F.F-id D.⋆ᴴ D.id₂))
+                        (G.F₂ (F.F-seq C.id₁ f)))
+      ∙ cong (λ r → (G.F-id E.⋆ᴴ E.id₂) E.⋆ⱽ
+                    (G.F-seq D.id₁ (F.F₁ f) E.⋆ⱽ r))
+             (sym (G.F-seqⱽ (F.F-id D.⋆ᴴ D.id₂) (F.F-seq C.id₁ f)))
+      ∙ sym (E.⋆ⱽAssoc (G.F-id E.⋆ᴴ E.id₂)
+                       (G.F-seq D.id₁ (F.F₁ f))
+                       (G.F₂ ((F.F-id D.⋆ᴴ D.id₂) D.⋆ⱽ F.F-seq C.id₁ f)))
+
+    unitality-post : (G.F₂ D.id₂ E.⋆ⱽ G.F₂ (F.F₂ {f = f} C.id₂))
+                     ≡ G.F₂ (F.F₂ {f = f} C.id₂)
+    unitality-post = cong (E._⋆ⱽ G.F₂ (F.F₂ C.id₂)) G.F-id₂
+                   ∙ E.⋆ⱽIdL _
+  seqLaxFunctor .F-unitality-r f =
+    -- Claude
+      unitality-r-pre
+    ◁ (λ i → G.F-unitality-r (F.F₁ f) i E.⋆ⱽ G.F₂ (F.F-unitality-r f i))
+    ▷ unitality-post
+    where
+    unitality-r-pre :
+        ((E.id₂ E.⋆ᴴ (G.F-id E.⋆ⱽ G.F₂ F.F-id)) E.⋆ⱽ
+         (G.F-seq (F.F₁ f) (F.F₁ C.id₁) E.⋆ⱽ G.F₂ (F.F-seq f C.id₁)))
+      ≡ (((E.id₂ E.⋆ᴴ G.F-id) E.⋆ⱽ G.F-seq (F.F₁ f) D.id₁) E.⋆ⱽ
+         G.F₂ ((D.id₂ D.⋆ᴴ F.F-id) D.⋆ⱽ F.F-seq f C.id₁))
+    unitality-r-pre =
+        cong (λ δ → (δ E.⋆ᴴ (G.F-id E.⋆ⱽ G.F₂ F.F-id)) E.⋆ⱽ
+                    (G.F-seq (F.F₁ f) (F.F₁ C.id₁) E.⋆ⱽ
+                     G.F₂ (F.F-seq f C.id₁)))
+             (sym (E.⋆ⱽIdL E.id₂))
+      ∙ cong (E._⋆ⱽ (G.F-seq (F.F₁ f) (F.F₁ C.id₁) E.⋆ⱽ
+                     G.F₂ (F.F-seq f C.id₁)))
+             (E.interchange E.id₂ E.id₂ G.F-id (G.F₂ F.F-id))
+      ∙ E.⋆ⱽAssoc (E.id₂ E.⋆ᴴ G.F-id) (E.id₂ E.⋆ᴴ G.F₂ F.F-id)
+                  (G.F-seq (F.F₁ f) (F.F₁ C.id₁) E.⋆ⱽ
+                   G.F₂ (F.F-seq f C.id₁))
+      ∙ cong ((E.id₂ E.⋆ᴴ G.F-id) E.⋆ⱽ_)
+             (sym (E.⋆ⱽAssoc (E.id₂ E.⋆ᴴ G.F₂ F.F-id)
+                             (G.F-seq (F.F₁ f) (F.F₁ C.id₁))
+                             (G.F₂ (F.F-seq f C.id₁))))
+      ∙ cong (λ δ → (E.id₂ E.⋆ᴴ G.F-id) E.⋆ⱽ
+                    (((δ E.⋆ᴴ G.F₂ F.F-id) E.⋆ⱽ
+                      G.F-seq (F.F₁ f) (F.F₁ C.id₁)) E.⋆ⱽ
+                     G.F₂ (F.F-seq f C.id₁)))
+             (sym G.F-id₂)
+      ∙ cong (λ r → (E.id₂ E.⋆ᴴ G.F-id) E.⋆ⱽ
+                    (r E.⋆ⱽ G.F₂ (F.F-seq f C.id₁)))
+             (sym (G.F-seqᴴ D.id₂ F.F-id))
+      ∙ cong ((E.id₂ E.⋆ᴴ G.F-id) E.⋆ⱽ_)
+             (E.⋆ⱽAssoc (G.F-seq (F.F₁ f) D.id₁)
+                        (G.F₂ (D.id₂ D.⋆ᴴ F.F-id))
+                        (G.F₂ (F.F-seq f C.id₁)))
+      ∙ cong (λ r → (E.id₂ E.⋆ᴴ G.F-id) E.⋆ⱽ
+                    (G.F-seq (F.F₁ f) D.id₁ E.⋆ⱽ r))
+             (sym (G.F-seqⱽ (D.id₂ D.⋆ᴴ F.F-id) (F.F-seq f C.id₁)))
+      ∙ sym (E.⋆ⱽAssoc (E.id₂ E.⋆ᴴ G.F-id)
+                       (G.F-seq (F.F₁ f) D.id₁)
+                       (G.F₂ ((D.id₂ D.⋆ᴴ F.F-id) D.⋆ⱽ F.F-seq f C.id₁)))
+
+    unitality-post : (G.F₂ D.id₂ E.⋆ⱽ G.F₂ (F.F₂ {f = f} C.id₂))
+                     ≡ G.F₂ (F.F₂ {f = f} C.id₂)
+    unitality-post = cong (E._⋆ⱽ G.F₂ (F.F₂ C.id₂)) G.F-id₂
+                   ∙ E.⋆ⱽIdL _
+  seqLaxFunctor .F-associativity f g h =
+    -- Claude
+      assoc-pre
+    ◁ (λ i → G.F-associativity (F.F₁ f) (F.F₁ g) (F.F₁ h) i
+             E.⋆ⱽ G.F₂ (F.F-associativity f g h i))
+    ▷ assoc-post
+    where
+    assoc-pre :
+        (((G.F-seq (F.F₁ f) (F.F₁ g) E.⋆ⱽ G.F₂ (F.F-seq f g)) E.⋆ᴴ E.id₂) E.⋆ⱽ
+         (G.F-seq (F.F₁ (f C.⋆₁ g)) (F.F₁ h) E.⋆ⱽ
+          G.F₂ (F.F-seq (f C.⋆₁ g) h)))
+      ≡ (((G.F-seq (F.F₁ f) (F.F₁ g) E.⋆ᴴ E.id₂) E.⋆ⱽ
+          G.F-seq (F.F₁ f D.⋆₁ F.F₁ g) (F.F₁ h)) E.⋆ⱽ
+         G.F₂ ((F.F-seq f g D.⋆ᴴ D.id₂) D.⋆ⱽ F.F-seq (f C.⋆₁ g) h))
+    assoc-pre =
+        cong (λ δ → ((G.F-seq (F.F₁ f) (F.F₁ g) E.⋆ⱽ G.F₂ (F.F-seq f g)) E.⋆ᴴ δ)
+                    E.⋆ⱽ
+                    (G.F-seq (F.F₁ (f C.⋆₁ g)) (F.F₁ h) E.⋆ⱽ
+                     G.F₂ (F.F-seq (f C.⋆₁ g) h)))
+             (sym (E.⋆ⱽIdL E.id₂))
+      ∙ cong (E._⋆ⱽ (G.F-seq (F.F₁ (f C.⋆₁ g)) (F.F₁ h) E.⋆ⱽ
+                     G.F₂ (F.F-seq (f C.⋆₁ g) h)))
+             (E.interchange (G.F-seq (F.F₁ f) (F.F₁ g)) (G.F₂ (F.F-seq f g))
+                            E.id₂ E.id₂)
+      ∙ E.⋆ⱽAssoc (G.F-seq (F.F₁ f) (F.F₁ g) E.⋆ᴴ E.id₂)
+                  (G.F₂ (F.F-seq f g) E.⋆ᴴ E.id₂)
+                  (G.F-seq (F.F₁ (f C.⋆₁ g)) (F.F₁ h) E.⋆ⱽ
+                   G.F₂ (F.F-seq (f C.⋆₁ g) h))
+      ∙ cong ((G.F-seq (F.F₁ f) (F.F₁ g) E.⋆ᴴ E.id₂) E.⋆ⱽ_)
+             (sym (E.⋆ⱽAssoc (G.F₂ (F.F-seq f g) E.⋆ᴴ E.id₂)
+                             (G.F-seq (F.F₁ (f C.⋆₁ g)) (F.F₁ h))
+                             (G.F₂ (F.F-seq (f C.⋆₁ g) h))))
+      ∙ cong (λ δ → (G.F-seq (F.F₁ f) (F.F₁ g) E.⋆ᴴ E.id₂) E.⋆ⱽ
+                    (((G.F₂ (F.F-seq f g) E.⋆ᴴ δ) E.⋆ⱽ
+                      G.F-seq (F.F₁ (f C.⋆₁ g)) (F.F₁ h)) E.⋆ⱽ
+                     G.F₂ (F.F-seq (f C.⋆₁ g) h)))
+             (sym G.F-id₂)
+      ∙ cong (λ r → (G.F-seq (F.F₁ f) (F.F₁ g) E.⋆ᴴ E.id₂) E.⋆ⱽ
+                    (r E.⋆ⱽ G.F₂ (F.F-seq (f C.⋆₁ g) h)))
+             (sym (G.F-seqᴴ (F.F-seq f g) D.id₂))
+      ∙ cong ((G.F-seq (F.F₁ f) (F.F₁ g) E.⋆ᴴ E.id₂) E.⋆ⱽ_)
+             (E.⋆ⱽAssoc (G.F-seq (F.F₁ f D.⋆₁ F.F₁ g) (F.F₁ h))
+                        (G.F₂ (F.F-seq f g D.⋆ᴴ D.id₂))
+                        (G.F₂ (F.F-seq (f C.⋆₁ g) h)))
+      ∙ cong (λ r → (G.F-seq (F.F₁ f) (F.F₁ g) E.⋆ᴴ E.id₂) E.⋆ⱽ
+                    (G.F-seq (F.F₁ f D.⋆₁ F.F₁ g) (F.F₁ h) E.⋆ⱽ r))
+             (sym (G.F-seqⱽ (F.F-seq f g D.⋆ᴴ D.id₂) (F.F-seq (f C.⋆₁ g) h)))
+      ∙ sym (E.⋆ⱽAssoc (G.F-seq (F.F₁ f) (F.F₁ g) E.⋆ᴴ E.id₂)
+                       (G.F-seq (F.F₁ f D.⋆₁ F.F₁ g) (F.F₁ h))
+                       (G.F₂ ((F.F-seq f g D.⋆ᴴ D.id₂) D.⋆ⱽ
+                              F.F-seq (f C.⋆₁ g) h)))
+
+    assoc-post :
+        (((E.id₂ E.⋆ᴴ G.F-seq (F.F₁ g) (F.F₁ h)) E.⋆ⱽ
+          G.F-seq (F.F₁ f) (F.F₁ g D.⋆₁ F.F₁ h)) E.⋆ⱽ
+         G.F₂ ((D.id₂ D.⋆ᴴ F.F-seq g h) D.⋆ⱽ F.F-seq f (g C.⋆₁ h)))
+      ≡ ((E.id₂ E.⋆ᴴ (G.F-seq (F.F₁ g) (F.F₁ h) E.⋆ⱽ G.F₂ (F.F-seq g h))) E.⋆ⱽ
+         (G.F-seq (F.F₁ f) (F.F₁ (g C.⋆₁ h)) E.⋆ⱽ
+          G.F₂ (F.F-seq f (g C.⋆₁ h))))
+    assoc-post =
+        E.⋆ⱽAssoc (E.id₂ E.⋆ᴴ G.F-seq (F.F₁ g) (F.F₁ h))
+                  (G.F-seq (F.F₁ f) (F.F₁ g D.⋆₁ F.F₁ h))
+                  (G.F₂ ((D.id₂ D.⋆ᴴ F.F-seq g h) D.⋆ⱽ F.F-seq f (g C.⋆₁ h)))
+      ∙ cong ((E.id₂ E.⋆ᴴ G.F-seq (F.F₁ g) (F.F₁ h)) E.⋆ⱽ_)
+             (cong (G.F-seq (F.F₁ f) (F.F₁ g D.⋆₁ F.F₁ h) E.⋆ⱽ_)
+                   (G.F-seqⱽ (D.id₂ D.⋆ᴴ F.F-seq g h) (F.F-seq f (g C.⋆₁ h))))
+      ∙ cong ((E.id₂ E.⋆ᴴ G.F-seq (F.F₁ g) (F.F₁ h)) E.⋆ⱽ_)
+             (sym (E.⋆ⱽAssoc (G.F-seq (F.F₁ f) (F.F₁ g D.⋆₁ F.F₁ h))
+                             (G.F₂ (D.id₂ D.⋆ᴴ F.F-seq g h))
+                             (G.F₂ (F.F-seq f (g C.⋆₁ h)))))
+      ∙ cong (λ r → (E.id₂ E.⋆ᴴ G.F-seq (F.F₁ g) (F.F₁ h)) E.⋆ⱽ
+                    (r E.⋆ⱽ G.F₂ (F.F-seq f (g C.⋆₁ h))))
+             (G.F-seqᴴ D.id₂ (F.F-seq g h))
+      ∙ cong (λ δ → (E.id₂ E.⋆ᴴ G.F-seq (F.F₁ g) (F.F₁ h)) E.⋆ⱽ
+                    (((δ E.⋆ᴴ G.F₂ (F.F-seq g h)) E.⋆ⱽ
+                      G.F-seq (F.F₁ f) (F.F₁ (g C.⋆₁ h))) E.⋆ⱽ
+                     G.F₂ (F.F-seq f (g C.⋆₁ h))))
+             G.F-id₂
+      ∙ cong ((E.id₂ E.⋆ᴴ G.F-seq (F.F₁ g) (F.F₁ h)) E.⋆ⱽ_)
+             (E.⋆ⱽAssoc (E.id₂ E.⋆ᴴ G.F₂ (F.F-seq g h))
+                        (G.F-seq (F.F₁ f) (F.F₁ (g C.⋆₁ h)))
+                        (G.F₂ (F.F-seq f (g C.⋆₁ h))))
+      ∙ sym (E.⋆ⱽAssoc (E.id₂ E.⋆ᴴ G.F-seq (F.F₁ g) (F.F₁ h))
+                       (E.id₂ E.⋆ᴴ G.F₂ (F.F-seq g h))
+                       (G.F-seq (F.F₁ f) (F.F₁ (g C.⋆₁ h)) E.⋆ⱽ
+                        G.F₂ (F.F-seq f (g C.⋆₁ h))))
+      ∙ cong (E._⋆ⱽ (G.F-seq (F.F₁ f) (F.F₁ (g C.⋆₁ h)) E.⋆ⱽ
+                     G.F₂ (F.F-seq f (g C.⋆₁ h))))
+             (sym (E.interchange E.id₂ E.id₂
+                                 (G.F-seq (F.F₁ g) (F.F₁ h))
+                                 (G.F₂ (F.F-seq g h))))
+      ∙ cong (λ δ → (δ E.⋆ᴴ (G.F-seq (F.F₁ g) (F.F₁ h) E.⋆ⱽ
+                             G.F₂ (F.F-seq g h)))
+                    E.⋆ⱽ
+                    (G.F-seq (F.F₁ f) (F.F₁ (g C.⋆₁ h)) E.⋆ⱽ
+                     G.F₂ (F.F-seq f (g C.⋆₁ h))))
+             (E.⋆ⱽIdL E.id₂)
+
+
+module _ {C : Category ℓC ℓC'} {D : Category ℓD ℓD'} (F : Functor C D) where
+  private
+    module C = Category C
+    module D = Category D
+    module F = Functor F
+
+  Functor→LaxFunctor : LaxFunctor (Cat→2Cat C) (Cat→2Cat D)
+  Functor→LaxFunctor .F₀ = F.F-ob
+  Functor→LaxFunctor .F₁ = F.F-hom
+  Functor→LaxFunctor .F₂ = cong F.F-hom
+  Functor→LaxFunctor .F-id = sym F.F-id
+  Functor→LaxFunctor .F-seq f g = sym $ F.F-seq f g
+  Functor→LaxFunctor .F-id₂ = D.isSetHom _ _ _ _
+  Functor→LaxFunctor .F-seqⱽ = λ _ _ → D.isSetHom _ _ _ _
+  Functor→LaxFunctor .F-seqᴴ = λ _ _ → D.isSetHom _ _ _ _
+  Functor→LaxFunctor .F-unitality-l _ = isProp→PathP (λ _ → D.isSetHom _ _) _ _
+  Functor→LaxFunctor .F-unitality-r _ = isProp→PathP (λ _ → D.isSetHom _ _) _ _
+  Functor→LaxFunctor .F-associativity _ _ _ = isProp→PathP (λ _ → D.isSetHom _ _) _ _

--- a/Cubical/Categories/2Functor/CodomainFibration.agda
+++ b/Cubical/Categories/2Functor/CodomainFibration.agda
@@ -1,0 +1,389 @@
+{-# OPTIONS --lossy-unification #-}
+module Cubical.Categories.2Functor.CodomainFibration where
+
+open import Cubical.Foundations.Prelude
+open import Cubical.Foundations.GroupoidLaws
+open import Cubical.Foundations.Function
+open import Cubical.Foundations.Structure
+
+open import Cubical.Data.Sigma
+import Cubical.Data.Equality as Eq
+
+open import Cubical.Categories.Category
+open import Cubical.Categories.Functor as Func
+open import Cubical.Categories.NaturalTransformation
+open import Cubical.Categories.Instances.TotalCategory
+open import Cubical.Categories.Instances.Fiber
+open import Cubical.Categories.Limits.Pullback.Alt
+
+open import Cubical.Categories.Displayed.Base
+open import Cubical.Categories.Displayed.Functor
+open import Cubical.Categories.Displayed.Functor.More
+
+open import Cubical.Categories.2Category.Base
+open import Cubical.Categories.2Functor.Base
+open import Cubical.Categories.2Functor.Fibration
+
+private
+  variable
+    ℓC ℓC' ℓC'' ℓD ℓD' ℓD'' ℓE ℓE' : Level
+
+open 2Category
+open LaxFunctor
+open PseudoFunctor
+open isPseudo
+open Functorᴰ
+open Functor
+open NatTrans
+open isIso2Cell
+
+module _ {ℓC ℓC'} (C : Category ℓC ℓC') (pb : Pullbacks C) where
+  private
+    module C = Category C
+
+  CodomainFibration-lax : LaxFunctor (Cat→2CatEq (C ^op)) (CAT {ℓC = _} {ℓC' = _})
+  CodomainFibration-lax .F₀ c = ∫C (Slice C c)
+  CodomainFibration-lax .F₁ = ChangeBase C pb
+  CodomainFibration-lax .F₂ Eq.refl = idTrans _
+  CodomainFibration-lax .F-id = ChangeBaseId C pb
+  CodomainFibration-lax .F-seq f g = ChangeBaseComp C pb f g
+  CodomainFibration-lax .F-id₂ = refl
+  CodomainFibration-lax .F-seqⱽ {y = y} Eq.refl Eq.refl =
+    makeNatTransPath (funExt λ _ → sym $ ∫C (Slice C y) .Category.⋆IdL _)
+  CodomainFibration-lax .F-seqᴴ {z = z} {f = f} {g = g} Eq.refl Eq.refl =
+    makeNatTransPath (funExt λ _ →
+        Slice.⋆IdR _
+      ∙ sym (Slice.⋆IdL _)
+      ∙ Slice.⟨ sym (ChangeBase C pb g .F-id) ⟩⋆⟨ refl ⟩
+      ∙ Slice.⟨ sym (Slice.⋆IdR _) ⟩⋆⟨ refl ⟩)
+      where module Slice = Category (∫C (Slice C z))
+  CodomainFibration-lax .F-unitality-l {x = x} {y = y} f =
+    -- Gross proof that I outsourced to Claude
+    makeNatTransPathP _ _ (λ i (a , α) → hPath (a , α) i , condPath (a , α) i)
+    where
+    module _ ((a , α) : ∫C (Slice C x) .Category.ob) where
+      module pbfα = PullbackNotation (pb f α)
+      module pbfid = PullbackNotation (pb (f C.⋆ C.id) α)
+      module pbId = PullbackNotation (pb (C.id {x}) α)
+      module pbgₗ = PullbackNotation (pb f pbId.pbπ₁)
+      -- Y = ChangeBase f applied to (F-id at (a,α))
+      Y : C.Hom[ pbfα.vert , pbgₗ.vert ]
+      Y = ChangeBase C pb f .F-hom (ChangeBaseId C pb .N-ob (a , α)) .fst
+      -- Z = F-seq id f at (a,α)
+      Z : C.Hom[ pbgₗ.vert , pbfid.vert ]
+      Z = ChangeBaseComp C pb (C.id {x}) f .N-ob (a , α) .fst
+      -- LHS.N-ob(a,α).fst computes to (Y ⋆ id) ⋆ Z
+      lhs-π₁ : ((Y C.⋆ C.id) C.⋆ Z) C.⋆ pbfid.pbπ₁ ≡ pbfα.pbπ₁
+      lhs-π₁ =
+          C.⋆Assoc _ _ _
+        ∙ C.⟨ refl ⟩⋆⟨ pbfid.pbβ₁ ⟩
+        ∙ C.⟨ C.⋆IdR _ ⟩⋆⟨ refl ⟩
+        ∙ pbgₗ.pbβ₁
+      lhs-π₂ : ((Y C.⋆ C.id) C.⋆ Z) C.⋆ pbfid.pbπ₂ ≡ pbfα.pbπ₂
+      lhs-π₂ =
+          C.⋆Assoc _ _ _
+        ∙ C.⟨ refl ⟩⋆⟨ pbfid.pbβ₂ ⟩
+        ∙ C.⟨ C.⋆IdR _ ⟩⋆⟨ refl ⟩
+        ∙ sym (C.⋆Assoc _ _ _)
+        ∙ C.⟨ pbgₗ.pbβ₂ ⟩⋆⟨ refl ⟩
+        ∙ C.⋆Assoc _ _ _
+        ∙ C.⟨ refl ⟩⋆⟨ pbId.pbβ₂ ⟩
+        ∙ C.⋆IdR _
+      -- interpolating family
+      eq : (i : I) → pbfα.pbπ₁ C.⋆ C.⋆IdR f i ≡ pbfα.pbπ₂ C.⋆ α
+      eq i = (λ j → pbfα.pbπ₁ C.⋆ C.⋆IdR f (i ∨ j)) ∙ pbfα.pbCommutes
+      θ-path : PathP (λ i → C.Hom[ pbfα.vert , PullbackNotation.vert (pb (C.⋆IdR f i) α) ])
+                     (pbfid.pbIntro pbfα.pbπ₁ pbfα.pbπ₂ (eq i0))
+                     (pbfα.pbIntro pbfα.pbπ₁ pbfα.pbπ₂ (eq i1))
+      θ-path i = PullbackNotation.pbIntro (pb (C.⋆IdR f i) α) pbfα.pbπ₁ pbfα.pbπ₂ (eq i)
+      hPath : PathP (λ i → C.Hom[ pbfα.vert , PullbackNotation.vert (pb (C.⋆IdR f i) α) ])
+                    ((Y C.⋆ C.id) C.⋆ Z) C.id
+      hPath = sym (pbfid.pbIntro≡ (sym lhs-π₁) (sym lhs-π₂)) ◁ θ-path ▷
+              pbfα.pbIntro≡ (sym (C.⋆IdL _)) (sym (C.⋆IdL _))
+      condPath : PathP (λ i → hPath i C.⋆ PullbackNotation.pbπ₁ (pb (C.⋆IdR f i) α) ≡ pbfα.pbπ₁)
+                 _ _
+      condPath = isProp→PathP (λ _ → C.isSetHom _ _) _ _
+  CodomainFibration-lax .F-unitality-r {x = x} {y = y} f =
+    -- Claude
+    makeNatTransPathP _ _ (λ i (a , α) → hPath (a , α) i , condPath (a , α) i)
+    where
+    module _ ((a , α) : ∫C (Slice C x) .Category.ob) where
+      module pbfα = PullbackNotation (pb f α)
+      module pbidf = PullbackNotation (pb (C.id C.⋆ f) α)
+      module pbIdᵧ = PullbackNotation (pb (C.id {y}) pbfα.pbπ₁)
+      -- W = F-id at (pbfα.vert, pbfα.pbπ₁) (in ∫C (Slice C y))
+      W : C.Hom[ pbfα.vert , pbIdᵧ.vert ]
+      W = ChangeBaseId C pb .N-ob (pbfα.vert , pbfα.pbπ₁) .fst
+      -- V = F-seq f id at (a,α)
+      V : C.Hom[ pbIdᵧ.vert , pbidf.vert ]
+      V = ChangeBaseComp C pb f (C.id {y}) .N-ob (a , α) .fst
+      -- LHS.N-ob(a,α).fst computes to (C.id ⋆ W) ⋆ V
+      lhs-π₁ : ((C.id C.⋆ W) C.⋆ V) C.⋆ pbidf.pbπ₁ ≡ pbfα.pbπ₁
+      lhs-π₁ =
+          C.⋆Assoc _ _ _
+        ∙ C.⟨ refl ⟩⋆⟨ pbidf.pbβ₁ ⟩
+        ∙ C.⟨ C.⋆IdL _ ⟩⋆⟨ refl ⟩
+        ∙ pbIdᵧ.pbβ₁
+      lhs-π₂ : ((C.id C.⋆ W) C.⋆ V) C.⋆ pbidf.pbπ₂ ≡ pbfα.pbπ₂
+      lhs-π₂ =
+          C.⋆Assoc _ _ _
+        ∙ C.⟨ refl ⟩⋆⟨ pbidf.pbβ₂ ⟩
+        ∙ C.⟨ C.⋆IdL _ ⟩⋆⟨ refl ⟩
+        ∙ sym (C.⋆Assoc _ _ _)
+        ∙ C.⟨ pbIdᵧ.pbβ₂ ⟩⋆⟨ refl ⟩
+        ∙ C.⋆IdL _
+      eq : (i : I) → pbfα.pbπ₁ C.⋆ C.⋆IdL f i ≡ pbfα.pbπ₂ C.⋆ α
+      eq i = (λ j → pbfα.pbπ₁ C.⋆ C.⋆IdL f (i ∨ j)) ∙ pbfα.pbCommutes
+      θ-path : PathP (λ i → C.Hom[ pbfα.vert , PullbackNotation.vert (pb (C.⋆IdL f i) α) ])
+                     (pbidf.pbIntro pbfα.pbπ₁ pbfα.pbπ₂ (eq i0))
+                     (pbfα.pbIntro pbfα.pbπ₁ pbfα.pbπ₂ (eq i1))
+      θ-path i = PullbackNotation.pbIntro (pb (C.⋆IdL f i) α) pbfα.pbπ₁ pbfα.pbπ₂ (eq i)
+      hPath : PathP (λ i → C.Hom[ pbfα.vert , PullbackNotation.vert (pb (C.⋆IdL f i) α) ])
+                    ((C.id C.⋆ W) C.⋆ V) C.id
+      hPath = sym (pbidf.pbIntro≡ (sym lhs-π₁) (sym lhs-π₂)) ◁ θ-path ▷
+              pbfα.pbIntro≡ (sym (C.⋆IdL _)) (sym (C.⋆IdL _))
+      condPath : PathP (λ i → hPath i C.⋆ PullbackNotation.pbπ₁ (pb (C.⋆IdL f i) α) ≡ pbfα.pbπ₁)
+                 _ _
+      condPath = isProp→PathP (λ _ → C.isSetHom _ _) _ _
+  CodomainFibration-lax .F-associativity {w = w} f g h =
+    -- Claude
+    makeNatTransPathP _ _ (λ i (a , α) → hPath (a , α) i , condPath (a , α) i)
+    where
+    module _ ((a , α) : ∫C (Slice C w) .Category.ob) where
+      module pbf    = PullbackNotation (pb f α)
+      module pbg    = PullbackNotation (pb g pbf.pbπ₁)
+      module pbh    = PullbackNotation (pb h pbg.pbπ₁)
+      module pbgf   = PullbackNotation (pb (g C.⋆ f) α)
+      module pbhg   = PullbackNotation (pb (h C.⋆ g) pbf.pbπ₁)
+      module pbH_gf = PullbackNotation (pb h pbgf.pbπ₁)
+      module pbLHS  = PullbackNotation (pb (h C.⋆ (g C.⋆ f)) α)
+      module pbRHS  = PullbackNotation (pb ((h C.⋆ g) C.⋆ f) α)
+
+      commonπ₂ : C.Hom[ pbh.vert , a ]
+      commonπ₂ = (pbh.pbπ₂ C.⋆ pbg.pbπ₂) C.⋆ pbf.pbπ₂
+
+      finalProof : pbh.pbπ₁ C.⋆ ((h C.⋆ g) C.⋆ f) ≡ commonπ₂ C.⋆ α
+      finalProof =
+          sym (C.⋆Assoc _ _ _)
+        ∙ C.⟨ sym (C.⋆Assoc _ _ _) ⟩⋆⟨ refl ⟩
+        ∙ C.⟨ C.⟨ pbh.pbCommutes ⟩⋆⟨ refl ⟩ ⟩⋆⟨ refl ⟩
+        ∙ C.⟨ C.⋆Assoc _ _ _ ⟩⋆⟨ refl ⟩
+        ∙ C.⟨ C.⟨ refl ⟩⋆⟨ pbg.pbCommutes ⟩ ⟩⋆⟨ refl ⟩
+        ∙ C.⟨ sym (C.⋆Assoc _ _ _) ⟩⋆⟨ refl ⟩
+        ∙ C.⋆Assoc _ _ _
+        ∙ C.⟨ refl ⟩⋆⟨ pbf.pbCommutes ⟩
+        ∙ sym (C.⋆Assoc _ _ _)
+
+      eq : (i : I) → pbh.pbπ₁ C.⋆ sym (C.⋆Assoc h g f) i ≡ commonπ₂ C.⋆ α
+      eq i = (λ j → pbh.pbπ₁ C.⋆ sym (C.⋆Assoc h g f) (i ∨ j)) ∙ finalProof
+
+      θ-path : PathP (λ i → C.Hom[ pbh.vert ,
+                                   PullbackNotation.vert (pb (sym (C.⋆Assoc h g f) i) α) ])
+                     (pbLHS.pbIntro pbh.pbπ₁ commonπ₂ (eq i0))
+                     (pbRHS.pbIntro pbh.pbπ₁ commonπ₂ (eq i1))
+      θ-path i = PullbackNotation.pbIntro
+                   (pb (sym (C.⋆Assoc h g f) i) α) pbh.pbπ₁ commonπ₂ (eq i)
+
+      LHSv : C.Hom[ pbh.vert , pbLHS.vert ]
+      LHSv =
+        ((ChangeBase C pb h .F-hom (ChangeBaseComp C pb f g .N-ob (a , α)) .fst)
+         C.⋆ C.id)
+        C.⋆ (ChangeBaseComp C pb (g C.⋆ f) h .N-ob (a , α) .fst)
+
+      lhs-π₁ : LHSv C.⋆ pbLHS.pbπ₁ ≡ pbh.pbπ₁
+      lhs-π₁ =
+          C.⋆Assoc _ _ _
+        ∙ C.⟨ refl ⟩⋆⟨ pbLHS.pbβ₁ ⟩
+        ∙ C.⟨ C.⋆IdR _ ⟩⋆⟨ refl ⟩
+        ∙ pbH_gf.pbβ₁
+
+      lhs-π₂ : LHSv C.⋆ pbLHS.pbπ₂ ≡ commonπ₂
+      lhs-π₂ =
+          C.⋆Assoc _ _ _
+        ∙ C.⟨ refl ⟩⋆⟨ pbLHS.pbβ₂ ⟩
+        ∙ C.⟨ C.⋆IdR _ ⟩⋆⟨ refl ⟩
+        ∙ sym (C.⋆Assoc _ _ _)
+        ∙ C.⟨ pbH_gf.pbβ₂ ⟩⋆⟨ refl ⟩
+        ∙ C.⋆Assoc _ _ _
+        ∙ C.⟨ refl ⟩⋆⟨ pbgf.pbβ₂ ⟩
+        ∙ sym (C.⋆Assoc _ _ _)
+
+      RHSv : C.Hom[ pbh.vert , pbRHS.vert ]
+      RHSv =
+        (((ChangeBase C pb h ∘F ChangeBase C pb g)
+              .F-hom (∫C (Slice C x) .Category.id) .fst)
+          C.⋆ (ChangeBaseComp C pb g h .N-ob (pbf.vert , pbf.pbπ₁) .fst))
+        C.⋆ (ChangeBaseComp C pb f (h C.⋆ g) .N-ob (a , α) .fst)
+        where x = _
+
+      rhs-π₁ : RHSv C.⋆ pbRHS.pbπ₁ ≡ pbh.pbπ₁
+      rhs-π₁ =
+          C.⋆Assoc _ _ _
+        ∙ C.⟨ refl ⟩⋆⟨ pbRHS.pbβ₁ ⟩
+        ∙ C.⋆Assoc _ _ _
+        ∙ C.⟨ refl ⟩⋆⟨ pbhg.pbβ₁ ⟩
+        ∙ pbh.pbβ₁
+
+      rhs-π₂ : RHSv C.⋆ pbRHS.pbπ₂ ≡ commonπ₂
+      rhs-π₂ =
+          C.⋆Assoc _ _ _
+        ∙ C.⟨ refl ⟩⋆⟨ pbRHS.pbβ₂ ⟩
+        ∙ sym (C.⋆Assoc _ _ _)
+        ∙ C.⟨ C.⋆Assoc _ _ _ ⟩⋆⟨ refl ⟩
+        ∙ C.⟨ C.⟨ refl ⟩⋆⟨ pbhg.pbβ₂ ⟩ ⟩⋆⟨ refl ⟩
+        ∙ C.⟨ sym (C.⋆Assoc _ _ _) ⟩⋆⟨ refl ⟩
+        ∙ C.⟨ C.⟨ pbh.pbβ₂ ⟩⋆⟨ refl ⟩ ⟩⋆⟨ refl ⟩
+        ∙ C.⟨ C.⋆Assoc _ _ _ ⟩⋆⟨ refl ⟩
+        ∙ C.⟨ C.⟨ refl ⟩⋆⟨ pbg.pbβ₂ ⟩ ⟩⋆⟨ refl ⟩
+        ∙ C.⟨ C.⟨ refl ⟩⋆⟨ C.⋆IdR _ ⟩ ⟩⋆⟨ refl ⟩
+
+      hPath : PathP (λ i → C.Hom[ pbh.vert ,
+                                  PullbackNotation.vert (pb (sym (C.⋆Assoc h g f) i) α) ])
+                    LHSv RHSv
+      hPath = sym (pbLHS.pbIntro≡ (sym lhs-π₁) (sym lhs-π₂)) ◁ θ-path ▷
+              pbRHS.pbIntro≡ (sym rhs-π₁) (sym rhs-π₂)
+
+      condPath : PathP (λ i → hPath i C.⋆ PullbackNotation.pbπ₁
+                               (pb (sym (C.⋆Assoc h g f) i) α) ≡ pbh.pbπ₁)
+                 _ _
+      condPath = isProp→PathP (λ _ → C.isSetHom _ _) _ _
+
+  private
+    CodomainFibration-pseudo-F-id-iso : ∀ {x : C.ob}
+      → isIso2Cell (CAT {ℓC = _} {ℓC' = _})
+          {x = CodomainFibration-lax .F₀ x} {y = CodomainFibration-lax .F₀ x}
+          (CodomainFibration-lax .F-id {x})
+    CodomainFibration-pseudo-F-id-iso {x = x} .inv .N-ob (a , α) =
+      pbId.pbπ₂ , sym pbId.pbCommutes ∙ C.⋆IdR _
+      where module pbId = PullbackNotation (pb (C.id {x}) α)
+    CodomainFibration-pseudo-F-id-iso {x = x} .inv .N-hom
+      {x = a , α} {y = b , β} (h , h≡) =
+      ΣPathP (pbIdβ.pbβ₂ , isProp→PathP (λ _ → C.isSetHom _ _) _ _)
+      where
+        module pbIdα = PullbackNotation (pb (C.id {x}) α)
+        module pbIdβ = PullbackNotation (pb (C.id {x}) β)
+    CodomainFibration-pseudo-F-id-iso {x = x} .sec =
+      makeNatTransPath (funExt λ (a , α) →
+        ΣPathP ( pbId.pbβ₂ , isProp→PathP (λ _ → C.isSetHom _ _) _ _))
+      where module pbId {a} {α : C [ a , x ]} = PullbackNotation (pb (C.id {x}) α)
+    CodomainFibration-pseudo-F-id-iso {x = x} .ret =
+      makeNatTransPath (funExt λ (a , α) →
+        ΣPathP ( pbId.pbExtensionality
+                   ( C.⋆Assoc _ _ _
+                   ∙ C.⟨ refl ⟩⋆⟨ pbId.pbβ₁ ⟩
+                   ∙ sym pbId.pbCommutes
+                   ∙ C.⋆IdR _
+                   ∙ sym (C.⋆IdL _))
+                   ( C.⋆Assoc _ _ _
+                   ∙ C.⟨ refl ⟩⋆⟨ pbId.pbβ₂ ⟩
+                   ∙ C.⋆IdR _
+                   ∙ sym (C.⋆IdL _))
+               , isProp→PathP (λ _ → C.isSetHom _ _) _ _))
+      where module pbId {a} {α : C [ a , x ]} = PullbackNotation (pb (C.id {x}) α)
+
+    CodomainFibration-pseudo-F-seq-iso : ∀ {x y z : C.ob}
+      (f : C [ y , x ]) (g : C [ z , y ])
+      → isIso2Cell (CAT {ℓC = _} {ℓC' = _})
+          {x = CodomainFibration-lax .F₀ x} {y = CodomainFibration-lax .F₀ z}
+          (CodomainFibration-lax .F-seq f g)
+    CodomainFibration-pseudo-F-seq-iso f g .inv .N-ob (a , α) =
+        pbg.pbIntro pbgf.pbπ₁
+          (pbf.pbIntro (pbgf.pbπ₁ C.⋆ g) pbgf.pbπ₂
+            (C.⋆Assoc _ _ _ ∙ pbgf.pbCommutes))
+          (sym pbf.pbβ₁)
+      , pbg.pbβ₁
+      where module pbf = PullbackNotation (pb f α)
+            module pbg = PullbackNotation (pb g pbf.pbπ₁)
+            module pbgf = PullbackNotation (pb (g C.⋆ f) α)
+    CodomainFibration-pseudo-F-seq-iso f g .inv .N-hom
+      {x = a , α} {y = b , β} (h , h≡) =
+      -- Claude
+      ΣPathP ( pbg_β.pbExtensionality
+        (  C.⋆Assoc _ _ _
+         ∙ C.⟨ refl ⟩⋆⟨ pbg_β.pbβ₁ ⟩
+         ∙ pbgf_β.pbβ₁
+         ∙ sym pbg_α.pbβ₁
+         ∙ C.⟨ refl ⟩⋆⟨ sym pbg_β.pbβ₁ ⟩
+         ∙ sym (C.⋆Assoc _ _ _))
+        (  C.⋆Assoc _ _ _
+         ∙ C.⟨ refl ⟩⋆⟨ pbg_β.pbβ₂ ⟩
+         ∙ pbf_β.pbExtensionality
+             (  C.⋆Assoc _ _ _
+              ∙ C.⟨ refl ⟩⋆⟨ pbf_β.pbβ₁ ⟩
+              ∙ sym (C.⋆Assoc _ _ _)
+              ∙ C.⟨ pbgf_β.pbβ₁ ⟩⋆⟨ refl ⟩
+              ∙ sym pbf_α.pbβ₁
+              ∙ C.⟨ refl ⟩⋆⟨ sym pbf_β.pbβ₁ ⟩
+              ∙ sym (C.⋆Assoc _ _ _))
+             (  C.⋆Assoc _ _ _
+              ∙ C.⟨ refl ⟩⋆⟨ pbf_β.pbβ₂ ⟩
+              ∙ pbgf_β.pbβ₂
+              ∙ C.⟨ sym pbf_α.pbβ₂ ⟩⋆⟨ refl ⟩
+              ∙ C.⋆Assoc _ _ _
+              ∙ C.⟨ refl ⟩⋆⟨ sym pbf_β.pbβ₂ ⟩
+              ∙ sym (C.⋆Assoc _ _ _))
+         ∙ C.⟨ sym pbg_α.pbβ₂ ⟩⋆⟨ refl ⟩
+         ∙ C.⋆Assoc _ _ _
+         ∙ C.⟨ refl ⟩⋆⟨ sym pbg_β.pbβ₂ ⟩
+         ∙ sym (C.⋆Assoc _ _ _))
+      , isProp→PathP (λ _ → C.isSetHom _ _) _ _)
+      where
+        module pbf_α = PullbackNotation (pb f α)
+        module pbf_β = PullbackNotation (pb f β)
+        module pbg_α = PullbackNotation (pb g pbf_α.pbπ₁)
+        module pbg_β = PullbackNotation (pb g pbf_β.pbπ₁)
+        module pbgf_α = PullbackNotation (pb (g C.⋆ f) α)
+        module pbgf_β = PullbackNotation (pb (g C.⋆ f) β)
+    CodomainFibration-pseudo-F-seq-iso f g .sec =
+      -- Claude
+      makeNatTransPath (funExt λ (a , α) →
+        let module pbf  = PullbackNotation (pb f α)
+            module pbg  = PullbackNotation (pb g pbf.pbπ₁)
+            module pbgf = PullbackNotation (pb (g C.⋆ f) α)
+        in ΣPathP
+          ( pbg.pbExtensionality
+              ( C.⋆Assoc _ _ _
+              ∙ C.⟨ refl ⟩⋆⟨ pbg.pbβ₁ ⟩
+              ∙ pbgf.pbβ₁
+              ∙ sym (C.⋆IdL _))
+              ( C.⋆Assoc _ _ _
+              ∙ C.⟨ refl ⟩⋆⟨ pbg.pbβ₂ ⟩
+              ∙ pbf.pbExtensionality
+                  ( C.⋆Assoc _ _ _
+                  ∙ C.⟨ refl ⟩⋆⟨ pbf.pbβ₁ ⟩
+                  ∙ sym (C.⋆Assoc _ _ _)
+                  ∙ C.⟨ pbgf.pbβ₁ ⟩⋆⟨ refl ⟩
+                  ∙ pbg.pbCommutes)
+                  ( C.⋆Assoc _ _ _
+                  ∙ C.⟨ refl ⟩⋆⟨ pbf.pbβ₂ ⟩
+                  ∙ pbgf.pbβ₂)
+              ∙ sym (C.⋆IdL _))
+          , isProp→PathP (λ _ → C.isSetHom _ _) _ _))
+    CodomainFibration-pseudo-F-seq-iso f g .ret =
+      makeNatTransPath (funExt λ (a , α) →
+        let module pbf  = PullbackNotation (pb f α)
+            module pbg  = PullbackNotation (pb g pbf.pbπ₁)
+            module pbgf = PullbackNotation (pb (g C.⋆ f) α)
+        in ΣPathP
+          ( pbgf.pbExtensionality
+              ( C.⋆Assoc _ _ _
+              ∙ C.⟨ refl ⟩⋆⟨ pbgf.pbβ₁ ⟩
+              ∙ pbg.pbβ₁
+              ∙ sym (C.⋆IdL _))
+              ( C.⋆Assoc _ _ _
+              ∙ C.⟨ refl ⟩⋆⟨ pbgf.pbβ₂ ⟩
+              ∙ sym (C.⋆Assoc _ _ _)
+              ∙ C.⟨ pbg.pbβ₂ ⟩⋆⟨ refl ⟩
+              ∙ pbf.pbβ₂
+              ∙ sym (C.⋆IdL _))
+          , isProp→PathP (λ _ → C.isSetHom _ _) _ _))
+
+  CodomainFibration-pseudo : isPseudo CodomainFibration-lax
+  CodomainFibration-pseudo .F-id-iso {x} = CodomainFibration-pseudo-F-id-iso {x}
+  CodomainFibration-pseudo .F-seq-iso f g = CodomainFibration-pseudo-F-seq-iso f g
+
+  -- Splitting lax and pseudo into separate top-level definitions is needed to
+  -- convince Agda that this definition is terminating (cf. SetsFibration).
+  CodomainFibration : FibrationEq C _ _
+  CodomainFibration .lax = CodomainFibration-lax
+  CodomainFibration .pseudo = CodomainFibration-pseudo

--- a/Cubical/Categories/2Functor/Fibration.agda
+++ b/Cubical/Categories/2Functor/Fibration.agda
@@ -1,0 +1,95 @@
+module Cubical.Categories.2Functor.Fibration where
+
+open import Cubical.Foundations.Prelude
+open import Cubical.Foundations.GroupoidLaws
+open import Cubical.Foundations.Function
+open import Cubical.Foundations.Structure
+
+open import Cubical.Data.Sigma
+import Cubical.Data.Equality as Eq
+
+open import Cubical.Categories.2Category.Base
+open import Cubical.Categories.2Functor.Base
+open import Cubical.Categories.Category
+open import Cubical.Categories.Functor as Func
+open import Cubical.Categories.NaturalTransformation
+
+private
+  variable
+    ℓC ℓC' ℓC'' ℓD ℓD' ℓD'' ℓE ℓE' : Level
+
+open 2Category
+open LaxFunctor
+open PseudoFunctor
+
+module _ {ℓC ℓC'} (C : Category ℓC ℓC') ℓD ℓD' where
+  OpFibration : Type _
+  OpFibration = PseudoFunctor (Cat→2Cat C) (CAT {ℓC = ℓD} {ℓC' = ℓD'})
+
+  OpFibrationEq : Type _
+  OpFibrationEq = PseudoFunctor (Cat→2CatEq C) (CAT {ℓC = ℓD} {ℓC' = ℓD'})
+
+module _ {ℓC ℓC'} (C : Category ℓC ℓC') ℓD ℓD' where
+  Fibration : Type _
+  Fibration = OpFibration (C ^op) ℓD ℓD'
+
+  FibrationEq : Type _
+  FibrationEq = OpFibrationEq (C ^op) ℓD ℓD'
+
+module _ {ℓC ℓC'} (C : Category ℓC ℓC') ℓD ℓD' where
+  module _ (F : Fibration C ℓD ℓD') {E : Category ℓE ℓE'} (G : Functor E C) where
+    private
+      module C = Category C
+      module E = Category E
+      module F = PseudoFunctor F
+      module G = Functor G
+      module CAT = 2Category (CAT {ℓC = ℓD} {ℓC' = ℓD'})
+
+    open isPseudo
+    open isIso2Cell
+
+    private
+      -- F's F₂ applied to any path is an iso 2-cell in CAT, with inverse
+      -- obtained by flipping the path.
+      F₂PathIsIso : ∀ {x y : C.ob} {f g : C.Hom[ y , x ]} (p : f ≡ g)
+                  → isIso2Cell (CAT {ℓC = ℓD} {ℓC' = ℓD'}) (F.F₂ p)
+      F₂PathIsIso p .inv = F.F₂ (sym p)
+      F₂PathIsIso p .sec =
+          sym (F.F-seqⱽ p (sym p))
+        ∙ cong F.F₂ (rCancel p)
+        ∙ F.F-id₂
+      F₂PathIsIso p .ret =
+          sym (F.F-seqⱽ (sym p) p)
+        ∙ cong F.F₂ (lCancel p)
+        ∙ F.F-id₂
+
+      -- Vertical composition of iso 2-cells in CAT is iso.
+      ⋆ⱽIsIso : ∀ {x y : CAT.ob} {f g h : CAT.Hom₁[ x , y ]}
+                  {α : CAT.Hom₂[ f , g ]} {β : CAT.Hom₂[ g , h ]}
+                → isIso2Cell (CAT {ℓC = ℓD} {ℓC' = ℓD'}) α
+                → isIso2Cell (CAT {ℓC = ℓD} {ℓC' = ℓD'}) β
+                → isIso2Cell (CAT {ℓC = ℓD} {ℓC' = ℓD'}) (α CAT.⋆ⱽ β)
+      ⋆ⱽIsIso {α = α} {β = β} isα isβ .inv = isβ .inv CAT.⋆ⱽ isα .inv
+      ⋆ⱽIsIso {α = α} {β = β} isα isβ .sec =
+          CAT.⋆ⱽAssoc α β (isβ .inv CAT.⋆ⱽ isα .inv)
+        ∙ cong (α CAT.⋆ⱽ_)
+               (sym (CAT.⋆ⱽAssoc β (isβ .inv) (isα .inv))
+                ∙ cong (CAT._⋆ⱽ isα .inv) (isβ .sec)
+                ∙ CAT.⋆ⱽIdL (isα .inv))
+        ∙ isα .sec
+      ⋆ⱽIsIso {α = α} {β = β} isα isβ .ret =
+          CAT.⋆ⱽAssoc (isβ .inv) (isα .inv) (α CAT.⋆ⱽ β)
+        ∙ cong (isβ .inv CAT.⋆ⱽ_)
+               (sym (CAT.⋆ⱽAssoc (isα .inv) α β)
+                ∙ cong (CAT._⋆ⱽ β) (isα .ret)
+                ∙ CAT.⋆ⱽIdL β)
+        ∙ isβ .ret
+
+    reindex : Fibration E ℓD ℓD'
+    reindex .lax = seqLaxFunctor (Functor→LaxFunctor (G ^opF)) (F .lax)
+    reindex .pseudo .F-id-iso =
+      ⋆ⱽIsIso (F .pseudo .F-id-iso)
+              (F₂PathIsIso (Functor→LaxFunctor (G ^opF) .F-id))
+    reindex .pseudo .F-seq-iso f g =
+      ⋆ⱽIsIso (F .pseudo .F-seq-iso _ _)
+              (F₂PathIsIso (Functor→LaxFunctor (G ^opF) .F-seq f g))

--- a/Cubical/Categories/2Functor/Lax.agda
+++ b/Cubical/Categories/2Functor/Lax.agda
@@ -1,0 +1,93 @@
+module Cubical.Categories.2Functor.Lax where
+
+open import Cubical.Foundations.Prelude
+open import Cubical.Foundations.Function
+open import Cubical.Foundations.Structure
+open import Cubical.Data.Sigma
+
+open import Cubical.Categories.2Category.Base
+open import Cubical.Categories.Category
+open import Cubical.Categories.Functor
+open import Cubical.Categories.NaturalTransformation
+
+private
+  variable
+    ℓ ℓ' ℓ'' ℓC ℓC' ℓC'' ℓD ℓD' ℓD'' : Level
+
+record LaxFunctor (C : 2Category ℓC ℓC' ℓC'') (D : 2Category ℓD ℓD' ℓD'') :
+    Type (ℓ-max (ℓ-max (ℓ-max ℓC ℓC') ℓC'') (ℓ-max (ℓ-max ℓD ℓD') ℓD''))
+    where
+  no-eta-equality
+
+  private
+    module C = 2Category C
+    module D = 2Category D
+
+  field
+    F₀ : C.ob → D.ob
+    F₁ : ∀ {x y} → C.Hom₁[ x , y ] → D.Hom₁[ F₀ x , F₀ y ]
+    F₂ : ∀ {x y} {f g : C.Hom₁[ x , y ]}
+       → C.Hom₂[ f , g ] → D.Hom₂[ F₁ f , F₁ g ]
+
+    F-id : ∀ {x} → D.Hom₂[ D.id₁ , F₁ (C.id₁ {x}) ]
+
+    F-seq : ∀ {x y z} (f : C.Hom₁[ x , y ]) (g : C.Hom₁[ y , z ])
+          → D.Hom₂[ (F₁ f) D.⋆₁ (F₁ g) , F₁ (f C.⋆₁ g) ]
+
+    F-id₂ : ∀ {x y} {f : C.Hom₁[ x , y ]}
+          → F₂ (C.id₂ {f = f}) ≡ D.id₂ {f = F₁ f}
+
+    F-seqⱽ : ∀ {x y} {f g h : C.Hom₁[ x , y ]}
+             (α : C.Hom₂[ f , g ]) (β : C.Hom₂[ g , h ])
+           → F₂ (α C.⋆ⱽ β) ≡ (F₂ α) D.⋆ⱽ (F₂ β)
+
+    F-seqᴴ : ∀ {x y z} {f f' : C.Hom₁[ x , y ]} {g g' : C.Hom₁[ y , z ]}
+             (α : C.Hom₂[ f , f' ]) (β : C.Hom₂[ g , g' ])
+           → (F-seq f g) D.⋆ⱽ F₂ (α C.⋆ᴴ β)
+             ≡ ((F₂ α) D.⋆ᴴ (F₂ β)) D.⋆ⱽ (F-seq f' g')
+
+    F-unitality-l : ∀ {x y} (f : C.Hom₁[ x , y ])
+                  → PathP (λ i → D.Hom₂[ D.⋆₁IdL (F₁ f) i , F₁ (C.⋆₁IdL f i) ])
+                          ((F-id D.⋆ᴴ D.id₂) D.⋆ⱽ (F-seq C.id₁ f))
+                          (F₂ C.id₂)
+
+    F-unitality-r : ∀ {x y} (f : C.Hom₁[ x , y ])
+                  → PathP (λ i → D.Hom₂[ D.⋆₁IdR (F₁ f) i , F₁ (C.⋆₁IdR f i) ])
+                          ((D.id₂ D.⋆ᴴ F-id) D.⋆ⱽ (F-seq f C.id₁))
+                          (F₂ C.id₂)
+
+    F-associativity : ∀ {w x y z} (f : C.Hom₁[ w , x ])
+                        (g : C.Hom₁[ x , y ]) (h : C.Hom₁[ y , z ])
+                    → PathP (λ i → D.Hom₂[ D.⋆₁Assoc (F₁ f) (F₁ g) (F₁ h) i
+                                         , F₁ (C.⋆₁Assoc f g h i) ])
+                            ((F-seq f g D.⋆ᴴ D.id₂) D.⋆ⱽ F-seq (f C.⋆₁ g) h)
+                            ((D.id₂ D.⋆ᴴ (F-seq g h)) D.⋆ⱽ F-seq f (g C.⋆₁ h))
+
+open 2Category
+module _ (C : 2Category ℓ ℓ' ℓ'') where
+  private module C = 2Category C
+  record isIso2Cell {x y : C.ob}
+    {f g : C.Hom₁[ x , y ]} (α : C.Hom₂[ f , g ]) : Type ℓ'' where
+    field
+      inv : C.Hom₂[ g , f ]
+      sec : α C.⋆ⱽ inv ≡ C.id₂
+      ret : inv C.⋆ⱽ α ≡ C.id₂
+
+record isPseudo {C : 2Category ℓC ℓC' ℓC''} {D : 2Category ℓD ℓD' ℓD''}
+                (F : LaxFunctor C D) :
+    Type (ℓ-max (ℓ-max (ℓ-max ℓC ℓC') ℓC'') (ℓ-max (ℓ-max ℓD ℓD') ℓD'')) where
+  private
+    module F = LaxFunctor F
+    module C = 2Category C
+    module D = 2Category D
+  field
+    F-id-iso : ∀ {x} → isIso2Cell D (F.F-id {x})
+    F-seq-iso : ∀ {x y z} (f : C.Hom₁[ x , y ]) (g : C.Hom₁[ y , z ])
+              → isIso2Cell D (F.F-seq f g)
+
+record PseudoFunctor (C : 2Category ℓC ℓC' ℓC'') (D : 2Category ℓD ℓD' ℓD'') :
+    Type (ℓ-max (ℓ-max (ℓ-max ℓC ℓC') ℓC'') (ℓ-max (ℓ-max ℓD ℓD') ℓD'')) where
+  field
+    lax : LaxFunctor C D
+    pseudo : isPseudo lax
+  open LaxFunctor lax public

--- a/Cubical/Categories/2Functor/Pseudofunctor.agda
+++ b/Cubical/Categories/2Functor/Pseudofunctor.agda
@@ -1,0 +1,59 @@
+module Cubical.Categories.2Functor.Pseudofunctor where
+
+open import Cubical.Foundations.Prelude
+open import Cubical.Foundations.Function
+open import Cubical.Foundations.Structure
+open import Cubical.Data.Sigma
+
+open import Cubical.Categories.2Category.Base
+open import Cubical.Categories.Category
+open import Cubical.Categories.Functor
+open import Cubical.Categories.NaturalTransformation
+
+private
+  variable
+    ℓC ℓC' ℓC'' ℓD ℓD' ℓD'' : Level
+
+record Pseudofunctor (C : 2Category ℓC ℓC' ℓC'') (D : 2Category ℓD ℓD' ℓD'') :
+    Type (ℓ-max (ℓ-max (ℓ-max ℓC ℓC') ℓC'') (ℓ-max (ℓ-max ℓD ℓD') ℓD'')) where
+  no-eta-equality
+
+  private
+    module C = 2Category C
+    module D = 2Category D
+
+  field
+    -- Action on objects
+    F₀ : C.ob → D.ob
+
+    -- Action on 1-morphisms
+    F₁ : ∀ {x y : C.ob} → C.Hom₁[ x , y ] → D.Hom₁[ F₀ x , F₀ y ]
+
+    -- Action on 2-cells
+    F₂ : ∀ {x y : C.ob} {f g : C.Hom₁[ x , y ]}
+       → C.Hom₂[ f , g ] → D.Hom₂[ F₁ f , F₁ g ]
+
+    -- Preservation of identity 1-morphism
+    F-id₁ : ∀ {x : C.ob} → F₁ (C.id₁ {x}) ≡ D.id₁ {F₀ x}
+
+    -- Preservation of identity 2-cell
+    F-id₂ : ∀ {x y : C.ob} {f : C.Hom₁[ x , y ]}
+          → F₂ (C.id₂ {x} {y} {f}) ≡ D.id₂ {F₀ x} {F₀ y} {F₁ f}
+
+    -- Preservation of horizontal composition (1-morphisms)
+    F-seq₁ : ∀ {x y z : C.ob} (f : C.Hom₁[ x , y ]) (g : C.Hom₁[ y , z ])
+           → F₁ (f C.⋆₁ g) ≡ (F₁ f) D.⋆₁ (F₁ g)
+
+    -- Preservation of vertical composition (2-cells)
+    F-seqⱽ : ∀ {x y : C.ob} {f g h : C.Hom₁[ x , y ]}
+             (α : C.Hom₂[ f , g ]) (β : C.Hom₂[ g , h ])
+           → F₂ (α C.⋆ⱽ β) ≡ (F₂ α) D.⋆ⱽ (F₂ β)
+
+    -- Preservation of horizontal composition (2-cells)
+    F-seqᴴ : ∀ {x y z : C.ob} {f f' : C.Hom₁[ x , y ]} {g g' : C.Hom₁[ y , z ]}
+             (α : C.Hom₂[ f , f' ]) (β : C.Hom₂[ g , g' ])
+           → PathP (λ i → D.Hom₂[ F-seq₁ f g i , F-seq₁ f' g' i ])
+                   (F₂ (α C.⋆ᴴ β))
+                   ((F₂ α) D.⋆ᴴ (F₂ β))
+
+open Pseudofunctor

--- a/Cubical/Categories/Instances/Sets/Fibration.agda
+++ b/Cubical/Categories/Instances/Sets/Fibration.agda
@@ -1,0 +1,93 @@
+module Cubical.Categories.Instances.Sets.Fibration where
+
+open import Cubical.Foundations.Prelude
+open import Cubical.Foundations.HLevels
+open import Cubical.Foundations.Equiv
+open import Cubical.Foundations.Equiv.HalfAdjoint
+open import Cubical.Foundations.Function
+open import Cubical.Foundations.Isomorphism
+open import Cubical.Foundations.Structure
+open import Cubical.Foundations.Transport
+open import Cubical.Foundations.Univalence
+open import Cubical.Functions.Embedding
+
+import Cubical.Data.Equality as Eq
+open import Cubical.Data.Sigma
+open import Cubical.Data.Unit
+
+open import Cubical.Categories.Category renaming (pathToIso to catPathToIso)
+open import Cubical.Categories.Functor
+open import Cubical.Categories.NaturalTransformation
+open import Cubical.Categories.Bifunctor
+open import Cubical.Categories.Instances.Sets
+open import Cubical.Categories.Instances.BinProduct
+open import Cubical.Categories.Instances.Functors
+open import Cubical.Categories.Presheaf
+
+open import Cubical.Categories.2Category.Base
+open import Cubical.Categories.2Functor.Base
+open import Cubical.Categories.2Functor.Fibration
+
+open 2Category
+open LaxFunctor
+open PseudoFunctor
+open isPseudo
+open isIso2Cell
+open isUnivalent
+open Functor
+open NatTrans
+
+private
+  variable
+    ℓ ℓ' : Level
+
+module _ ℓ ℓ' where
+  SetsFibration-lax :
+    LaxFunctor (Cat→2CatEq (SET ℓ ^op))
+      (CAT {ℓC = ℓ-max ℓ (ℓ-suc ℓ')} {ℓC' = ℓ-max ℓ ℓ'})
+  SetsFibration-lax .F₀ A .Category.ob = ⟨ A ⟩ → hSet ℓ'
+  SetsFibration-lax .F₀ A .Category.Hom[_,_] B B' =
+    ∀ (a : ⟨ A ⟩) → ⟨ B a ⟩ → ⟨ B' a ⟩
+  SetsFibration-lax .F₀ A .Category.id = λ a z → z
+  SetsFibration-lax .F₀ A .Category._⋆_ = λ f g a z₁ → g a (f a z₁)
+  SetsFibration-lax .F₀ A .Category.⋆IdL = λ _ → refl
+  SetsFibration-lax .F₀ A .Category.⋆IdR = λ _ → refl
+  SetsFibration-lax .F₀ A .Category.⋆Assoc = λ _ _ _ → refl
+  SetsFibration-lax .F₀ A .Category.isSetHom {y = y} =
+    isSetΠ λ _ → isSetΠ λ _ → y _ .snd
+  SetsFibration-lax .F₁ f .F-ob = λ z z₁ → z (f z₁)
+  SetsFibration-lax .F₁ f .F-hom = λ z a → z (f a)
+  SetsFibration-lax .F₁ f .F-id = refl
+  SetsFibration-lax .F₁ f .F-seq = λ _ _ → refl
+  SetsFibration-lax .F₂ Eq.refl = idTrans _
+  SetsFibration-lax .F-id .N-ob = λ x₁ a z → z
+  SetsFibration-lax .F-id .N-hom = λ _ → refl
+  SetsFibration-lax .F-seq f g .N-ob = λ x₁ a z₁ → z₁
+  SetsFibration-lax .F-seq f g .N-hom = λ _ → refl
+  SetsFibration-lax .F-id₂ = refl
+  SetsFibration-lax .F-seqⱽ Eq.refl Eq.refl = makeNatTransPath refl
+  SetsFibration-lax .F-seqᴴ Eq.refl Eq.refl = makeNatTransPath refl
+  SetsFibration-lax .F-unitality-l _ = makeNatTransPathP _ _ refl
+  SetsFibration-lax .F-unitality-r _ = makeNatTransPathP _ _ refl
+  SetsFibration-lax .F-associativity _ _ _ = makeNatTransPathP _ _ refl
+
+  SetsFibration-pseudo-F-id-iso : ∀ {A : hSet ℓ}
+    → isIso2Cell CAT {x = SetsFibration-lax .F₀ A} {y = SetsFibration-lax .F₀ A}
+      (SetsFibration-lax .F-id {A})
+  SetsFibration-pseudo-F-id-iso .inv .N-ob = λ x a z → z
+  SetsFibration-pseudo-F-id-iso .inv .N-hom = λ _ → refl
+  SetsFibration-pseudo-F-id-iso .sec = makeNatTransPath refl
+  SetsFibration-pseudo-F-id-iso .ret = makeNatTransPath refl
+
+  SetsFibration-pseudo : isPseudo SetsFibration-lax
+  SetsFibration-pseudo .F-id-iso {x} = SetsFibration-pseudo-F-id-iso {x}
+  SetsFibration-pseudo .F-seq-iso f g .inv .N-ob = λ x₁ a z₁ → z₁
+  SetsFibration-pseudo .F-seq-iso f g .inv .N-hom = λ _ → refl
+  SetsFibration-pseudo .F-seq-iso f g .sec = makeNatTransPath refl
+  SetsFibration-pseudo .F-seq-iso f g .ret = makeNatTransPath refl
+
+  -- Separating the definition of the component definitions, specifically
+  -- the isPseudo proof, to convince Agda that this definition is terminating
+  SetsFibration : FibrationEq (SET ℓ) _ _
+  SetsFibration .lax = SetsFibration-lax
+  SetsFibration .pseudo = SetsFibration-pseudo


### PR DESCRIPTION
- Defines 2-categories and lax/psuedofunctors for them
- Provides a `2Category` of categories and defines fibrations as pseudofunctors into it
- Shows that composition of lax functors is lax and uses this to define the reindexing operation on fibrations
- Shows that families of sets forms a fibration in this way
- Defines the codomain fibration for any category with pullbacks