### PR TITLE
Define strict functors

### DIFF
--- a/Cubical/Categories/Functors/Strict/Base.agda
+++ b/Cubical/Categories/Functors/Strict/Base.agda
@@ -1,0 +1,152 @@
+-- Functors that are definitonally unital and associative.
+-- Spiritually similar to the usage of PshHom over NatTrans
+--
+-- Should this be the default notion of functor?
+-- It does rely on eta-equality
+module Cubical.Categories.Functors.Strict.Base where
+
+open import Cubical.Foundations.Prelude
+open import Cubical.Foundations.HLevels
+open import Cubical.Foundations.Function
+
+import Cubical.Data.Equality as Eq
+open import Cubical.Data.Sigma
+
+open import Cubical.Categories.Category renaming (isIso to isIsoC)
+open import Cubical.Categories.Morphism
+open import Cubical.Categories.Instances.BinProduct
+open import Cubical.Categories.Bifunctor
+open import Cubical.Categories.Functor
+
+private
+  variable
+    ℓc ℓc' ℓd ℓd' ℓe ℓe' : Level
+
+module _ (C : Category ℓc ℓc') (D : Category ℓd ℓd') where
+  private
+    module C = Category C
+    module D = Category D
+  record StrictFunctor : Type (ℓ-max (ℓ-max ℓc ℓc') (ℓ-max ℓd ℓd')) where
+    open Category
+    field
+      F-ob  : C .ob → D .ob
+      F-hom : {x y : C .ob} → C [ x , y ] → D [ F-ob x , F-ob y ]
+      F-id  : {x : C .ob} (f : C [ x , x ])
+        → C .id ≡ f
+        → F-hom f ≡ D .id
+      F-seq : {x y z : C .ob}
+        (f : C [ x , y ]) (g : C [ y , z ]) (h : C [ x , z ])
+            → f C.⋆ g ≡ h
+            → F-hom h ≡ F-hom f D.⋆ F-hom g
+
+open StrictFunctor
+open Bifunctor
+open BifunctorSepAx
+
+
+SId : ∀ {C : Category ℓc ℓc'} → StrictFunctor C C
+SId .F-ob = λ z → z
+SId .F-hom = λ z → z
+SId .F-id = λ f e → sym e
+SId .F-seq = λ f g h e → sym e
+
+module _ {C : Category ℓc ℓc'} {D : Category ℓd ℓd'} {E : Category ℓe ℓe'} where
+  private
+    module E = Category E
+  _S∘_ : StrictFunctor D E → StrictFunctor C D → StrictFunctor C E
+  (G S∘ F) .F-ob = λ z → G .F-ob (F .F-ob z)
+  (G S∘ F) .F-hom = λ z → G .F-hom (F .F-hom z)
+  (G S∘ F) .F-id f e = G .F-id (F .F-hom f) (sym $ F .F-id f e)
+  (G S∘ F) .F-seq f g h e =
+    G .F-seq (F .F-hom f) (F .F-hom g) (F .F-hom h) (sym $ F .F-seq f g h e)
+
+module _ (C : Category ℓc ℓc') (D : Category ℓd ℓd') where
+  test-lUnit : (F : StrictFunctor C D) → (SId S∘ F) ≡ F
+  test-lUnit F = refl
+
+  test-rUnit : (F : StrictFunctor C D) → (F S∘ SId) ≡ F
+  test-rUnit F = refl
+
+module _ {B : Category ℓc ℓc'} {C : Category ℓd ℓd'}
+         {D : Category ℓe ℓe'} {E : Category ℓc ℓe'}
+         where
+  test-Assoc : (F : StrictFunctor B C) (G : StrictFunctor C D) (H : StrictFunctor D E)
+             → ((H S∘ G) S∘ F) ≡ (H S∘ (G S∘ F))
+  test-Assoc F G H = refl
+
+Strict→Fun : ∀ {C : Category ℓc ℓc'} {D : Category ℓd ℓd'}
+           → StrictFunctor C D → Functor C D
+Strict→Fun F .Functor.F-ob   = F .F-ob
+Strict→Fun F .Functor.F-hom  = F .F-hom
+Strict→Fun F .Functor.F-id   = F .F-id _ refl
+Strict→Fun F .Functor.F-seq f g = F .F-seq f g _ refl
+
+Fun→Strict : ∀ {C : Category ℓc ℓc'} {D : Category ℓd ℓd'}
+           → Functor C D → StrictFunctor C D
+Fun→Strict F .F-ob = F .Functor.F-ob
+Fun→Strict F .F-hom = F .Functor.F-hom
+Fun→Strict F .F-id f e =
+  cong (F .Functor.F-hom) (sym e) ∙ F .Functor.F-id
+Fun→Strict F .F-seq f g h e =
+  cong (F .Functor.F-hom) (sym e) ∙ F .Functor.F-seq f g
+
+-- Everything below here was written by Claude to
+-- port a sufficient amount of theory for
+-- completing Double.Instances.Prof
+_^opS : ∀ {C : Category ℓc ℓc'} {D : Category ℓd ℓd'}
+      → StrictFunctor C D → StrictFunctor (C ^op) (D ^op)
+(F ^opS) .F-ob = F .F-ob
+(F ^opS) .F-hom = F .F-hom
+(F ^opS) .F-id f e = F .F-id f e
+(F ^opS) .F-seq f g h e = F .F-seq g f h e
+
+compLS : ∀ {ℓc ℓc' ℓc'' ℓc''' ℓd ℓd' ℓe ℓe' : Level}
+       → {C  : Category ℓc  ℓc'}
+         {C' : Category ℓc'' ℓc'''}
+         {D  : Category ℓd  ℓd'}
+         {E  : Category ℓe  ℓe'}
+       → Bifunctor C' D E → StrictFunctor C C' → Bifunctor C D E
+compLS {C = C}{D = D}{E = E} F G = mkBifunctorSepAx B where
+  B : BifunctorSepAx C D E
+  B .Bif-ob c d = F ⟅ G .F-ob c , d ⟆b
+  B .Bif-homL f d = F ⟪ G .F-hom f ⟫l
+  B .Bif-L-id {c}{d} = (λ i → F ⟪ G .F-id (Category.id C) refl i ⟫l) ∙ F .Bif-L-id
+  B .Bif-L-seq {d = d} f f' =
+    (λ i → F ⟪ G .F-seq f f' _ refl i ⟫l) ∙ F .Bif-L-seq _ _
+  B .Bif-homR c g = F ⟪ g ⟫r
+  B .Bif-R-id = F .Bif-R-id
+  B .Bif-R-seq = F .Bif-R-seq
+  B .Bif-hom× f g = F ⟪ G .F-hom f , g ⟫×
+  B .Bif-LR-fuse f g = F .Bif-LR-fuse (G .F-hom f) g
+  B .Bif-RL-fuse f g = F .Bif-RL-fuse (G .F-hom f) g
+
+compRS : ∀ {ℓc ℓc' ℓd ℓd' ℓd'' ℓd''' ℓe ℓe' : Level}
+       → {C  : Category ℓc  ℓc'}
+         {D  : Category ℓd  ℓd'}
+         {D' : Category ℓd'' ℓd'''}
+         {E  : Category ℓe  ℓe'}
+       → Bifunctor C D' E → StrictFunctor D D' → Bifunctor C D E
+compRS {C = C}{D = D}{E = E} F H = mkBifunctorSepAx B where
+  B : BifunctorSepAx C D E
+  B .Bif-ob c d = F ⟅ c , H .F-ob d ⟆b
+  B .Bif-homL f d = F ⟪ f ⟫l
+  B .Bif-L-id = F .Bif-L-id
+  B .Bif-L-seq = F .Bif-L-seq
+  B .Bif-homR c g = F ⟪ H .F-hom g ⟫r
+  B .Bif-R-id {c}{d} = (λ i → F ⟪ H .F-id (Category.id D) refl i ⟫r) ∙ F .Bif-R-id
+  B .Bif-R-seq g g' =
+    (λ i → F ⟪ H .F-seq g g' _ refl i ⟫r) ∙ F .Bif-R-seq _ _
+  B .Bif-hom× f g = F ⟪ f , H .F-hom g ⟫×
+  B .Bif-LR-fuse f g = F .Bif-LR-fuse f (H .F-hom g)
+  B .Bif-RL-fuse f g = F .Bif-RL-fuse f (H .F-hom g)
+
+compLRS : ∀ {ℓc ℓc' ℓc'' ℓc''' ℓd ℓd' ℓd'' ℓd''' ℓe ℓe' : Level}
+        → {C  : Category ℓc  ℓc'}
+          {C' : Category ℓc'' ℓc'''}
+          {D  : Category ℓd  ℓd'}
+          {D' : Category ℓd'' ℓd'''}
+          {E  : Category ℓe  ℓe'}
+        → Bifunctor C' D' E
+        → StrictFunctor C C' → StrictFunctor D D'
+        → Bifunctor C D E
+compLRS F G H = compLS (compRS F H) G

--- a/Cubical/Categories/Functors/Strict/Bifunctor.agda
+++ b/Cubical/Categories/Functors/Strict/Bifunctor.agda
@@ -1,0 +1,344 @@
+-- Strict bifunctors
+-- Also strict relators,
+-- StrictHomBif, StrictCurryBifunctor, ⊗-BifS, natLS/natRS helpers,
+-- and the specialized CoYoneda for strict relators used by PROF.λᴴ.
+-- Written by Claude
+module Cubical.Categories.Functors.Strict.Bifunctor where
+
+open import Cubical.Foundations.Prelude
+open import Cubical.Foundations.HLevels
+open import Cubical.Foundations.Function
+open import Cubical.Foundations.Structure
+
+open import Cubical.Data.Sigma
+
+open import Cubical.Categories.Category renaming (isIso to isIsoC)
+open import Cubical.Categories.Morphism
+open import Cubical.Categories.Instances.BinProduct
+open import Cubical.Categories.Bifunctor
+open import Cubical.Categories.Functor
+open import Cubical.Categories.Instances.Sets
+open import Cubical.Categories.NaturalTransformation
+open import Cubical.Categories.Instances.Functors
+open import Cubical.Categories.Presheaf.Constructions.Tensor
+
+open import Cubical.Categories.Functors.Strict.Base
+open import Cubical.Categories.Functors.Strict.Presheaf
+
+private
+  variable
+    ℓc ℓc' ℓd ℓd' ℓe ℓe' : Level
+
+open StrictFunctor
+open Bifunctor
+open BifunctorSepAx
+
+-- ===== Strict Bifunctors =====
+-- Witness-passing identity and composition laws on both sides,
+-- mirroring BifunctorSepAx.
+
+record StrictBifunctor (C : Category ℓc ℓc')
+                       (D : Category ℓd ℓd')
+                       (E : Category ℓe ℓe')
+       : Type (ℓ-max ℓc (ℓ-max ℓc' (ℓ-max ℓd (ℓ-max ℓd' (ℓ-max ℓe ℓe'))))) where
+  private
+    module C = Category C
+    module D = Category D
+    module E = Category E
+  field
+    Bif-ob : C .Category.ob → D .Category.ob → E .Category.ob
+
+    Bif-homL : ∀ {c c'} → (f : C [ c , c' ]) → ∀ d
+             → E [ Bif-ob c d , Bif-ob c' d ]
+    Bif-L-id : ∀ {c d} (f : C [ c , c ]) → C.id ≡ f
+             → Bif-homL f d ≡ E.id
+    Bif-L-seq : ∀ {c c' c'' d}
+              (f : C [ c , c' ])(f' : C [ c' , c'' ])(h : C [ c , c'' ])
+             → f C.⋆ f' ≡ h
+             → Bif-homL h d ≡ Bif-homL f d E.⋆ Bif-homL f' d
+
+    Bif-homR : ∀ {d d'} c → (g : D [ d , d' ]) → E [ Bif-ob c d , Bif-ob c d' ]
+    Bif-R-id : ∀ {c d} (g : D [ d , d ]) → D.id ≡ g
+             → Bif-homR c g ≡ E.id
+    Bif-R-seq : ∀ {c d d' d''}
+              (g : D [ d , d' ])(g' : D [ d' , d'' ])(h : D [ d , d'' ])
+             → g D.⋆ g' ≡ h
+             → Bif-homR c h ≡ Bif-homR c g E.⋆ Bif-homR c g'
+
+    Bif-hom× : ∀ {c c' d d'} (f : C [ c , c' ])(g : D [ d , d' ])
+             → E [ Bif-ob c d , Bif-ob c' d' ]
+    Bif-LR-fuse : ∀ {c c' d d'} → (f : C [ c , c' ]) (g : D [ d , d' ])
+               → Bif-homL f d E.⋆ Bif-homR c' g
+               ≡ Bif-hom× f g
+    Bif-RL-fuse : ∀ {c c' d d'} → (f : C [ c , c' ]) (g : D [ d , d' ])
+               → Bif-homR c g E.⋆ Bif-homL f d'
+               ≡ Bif-hom× f g
+
+open StrictBifunctor
+
+StrictBif→Bif : ∀ {C : Category ℓc ℓc'}{D : Category ℓd ℓd'}{E : Category ℓe ℓe'}
+  → StrictBifunctor C D E → Bifunctor C D E
+StrictBif→Bif F = mkBifunctorSepAx B where
+  B : BifunctorSepAx _ _ _
+  B .Bif-ob = F .StrictBifunctor.Bif-ob
+  B .Bif-homL = F .StrictBifunctor.Bif-homL
+  B .BifunctorSepAx.Bif-L-id = F .Bif-L-id _ refl
+  B .BifunctorSepAx.Bif-L-seq f f' = F .Bif-L-seq f f' _ refl
+  B .Bif-homR = F .StrictBifunctor.Bif-homR
+  B .BifunctorSepAx.Bif-R-id = F .Bif-R-id _ refl
+  B .BifunctorSepAx.Bif-R-seq g g' = F .Bif-R-seq g g' _ refl
+  B .BifunctorSepAx.Bif-hom× = F .StrictBifunctor.Bif-hom×
+  B .BifunctorSepAx.Bif-LR-fuse = F .StrictBifunctor.Bif-LR-fuse
+  B .BifunctorSepAx.Bif-RL-fuse = F .StrictBifunctor.Bif-RL-fuse
+
+-- Reverse direction: any Bifunctor can be viewed as a StrictBifunctor
+-- by synthesizing the witness-passing laws from the ordinary laws.
+Bif→StrictBif : ∀ {C : Category ℓc ℓc'}{D : Category ℓd ℓd'}{E : Category ℓe ℓe'}
+  → Bifunctor C D E → StrictBifunctor C D E
+Bif→StrictBif {C = C}{D = D}{E = E} F .StrictBifunctor.Bif-ob =
+  F .Bifunctor.Bif-ob
+Bif→StrictBif {C = C}{D = D}{E = E} F .StrictBifunctor.Bif-homL =
+  F .Bifunctor.Bif-homL
+Bif→StrictBif {C = C}{D = D}{E = E} F .StrictBifunctor.Bif-L-id {d = d} f e =
+  cong (λ x → F .Bifunctor.Bif-homL x d) (sym e) ∙ F .Bifunctor.Bif-L-id
+Bif→StrictBif {C = C}{D = D}{E = E} F .StrictBifunctor.Bif-L-seq {d = d} f f' h e =
+  cong (λ x → F .Bifunctor.Bif-homL x d) (sym e) ∙ F .Bifunctor.Bif-L-seq f f'
+Bif→StrictBif {C = C}{D = D}{E = E} F .StrictBifunctor.Bif-homR =
+  F .Bifunctor.Bif-homR
+Bif→StrictBif {C = C}{D = D}{E = E} F .StrictBifunctor.Bif-R-id {c = c} g e =
+  cong (λ x → F .Bifunctor.Bif-homR c x) (sym e) ∙ F .Bifunctor.Bif-R-id
+Bif→StrictBif {C = C}{D = D}{E = E} F .StrictBifunctor.Bif-R-seq {c = c} g g' h e =
+  cong (λ x → F .Bifunctor.Bif-homR c x) (sym e) ∙ F .Bifunctor.Bif-R-seq g g'
+Bif→StrictBif {C = C}{D = D}{E = E} F .StrictBifunctor.Bif-hom× =
+  F .Bifunctor.Bif-hom×
+Bif→StrictBif {C = C}{D = D}{E = E} F .StrictBifunctor.Bif-LR-fuse =
+  F .Bifunctor.Bif-LR-fuse
+Bif→StrictBif {C = C}{D = D}{E = E} F .StrictBifunctor.Bif-RL-fuse =
+  F .Bifunctor.Bif-RL-fuse
+
+-- Strict Sym: swap the two arguments of a StrictBifunctor.
+StrictSym : ∀ {C : Category ℓc ℓc'}{D : Category ℓd ℓd'}{E : Category ℓe ℓe'}
+  → StrictBifunctor C D E → StrictBifunctor D C E
+StrictSym F .StrictBifunctor.Bif-ob d c = F .Bif-ob c d
+StrictSym F .StrictBifunctor.Bif-homL g c = F .Bif-homR c g
+StrictSym F .StrictBifunctor.Bif-L-id g e = F .Bif-R-id g e
+StrictSym F .StrictBifunctor.Bif-L-seq g g' h e = F .Bif-R-seq g g' h e
+StrictSym F .StrictBifunctor.Bif-homR d f = F .Bif-homL f d
+StrictSym F .StrictBifunctor.Bif-R-id f e = F .Bif-L-id f e
+StrictSym F .StrictBifunctor.Bif-R-seq f f' h e = F .Bif-L-seq f f' h e
+StrictSym F .StrictBifunctor.Bif-hom× g f = F .Bif-hom× f g
+StrictSym F .StrictBifunctor.Bif-LR-fuse g f = F .Bif-RL-fuse f g
+StrictSym F .StrictBifunctor.Bif-RL-fuse g f = F .Bif-LR-fuse f g
+
+-- ===== Strict Relators and constructions =====
+
+-- A strict relator: StrictBifunctor (C^op) D (SET ℓ)
+StrictRelatoro* : (C : Category ℓc ℓc') → ∀ ℓe → (D : Category ℓd ℓd')
+  → Type _
+StrictRelatoro* C ℓ D = StrictBifunctor (C ^op) D (SET ℓ)
+
+-- Strict composition of a StrictBifunctor with StrictFunctors on both sides.
+scompLS : ∀ {ℓc ℓc' ℓc'' ℓc''' ℓd ℓd' ℓe ℓe' : Level}
+  → {C : Category ℓc ℓc'}{C' : Category ℓc'' ℓc'''}
+    {D : Category ℓd ℓd'}{E : Category ℓe ℓe'}
+  → StrictBifunctor C' D E → StrictFunctor C C' → StrictBifunctor C D E
+scompLS F G .StrictBifunctor.Bif-ob c d = F .StrictBifunctor.Bif-ob (G .F-ob c) d
+scompLS F G .StrictBifunctor.Bif-homL f d = F .StrictBifunctor.Bif-homL (G .F-hom f) d
+scompLS F G .StrictBifunctor.Bif-L-id f e =
+  F .Bif-L-id (G .F-hom f) (sym (G .F-id f e))
+scompLS F G .StrictBifunctor.Bif-L-seq f f' h e =
+  F .Bif-L-seq (G .F-hom f) (G .F-hom f') (G .F-hom h) (sym (G .F-seq f f' h e))
+scompLS F G .StrictBifunctor.Bif-homR c g = F .StrictBifunctor.Bif-homR (G .F-ob c) g
+scompLS F G .StrictBifunctor.Bif-R-id g e = F .Bif-R-id g e
+scompLS F G .StrictBifunctor.Bif-R-seq g g' h e = F .Bif-R-seq g g' h e
+scompLS F G .StrictBifunctor.Bif-hom× f g = F .StrictBifunctor.Bif-hom× (G .F-hom f) g
+scompLS F G .StrictBifunctor.Bif-LR-fuse f g = F .StrictBifunctor.Bif-LR-fuse (G .F-hom f) g
+scompLS F G .StrictBifunctor.Bif-RL-fuse f g = F .StrictBifunctor.Bif-RL-fuse (G .F-hom f) g
+
+scompRS : ∀ {ℓc ℓc' ℓd ℓd' ℓd'' ℓd''' ℓe ℓe' : Level}
+  → {C : Category ℓc ℓc'}{D : Category ℓd ℓd'}
+    {D' : Category ℓd'' ℓd'''}{E : Category ℓe ℓe'}
+  → StrictBifunctor C D' E → StrictFunctor D D' → StrictBifunctor C D E
+scompRS F H .StrictBifunctor.Bif-ob c d = F .StrictBifunctor.Bif-ob c (H .F-ob d)
+scompRS F H .StrictBifunctor.Bif-homL f d = F .StrictBifunctor.Bif-homL f (H .F-ob d)
+scompRS F H .StrictBifunctor.Bif-L-id f e = F .Bif-L-id f e
+scompRS F H .StrictBifunctor.Bif-L-seq f f' h e = F .Bif-L-seq f f' h e
+scompRS F H .StrictBifunctor.Bif-homR c g = F .StrictBifunctor.Bif-homR c (H .F-hom g)
+scompRS F H .StrictBifunctor.Bif-R-id g e =
+  F .Bif-R-id (H .F-hom g) (sym (H .F-id g e))
+scompRS F H .StrictBifunctor.Bif-R-seq g g' h e =
+  F .Bif-R-seq (H .F-hom g) (H .F-hom g') (H .F-hom h) (sym (H .F-seq g g' h e))
+scompRS F H .StrictBifunctor.Bif-hom× f g = F .StrictBifunctor.Bif-hom× f (H .F-hom g)
+scompRS F H .StrictBifunctor.Bif-LR-fuse f g = F .StrictBifunctor.Bif-LR-fuse f (H .F-hom g)
+scompRS F H .StrictBifunctor.Bif-RL-fuse f g = F .StrictBifunctor.Bif-RL-fuse f (H .F-hom g)
+
+scompLRS : ∀ {ℓc ℓc' ℓc'' ℓc''' ℓd ℓd' ℓd'' ℓd''' ℓe ℓe' : Level}
+  → {C : Category ℓc ℓc'}{C' : Category ℓc'' ℓc'''}
+    {D : Category ℓd ℓd'}{D' : Category ℓd'' ℓd'''}
+    {E : Category ℓe ℓe'}
+  → StrictBifunctor C' D' E
+  → StrictFunctor C C' → StrictFunctor D D'
+  → StrictBifunctor C D E
+scompLRS F G H = scompLS (scompRS F H) G
+
+-- Strict HomBif: witness-passing identity and composition laws.
+-- Bif-hom× f g h = (f ⋆ h) ⋆ g, making LR-fuse = refl.
+module _ {ℓc ℓc' : Level} where
+  private module H (C : Category ℓc ℓc') = Category C
+  StrictHomBif : (C : Category ℓc ℓc') → StrictBifunctor (C ^op) C (SET ℓc')
+  StrictHomBif C .StrictBifunctor.Bif-ob c c' = (C [ c , c' ]) , H.isSetHom C
+  StrictHomBif C .StrictBifunctor.Bif-homL f c' g = H._⋆_ C f g
+  StrictHomBif C .StrictBifunctor.Bif-L-id f e =
+    funExt λ g → cong (λ x → H._⋆_ C x g) (sym e) ∙ H.⋆IdL C g
+  StrictHomBif C .StrictBifunctor.Bif-L-seq f f' h e =
+    funExt λ g → cong (λ x → H._⋆_ C x g) (sym e) ∙ H.⋆Assoc C f' f g
+  StrictHomBif C .StrictBifunctor.Bif-homR c g f = H._⋆_ C f g
+  StrictHomBif C .StrictBifunctor.Bif-R-id g e =
+    funExt λ f → cong (H._⋆_ C f) (sym e) ∙ H.⋆IdR C f
+  StrictHomBif C .StrictBifunctor.Bif-R-seq g g' h e =
+    funExt λ f → cong (H._⋆_ C f) (sym e) ∙ sym (H.⋆Assoc C f g g')
+  StrictHomBif C .StrictBifunctor.Bif-hom× f g h = H._⋆_ C (H._⋆_ C f h) g
+  StrictHomBif C .StrictBifunctor.Bif-LR-fuse f g = refl
+  StrictHomBif C .StrictBifunctor.Bif-RL-fuse f g =
+    funExt λ h → sym (H.⋆Assoc C f h g)
+
+-- Relator→Psh for strict relators: produces a StrictPresheaf on C ×C D^op.
+-- The key: morphisms in C ×C (D^op) are pairs, and the action is Bif-hom×.
+module _ {C : Category ℓc ℓc'} {D : Category ℓd ℓd'} where
+  StrictRelator→Psh : (P : StrictRelatoro* C ℓe D)
+    → StrictPresheaf (C ×C D ^op) ℓe
+  StrictRelator→Psh P .F-ob (c , d) = P .StrictBifunctor.Bif-ob c d
+  StrictRelator→Psh P .F-hom (f , g) = P .StrictBifunctor.Bif-hom× f g
+  StrictRelator→Psh {ℓe = ℓe} P .F-id (f , g) e =
+    sym (P .StrictBifunctor.Bif-LR-fuse f g)
+    -- ∙ cong₂ (P .Bif-L-id f (cong fst e)) (P .Bif-R-id g (cong snd e))
+    ∙ funExt (λ y → funExt⁻ (P .Bif-R-id g (cong snd e)) _
+                  ∙ funExt⁻ (P .Bif-L-id f (cong fst e)) _)
+    where open Category (SET ℓe)
+  StrictRelator→Psh {ℓe = ℓe} P .F-seq (f₁ , g₁) (f₂ , g₂) (f , g) e =
+    sym (P .Bif-LR-fuse f g)
+    ∙ funExt (λ y →
+        -- Start: R(c'',g)(L(f,d)(y))
+        funExt⁻ (P .Bif-R-seq g₁ g₂ g (cong snd e)) (P .Bif-homL f _ y)
+        -- Expand L(f,d)(y) to L(f₂,d)(L(f₁,d)(y))
+        ∙ cong (λ x → P .Bif-homR _ g₂ (P .Bif-homR _ g₁ x))
+               (funExt⁻ (P .Bif-L-seq f₁ f₂ f (cong fst e)) y)
+        -- Interchange: R(c'',g₁)∘L(f₂,d) = L(f₂,d')∘R(c',g₁)
+        ∙ cong (P .Bif-homR _ g₂)
+               (funExt⁻ (P .Bif-LR-fuse f₂ g₁
+                       ∙ sym (P .Bif-RL-fuse f₂ g₁))
+                        (P .Bif-homL f₁ _ y))
+        -- Fold R(c'',g₂)∘L(f₂,d') into hom×(f₂,g₂)
+        ∙ funExt⁻ (P .Bif-LR-fuse f₂ g₂) _
+        -- Fold R(c',g₁)∘L(f₁,d) into hom×(f₁,g₁)
+        ∙ cong (P .Bif-hom× f₂ g₂)
+               (funExt⁻ (P .Bif-LR-fuse f₁ g₁) y))
+    where open Category (SET ℓe)
+
+-- Strict CurryBifunctor: StrictBifunctor → StrictFunctor C (FUNCTOR D E).
+-- The witness-passing F-id/F-seq use makeNatTransPath.
+StrictCurryBifunctor : ∀ {C : Category ℓc ℓc'}{D : Category ℓd ℓd'}{E : Category ℓe ℓe'}
+  → StrictBifunctor C D E → StrictFunctor C (FUNCTOR D E)
+StrictCurryBifunctor F .F-ob c = appL (StrictBif→Bif F) c
+StrictCurryBifunctor F .F-hom f .NatTrans.N-ob d = appR (StrictBif→Bif F) d .Functor.F-hom f
+StrictCurryBifunctor F .F-hom f .NatTrans.N-hom g = Bif-RL-commute (StrictBif→Bif F) f g
+StrictCurryBifunctor F .F-id f e =
+  makeNatTransPath (funExt λ d → F .Bif-L-id f e)
+StrictCurryBifunctor F .F-seq f₁ f₂ f e =
+  makeNatTransPath (funExt λ d → F .Bif-L-seq f₁ f₂ f e)
+
+-- Strict ⊗-Bif: the tensor product of presheaves as a StrictBifunctor.
+-- Obtained by converting the non-strict ⊗-Bif via Bif→StrictBif.
+module _ {C : Category ℓc ℓc'} where
+  ⊗-BifS : ∀ {ℓP ℓQ}
+    → StrictBifunctor (FUNCTOR C (SET ℓP))
+                      (FUNCTOR (C ^op) (SET ℓQ))
+                      (SET (ℓ-max (ℓ-max ℓc ℓc') (ℓ-max ℓP ℓQ)))
+  ⊗-BifS = Bif→StrictBif (⊗-Bif {C = C})
+
+-- ===== L/R naturality helpers for SPshHom on strict relators =====
+module _ {C : Category ℓc ℓc'} {D : Category ℓd ℓd'} {ℓp ℓq}
+  (P : StrictRelatoro* C ℓp D) (Q : StrictRelatoro* C ℓq D)
+  where
+  private
+    module Cm = Category C
+    module Dm = Category D
+    module P = StrictBifunctor P
+    module Q = StrictBifunctor Q
+
+  open SPshHom
+
+  natLS : (α : SPshHom (StrictRelator→Psh P) (StrictRelator→Psh Q))
+        → ∀ {c c' d} (f : C [ c' , c ]) (p : ⟨ P.Bif-ob c d ⟩)
+        → α .N-ob (c' , d) (P.Bif-homL f d p)
+        ≡ Q.Bif-homL f d (α .N-ob (c , d) p)
+  natLS α {c}{c'}{d} f p =
+    sym (α .N-hom (c' , d) (c , d) (f , Dm.id) p (P.Bif-homL f d p) witness-P)
+    ∙ witness-Q
+    where
+      witness-P : P.Bif-hom× f Dm.id p ≡ P.Bif-homL f d p
+      witness-P = funExt⁻ (sym (P.Bif-LR-fuse f Dm.id)) p
+                ∙ funExt⁻ (P.Bif-R-id Dm.id refl) (P.Bif-homL f d p)
+      witness-Q : Q.Bif-hom× f Dm.id (α .N-ob (c , d) p)
+                ≡ Q.Bif-homL f d (α .N-ob (c , d) p)
+      witness-Q = funExt⁻ (sym (Q.Bif-LR-fuse f Dm.id)) _
+                ∙ funExt⁻ (Q.Bif-R-id Dm.id refl) _
+
+  natRS : (α : SPshHom (StrictRelator→Psh P) (StrictRelator→Psh Q))
+        → ∀ {c d d'} (g : D [ d , d' ]) (p : ⟨ P.Bif-ob c d ⟩)
+        → α .N-ob (c , d') (P.Bif-homR c g p)
+        ≡ Q.Bif-homR c g (α .N-ob (c , d) p)
+  natRS α {c}{d}{d'} g p =
+    sym (α .N-hom (c , d') (c , d) (Cm.id , g) p (P.Bif-homR c g p) witness-P)
+    ∙ witness-Q
+    where
+      witness-P : P.Bif-hom× Cm.id g p ≡ P.Bif-homR c g p
+      witness-P = funExt⁻ (sym (P.Bif-RL-fuse Cm.id g)) p
+                ∙ funExt⁻ (P.Bif-L-id Cm.id refl) (P.Bif-homR c g p)
+      witness-Q : Q.Bif-hom× Cm.id g (α .N-ob (c , d) p)
+                ≡ Q.Bif-homR c g (α .N-ob (c , d) p)
+      witness-Q = funExt⁻ (sym (Q.Bif-RL-fuse Cm.id g)) _
+                ∙ funExt⁻ (Q.Bif-L-id Cm.id refl) _
+
+-- ===== Specialized CoYoneda for strict relators =====
+-- PROF.λᴴ needs an iso between the tensor
+--   (appL (StrictBif→Bif (StrictHomBif C)) c ⊗ appL (StrictBif→Bif (StrictSym f)) d)
+-- and ⟨ f .Bif-ob c d ⟩.  This is CoYoneda specialized to the strict
+-- relator's shape, so we can take advantage of fr's witness-passing
+-- L-id/L-seq laws directly rather than going through Fun→Strict.
+module _ {C : Category ℓc ℓc'}{D : Category ℓd ℓd'}{ℓp}
+  (fr : StrictRelatoro* C ℓp D) where
+  private
+    module fr = StrictBifunctor fr
+    module Cm = Category C
+    module Dm = Category D
+
+  λRelPc : Cm.ob → Functor C (SET ℓc')
+  λRelPc c = appL (StrictBif→Bif (StrictHomBif C)) c
+
+  λRelQd : Dm.ob → Functor (C ^op) (SET ℓp)
+  λRelQd d = appL (StrictBif→Bif (StrictSym fr)) d
+
+  λRel-ob : ∀ c d → (λRelPc c ⊗ λRelQd d) → ⟨ fr .Bif-ob c d ⟩
+  λRel-ob c d = T.rec (fr .Bif-ob c d .snd)
+    (λ {x} g p → fr .Bif-homL g d p)
+    (λ {x}{y} p h q → sym (funExt⁻ (fr .Bif-L-seq h p _ refl) q))
+    where module T = Tensor (λRelPc c) (λRelQd d)
+
+  λRel⁻-ob : ∀ c d → ⟨ fr .Bif-ob c d ⟩ → (λRelPc c ⊗ λRelQd d)
+  λRel⁻-ob c d p = Cm.id T.,⊗ p
+    where module T = Tensor (λRelPc c) (λRelQd d)
+
+  -- Section: λRel-ob ∘ λRel⁻-ob = id
+  λRel-sec : ∀ c d (p : ⟨ fr .Bif-ob c d ⟩)
+           → λRel-ob c d (λRel⁻-ob c d p) ≡ p
+  λRel-sec c d p = funExt⁻ (fr .Bif-L-id Cm.id refl) p
+
+  -- Retraction: λRel⁻-ob ∘ λRel-ob = id
+  λRel-ret : ∀ c d (x : λRelPc c ⊗ λRelQd d)
+           → λRel⁻-ob c d (λRel-ob c d x) ≡ x
+  λRel-ret c d = T.ind (λ _ → T.isSet⊗ _ _)
+    (λ {y} g p →
+      T.swap Cm.id g p
+      ∙ cong (T._,⊗ p) (Cm.⋆IdL g))
+    where module T = Tensor (λRelPc c) (λRelQd d)

--- a/Cubical/Categories/Functors/Strict/Presheaf.agda
+++ b/Cubical/Categories/Functors/Strict/Presheaf.agda
@@ -1,0 +1,274 @@
+-- Strict presheaves, strict natural transformations, and SPshHom
+-- Written by Claude
+module Cubical.Categories.Functors.Strict.Presheaf where
+
+open import Cubical.Foundations.Prelude
+open import Cubical.Foundations.HLevels
+open import Cubical.Foundations.Function
+open import Cubical.Foundations.More
+open import Cubical.Foundations.Structure
+open import Cubical.Foundations.Isomorphism
+
+open import Cubical.Data.Sigma
+
+open import Cubical.Categories.Category renaming (isIso to isIsoC)
+open import Cubical.Categories.Morphism
+open import Cubical.Categories.Functor
+open import Cubical.Categories.Instances.Sets
+open import Cubical.Categories.Presheaf.Constructions.Tensor
+  using (◇; CoYoneda)
+open import Cubical.Categories.Presheaf.Morphism.Alt as PshMor
+  using (PshHom; PshIso; isPshIso)
+
+open import Cubical.Categories.Functors.Strict.Base
+open StrictFunctor
+
+private
+  variable
+    ℓc ℓc' ℓd ℓd' : Level
+
+module _  (C : Category ℓc ℓc') where
+  StrictPresheaf : (ℓ : Level) → Type _
+  StrictPresheaf ℓ = StrictFunctor (C ^op) (SET ℓ)
+
+module _ {C : Category ℓc ℓc'} {D : Category ℓd ℓd'} where
+  private
+    module C = Category C
+    module D = Category D
+
+  Strict-N-ob-Type : (F G : StrictFunctor C D) → Type _
+  Strict-N-ob-Type F G = (x : C.ob) → D.Hom[ F .F-ob x , G .F-ob x ]
+
+  Strict-N-hom-Type : (F G : StrictFunctor C D) → Strict-N-ob-Type F G → Type _
+  Strict-N-hom-Type F G ϕ = {x y : C.ob} (f : C [ x , y ])
+    → (g : D [ F .F-ob x , G .F-ob y ])
+    → (ϕ x D.⋆ G .F-hom f) ≡ g
+    → F .F-hom f D.⋆ ϕ y ≡ g
+
+
+  record StrictNatTrans (F G : StrictFunctor C D) : Type (ℓ-max (ℓ-max ℓc ℓc') ℓd') where
+    constructor natTrans
+    field
+      N-ob : Strict-N-ob-Type F G
+      N-hom :  Strict-N-hom-Type F G N-ob
+
+  record StrictNatIso (F G : StrictFunctor C D): Type (ℓ-max (ℓ-max ℓc ℓc') (ℓ-max ℓd ℓd')) where
+    field
+      trans : StrictNatTrans F G
+    open StrictNatTrans trans
+
+    field
+      Strict-nIso : ∀ (x : C.ob) → isIsoC D (N-ob x)
+
+  open StrictNatTrans
+
+  idStrictTrans : (F : StrictFunctor C D) → StrictNatTrans F F
+  idStrictTrans F .N-ob x = D.id
+  idStrictTrans F .N-hom f g p = D.⋆IdR _ ∙ (sym $ D.⋆IdL _) ∙ p
+
+  seqStrictTrans : {F G H : StrictFunctor C D}
+    (α : StrictNatTrans F G)
+    (β : StrictNatTrans G H) → StrictNatTrans F H
+  seqStrictTrans α β .N-ob x = (α .N-ob x) D.⋆ (β .N-ob x)
+  seqStrictTrans α β .N-hom f g p = compSq D (N-hom α f _ refl) (N-hom β f _ refl) ∙ p
+
+  makeStrictNatTransPath : {F G : StrictFunctor C D}
+    {α β : StrictNatTrans F G} →
+    α .N-ob ≡ β .N-ob → α ≡ β
+  makeStrictNatTransPath p i .N-ob = p i
+  makeStrictNatTransPath {F = F}{G = G}{α = α}{β = β} p i .N-hom f g q = help i q
+    where
+    help : PathP
+      (λ i → p i _ D.⋆ G .F-hom f ≡ g → F .F-hom f D.⋆ p i _ ≡ g)
+      (α .N-hom f g) (β .N-hom f g)
+    help = toPathP (funExt λ r → D .Category.isSetHom _ _ _ _)
+
+
+  module _ {F G : StrictFunctor C D} (α : StrictNatTrans F G) where
+    private
+      testStrictTrans-lUnit : seqStrictTrans (idStrictTrans F) α ≡ α
+      testStrictTrans-lUnit = makeStrictNatTransPath (funExt (λ _ → D.⋆IdL _))
+
+module _ {C : Category ℓc ℓc'} {ℓ} {P Q : StrictPresheaf C ℓ}
+  (α : StrictNatTrans P Q) where
+  private
+    module C = Category C
+
+    testStrictTrans-lUnit : seqStrictTrans (idStrictTrans P) α ≡ α
+    testStrictTrans-lUnit = makeStrictNatTransPath refl
+
+-- ===== Strict presheaf homomorphisms =====
+-- PshHomStrict between StrictPresheaves.  N-ob is a plain function
+-- (not a D.Hom), so identity is (λ z → z) and composition is
+-- function composition — both definitionally unital and associative.
+
+module _ {C : Category ℓc ℓc'} where
+  private
+    module C = Category C
+
+  module _ {ℓp ℓq} (P : StrictPresheaf C ℓp) (Q : StrictPresheaf C ℓq) where
+    SPshHom-N-ob-Type : Type _
+    SPshHom-N-ob-Type = ∀ (c : C.ob) → ⟨ P .F-ob c ⟩ → ⟨ Q .F-ob c ⟩
+
+    SPshHom-N-hom-Type : SPshHom-N-ob-Type → Type _
+    SPshHom-N-hom-Type ϕ =
+      ∀ c c' (f : C [ c , c' ]) (p' : ⟨ P .F-ob c' ⟩) p
+        → P .F-hom f p' ≡ p
+        → Q .F-hom f (ϕ c' p') ≡ ϕ c p
+
+    record SPshHom : Type (ℓc ⊔ℓ ℓc' ⊔ℓ ℓp ⊔ℓ ℓq) where
+      constructor spshhom
+      field
+        N-ob  : SPshHom-N-ob-Type
+        N-hom : SPshHom-N-hom-Type N-ob
+
+    isPropSPshHom-N-hom : (ϕ : SPshHom-N-ob-Type)
+      → isProp (SPshHom-N-hom-Type ϕ)
+    isPropSPshHom-N-hom ϕ = isPropΠ6
+      (λ c _ _ _ _ _ → (Q .F-ob c) .snd _ _)
+
+    SPshHomΣ : Type _
+    SPshHomΣ = Σ SPshHom-N-ob-Type SPshHom-N-hom-Type
+
+    isSetSPshHomΣ : isSet SPshHomΣ
+    isSetSPshHomΣ = isSetΣ
+      (isSetΠ λ c → isSet→ ((Q .F-ob c) .snd))
+      (λ _ → isProp→isSet (isPropSPshHom-N-hom _))
+
+    SPshHomΣIso : Iso SPshHom SPshHomΣ
+    SPshHomΣIso .Iso.fun α = α .SPshHom.N-ob , α .SPshHom.N-hom
+    SPshHomΣIso .Iso.inv (ϕ , h) = spshhom ϕ h
+    SPshHomΣIso .Iso.sec _ = refl
+    SPshHomΣIso .Iso.ret _ = refl
+
+    isSetSPshHom : isSet SPshHom
+    isSetSPshHom = isOfHLevelRetractFromIso 2 SPshHomΣIso isSetSPshHomΣ
+
+  open SPshHom
+
+  module _ {P Q : StrictPresheaf C ℓc} where
+    makeSPshHomΣPath : ∀ {α β : SPshHomΣ P Q} → α .fst ≡ β .fst
+      → α ≡ β
+    makeSPshHomΣPath = Σ≡Prop (isPropSPshHom-N-hom P Q)
+
+    makeSPshHomPath : ∀ {α β : SPshHom P Q} → α .N-ob ≡ β .N-ob
+      → α ≡ β
+    makeSPshHomPath {α} {β} p =
+      isoFunInjective (SPshHomΣIso P Q) α β (makeSPshHomΣPath p)
+
+  -- Identity and composition
+  idSPshHom : {P : StrictPresheaf C ℓc} → SPshHom P P
+  idSPshHom .N-ob c p = p
+  idSPshHom .N-hom c c' f p' p eq = eq
+
+  _⋆SPshHom_ : {P : StrictPresheaf C ℓc}
+    {Q : StrictPresheaf C ℓc}
+    {R : StrictPresheaf C ℓc}
+    → SPshHom P Q → SPshHom Q R → SPshHom P R
+  (α ⋆SPshHom β) .N-ob c p = β .N-ob c (α .N-ob c p)
+  (α ⋆SPshHom β) .N-hom c c' f p' p eq =
+    β .N-hom c c' f (α .N-ob c' p') (α .N-ob c p) (α .N-hom c c' f p' p eq)
+  infixr 9 _⋆SPshHom_
+
+  -- Definitional unit and associativity
+  module _ {P Q : StrictPresheaf C ℓc} (α : SPshHom P Q) where
+    private
+      test-⋆SPshHomIdL : idSPshHom ⋆SPshHom α ≡ α
+      test-⋆SPshHomIdL = refl
+
+      test-⋆SPshHomIdR : α ⋆SPshHom idSPshHom ≡ α
+      test-⋆SPshHomIdR = refl
+
+  module _ {P Q R S : StrictPresheaf C ℓc}
+    (α : SPshHom P Q)(β : SPshHom Q R)(γ : SPshHom R S) where
+    private
+      test-⋆SPshHomAssoc :
+        (α ⋆SPshHom β) ⋆SPshHom γ ≡ α ⋆SPshHom (β ⋆SPshHom γ)
+      test-⋆SPshHomAssoc = refl
+
+  -- Iso variant
+  record SPshIso (P Q : StrictPresheaf C ℓc) : Type (ℓ-max (ℓ-max ℓc ℓc') ℓc) where
+    field
+      trans : SPshHom P Q
+      nIso  : ∀ x → isIso (trans .N-ob x)
+
+  open SPshIso
+
+  module _ {P Q : StrictPresheaf C ℓc} where
+    invSPshIso : SPshIso P Q → SPshIso Q P
+    invSPshIso α .trans .N-ob c = α .nIso c .fst
+    invSPshIso α .trans .N-hom c c' f q' q eq =
+      sym (α .nIso c .snd .snd _)
+      ∙ cong (α .nIso c .fst)
+        (sym (α .trans .N-hom c c' f _ _ refl)
+        ∙ cong (Q .F-hom f) (α .nIso c' .snd .fst q')
+        ∙ eq)
+    invSPshIso α .nIso x .fst = α .trans .N-ob x
+    invSPshIso α .nIso x .snd .fst = α .nIso x .snd .snd
+    invSPshIso α .nIso x .snd .snd = α .nIso x .snd .fst
+
+  idSPshIso : {P : StrictPresheaf C ℓc} → SPshIso P P
+  idSPshIso .trans = idSPshHom
+  idSPshIso .nIso _ = IsoToIsIso idIso
+
+-- ===== Strict ◇ and CoYoneda =====
+
+-- Convert a PshHom between the underlying functors of two strict
+-- presheaves to an SPshHom (witness-passing form).
+PshHom→SPshHom : ∀ {C : Category ℓc ℓc'} {ℓp ℓq}
+  → {P : StrictPresheaf C ℓp}{Q : StrictPresheaf C ℓq}
+  → PshHom (Strict→Fun P) (Strict→Fun Q)
+  → SPshHom P Q
+PshHom→SPshHom α .SPshHom.N-ob = α .PshHom.N-ob
+PshHom→SPshHom α .SPshHom.N-hom c c' f p' p eq =
+  sym (α .PshHom.N-hom c c' f p') ∙ cong (α .PshHom.N-ob c) eq
+
+module _ {C : Category ℓc ℓc'} where
+  -- Strict ◇: wrap the non-strict ◇ via Fun→Strict.
+  ◇S : ∀ {ℓP} → StrictPresheaf C ℓP
+     → StrictPresheaf C (ℓ-max (ℓ-max ℓc ℓc') ℓP)
+  ◇S P = Fun→Strict (◇ (Strict→Fun P))
+
+  -- Strict CoYoneda: forward direction as an SPshHom, defined
+  -- directly to avoid Functor F-id mismatch from Fun→Strict roundtrip.
+  CoYonedaSHom : ∀ {ℓP} (P : StrictPresheaf C ℓP)
+    → SPshHom P (◇S P)
+  CoYonedaSHom P .SPshHom.N-ob x p =
+    CoYoneda (Strict→Fun P) .PshIso.trans .PshHom.N-ob x p
+  CoYonedaSHom P .SPshHom.N-hom c c' f p' p eq =
+    sym (CoYoneda (Strict→Fun P) .PshIso.trans .PshHom.N-hom c c' f p')
+    ∙ cong (CoYoneda (Strict→Fun P) .PshIso.trans .PshHom.N-ob c) eq
+
+  -- Strict CoYoneda: inverse direction as an SPshHom.
+  CoYonedaSInv : ∀ {ℓP} (P : StrictPresheaf C ℓP)
+    → SPshHom (◇S P) P
+  CoYonedaSInv P .SPshHom.N-ob x =
+    CoYoneda (Strict→Fun P) .PshIso.nIso x .fst
+  CoYonedaSInv {ℓP = ℓP} P .SPshHom.N-hom c c' f p' p eq =
+    let P'   = Strict→Fun P
+        α    = CoYoneda P'
+        tr   : ∀ x → ⟨ P' .Functor.F-ob x ⟩ → ⟨ ◇ P' .Functor.F-ob x ⟩
+        tr x = α .PshIso.trans .PshHom.N-ob x
+        inv  : ∀ x → ⟨ ◇ P' .Functor.F-ob x ⟩ → ⟨ P' .Functor.F-ob x ⟩
+        inv x = α .PshIso.nIso x .fst
+        sec  : ∀ x q → tr x (inv x q) ≡ q
+        sec x = α .PshIso.nIso x .snd .fst
+        ret  : ∀ x q → inv x (tr x q) ≡ q
+        ret x = α .PshIso.nIso x .snd .snd
+        step : tr c (P' .Functor.F-hom f (inv c' p')) ≡ p
+        step = α .PshIso.trans .PshHom.N-hom c c' f (inv c' p')
+             ∙ cong (◇ P' .Functor.F-hom f) (sec c' p')
+             ∙ eq
+    in sym (ret c (P' .Functor.F-hom f (inv c' p')))
+       ∙ cong (inv c) step
+
+  -- Section/retraction witnesses.
+  CoYonedaSSec : ∀ {ℓP} (P : StrictPresheaf C ℓP)
+    → ∀ x p → CoYonedaSInv P .SPshHom.N-ob x
+              (CoYonedaSHom P .SPshHom.N-ob x p) ≡ p
+  CoYonedaSSec P x = CoYoneda (Strict→Fun P) .PshIso.nIso x .snd .snd
+
+  CoYonedaSRet : ∀ {ℓP} (P : StrictPresheaf C ℓP)
+    → ∀ x p → CoYonedaSHom P .SPshHom.N-ob x
+              (CoYonedaSInv P .SPshHom.N-ob x p) ≡ p
+  CoYonedaSRet P x = CoYoneda (Strict→Fun P) .PshIso.nIso x .snd .fst


### PR DESCRIPTION
- Defines a type of functors such that the unit and associativity laws hold definitionally
- Defines a notion of natural transformation for these functors, but this type of natural transformations does not enjoy the same strictness properties. I don't think a type of general natural transformations ever can, because of `N-ob` being valued in an abstract type of morphism
- Also defines an accompanying notion of strict bifunctors and `PshHom` to interoperate with `StrictFunctor`. These are less thought out. I simply had Claude port a sufficient amount of code for using these strict functors when describing a double category of profunctors (to come in a later PR)

The motivating reason for `StrictFunctor` is that goals that mention a composition of functors `F ∘F Id` often force us to use heterogeneous paths because this composite is not definitionally `F`. We are able to use homogeneous paths by providing a type of functors for which this is a definitional equality. 

I'm curious but unsure if we would wish to use `StrictFunctor` as the default notion of functor. It relies on `eta-equality`, which isn't consistent with our recent `no-eta-equality` refactors