### PR TITLE
Define double categories

### DIFF
--- a/Cubical/Categories/Double/Base.agda
+++ b/Cubical/Categories/Double/Base.agda
@@ -1,0 +1,220 @@
+{-# OPTIONS --lossy-unification #-}
+module Cubical.Categories.Double.Base where
+
+open import Cubical.Foundations.Prelude
+open import Cubical.Foundations.More
+open import Cubical.Foundations.Function
+open import Cubical.Foundations.HLevels
+open import Cubical.Foundations.Isomorphism
+open import Cubical.Foundations.Structure
+
+open import Cubical.Reflection.RecordEquiv
+open import Cubical.Reflection.RecordEquiv.More
+
+open import Cubical.Data.Sigma
+open import Cubical.Data.Sigma.More
+import Cubical.Data.Equality as Eq
+open import Cubical.Data.Unit
+import Cubical.Data.Equality as Eq
+
+open import Cubical.Categories.Category
+open import Cubical.Categories.Functor
+open import Cubical.Categories.Bifunctor
+open import Cubical.Categories.Presheaf.Base
+open import Cubical.Categories.Presheaf.More
+open import Cubical.Categories.Instances.Sets
+open import Cubical.Categories.Limits.Pullback
+open import Cubical.Categories.Limits.Pullback.More
+open import Cubical.Categories.Functors.Constant
+open import Cubical.Categories.Profunctor.General
+open import Cubical.Categories.Profunctor.Relator
+open import Cubical.Categories.Presheaf.Morphism.Alt
+open import Cubical.Categories.Presheaf.Constructions.Tensor
+open import Cubical.Categories.NaturalTransformation
+
+open import Cubical.Categories.Displayed.Base
+
+private
+  variable
+    ℓC ℓV ℓH : Level
+
+-- A Pseudo Double Category
+record DoubleCategory ℓC ℓH ℓV ℓS :
+  Type (ℓ-max (ℓ-suc (ℓ-max (ℓ-max ℓC ℓS) ℓH)) (ℓ-suc ℓV))
+  where
+  no-eta-equality
+  field
+    ob : Type ℓC
+
+    -- Strict vertical morphisms
+    Homⱽ[_,_] : (x y : ob) → Type ℓV
+    idⱽ   : ∀ {x} → Homⱽ[ x , x ]
+    _⋆ⱽ_  : ∀ {x y z} (f : Homⱽ[ x , y ]) (g : Homⱽ[ y , z ]) → Homⱽ[ x , z ]
+    ⋆ⱽIdL : ∀ {x y} (f : Homⱽ[ x , y ]) → idⱽ ⋆ⱽ f ≡ f
+    ⋆ⱽIdR : ∀ {x y} (f : Homⱽ[ x , y ]) → f ⋆ⱽ idⱽ ≡ f
+    ⋆ⱽAssoc : ∀ {x y z w} (f : Homⱽ[ x , y ]) (g : Homⱽ[ y , z ]) (h : Homⱽ[ z , w ])
+           → (f ⋆ⱽ g) ⋆ⱽ h ≡ f ⋆ⱽ (g ⋆ⱽ h)
+    -- isSetHomⱽ : ∀ {x y} → isSet Homⱽ[ x , y ]
+
+    -- Weak horizontal morphisms
+    Homᴴ[_,_] : (x y : ob) → Type ℓH
+    idᴴ   : ∀ {x} → Homᴴ[ x , x ]
+    _⋆ᴴ_  : ∀ {x y z} →
+      (f : Homᴴ[ x , y ]) (g : Homᴴ[ y , z ]) → Homᴴ[ x , z ]
+    -- isSetHomᴴ : ∀ {x y} → isSet Homᴴ[ x , y ]
+
+  infixr 9 _⋆ᴴ_
+  infixr 9 _⋆ⱽ_
+
+  field
+    -- Squares
+    Sq : ∀ {x y z w} →
+      (fᴴ : Homᴴ[ x , y ]) → (gᴴ : Homᴴ[ z , w ]) →
+      (fⱽ : Homⱽ[ x , z ]) → (gⱽ : Homⱽ[ y , w ]) →
+      Type ℓS
+    isSetSq : ∀ {x y z w}
+      {fᴴ : Homᴴ[ x , y ]} {gᴴ : Homᴴ[ z , w ]}
+      {fⱽ : Homⱽ[ x , z ]} {gⱽ : Homⱽ[ y , w ]}
+      → isSet (Sq fᴴ gᴴ fⱽ gⱽ)
+
+  -- Globular Squares
+  GlobSq : ∀ {x y} → (f g : Homᴴ[ x , y ]) → Type ℓS
+  GlobSq f g = Sq f g idⱽ idⱽ
+
+  field
+    idⱽSq : ∀ {x y} → {h : Homᴴ[ x , y ]} → Sq h h idⱽ idⱽ
+    idᴴSq : ∀ {x y} → {v : Homⱽ[ x , y ]} → Sq idᴴ idᴴ v v
+
+    -- Strict vertical composition of squares
+    _⋆ⱽSq_ : ∀ {l1 r1 l2 r2 l3 r3}
+        {↑f : Homᴴ[ l1 , r1 ]} {←f : Homⱽ[ l1 , l2 ]} {↓f : Homᴴ[ l2 , r2 ]}
+        {→f : Homⱽ[ r1 , r2 ]} {←f' : Homⱽ[ l2 , l3 ]} {↓f' : Homᴴ[ l3 , r3 ]} {→f' : Homⱽ[ r2 , r3 ]} →
+      Sq ↑f ↓f ←f →f →
+      Sq ↓f ↓f' ←f' →f' →
+      Sq ↑f ↓f' (←f ⋆ⱽ ←f') (→f ⋆ⱽ →f')
+
+    ⋆ⱽIdLSq : ∀ {u1 u2 d1 d2}
+        {↑f : Homᴴ[ u1 , u2 ]} {←f : Homⱽ[ u1 , d1 ]} {↓f : Homᴴ[ d1 , d2 ]} {→f : Homⱽ[ u2 , d2 ]} →
+        (α : Sq ↑f ↓f ←f →f) →
+        PathP (λ i → Sq ↑f ↓f (⋆ⱽIdL ←f i) (⋆ⱽIdL →f i)) (idⱽSq ⋆ⱽSq α) α
+
+    ⋆ⱽIdRSq : ∀ {u1 u2 d1 d2}
+        {↑f : Homᴴ[ u1 , u2 ]} {←f : Homⱽ[ u1 , d1 ]} {↓f : Homᴴ[ d1 , d2 ]} {→f : Homⱽ[ u2 , d2 ]} →
+        (α : Sq ↑f ↓f ←f →f) →
+        PathP (λ i → Sq ↑f ↓f (⋆ⱽIdR ←f i) (⋆ⱽIdR →f i)) (α ⋆ⱽSq idⱽSq) α
+
+    ⋆ⱽAssocSq : ∀ {l1 r1 l2 r2 r3 r4 l3 l4}
+        {↑f : Homᴴ[ l1 , r1 ]} {←f : Homⱽ[ l1 , l2 ]} {↓f : Homᴴ[ l2 , r2 ]} {→f : Homⱽ[ r1 , r2 ]}
+        {↑f' : Homᴴ[ l3 , r3 ]} {←f' : Homⱽ[ l3 , l4 ]} {↓f' : Homᴴ[ l4 , r4 ]} {→f' : Homⱽ[ r3 , r4 ]}
+        {←f'' : Homⱽ[ l2 , l3 ]}{→f'' : Homⱽ[ r2 , r3 ]} →
+        (α : Sq ↑f ↓f ←f →f) → (β : Sq ↓f ↑f' ←f'' →f'') → (γ : Sq ↑f' ↓f' ←f' →f') →
+        PathP (λ i → Sq ↑f ↓f' (⋆ⱽAssoc ←f ←f'' ←f' i) (⋆ⱽAssoc →f →f'' →f' i))
+          ((α ⋆ⱽSq β) ⋆ⱽSq γ) (α ⋆ⱽSq (β ⋆ⱽSq γ))
+
+    -- Weak horizontal composition of squares
+    _⋆ᴴSq_ : ∀ {u1 u2 d1 d2 u3 d3}
+        {↑f : Homᴴ[ u1 , u2 ]} {←f : Homⱽ[ u1 , d1 ]} {↓f : Homᴴ[ d1 , d2 ]} {→f : Homⱽ[ u2 , d2 ]}
+        {↑f' : Homᴴ[ u2 , u3 ]} {↓f' : Homᴴ[ d2 , d3 ]} {→f' : Homⱽ[ u3 , d3 ]} →
+      Sq ↑f ↓f ←f →f →
+      Sq ↑f' ↓f' →f →f' →
+      Sq (↑f ⋆ᴴ ↑f') (↓f ⋆ᴴ ↓f') ←f →f'
+
+  infixr 9 _⋆ᴴSq_
+  infixr 9 _⋆ⱽSq_
+
+  field
+    -- left unitor
+    λᴴ : ∀ {x y} (f : Homᴴ[ x , y ]) → GlobSq (idᴴ ⋆ᴴ f) f
+    λᴴ⁻ : ∀ {x y} (f : Homᴴ[ x , y ]) → GlobSq f (idᴴ ⋆ᴴ f)
+    λᴴλᴴ⁻ : ∀ {x y} (f : Homᴴ[ x , y ]) →
+      PathP (λ i → Sq (idᴴ ⋆ᴴ f) (idᴴ ⋆ᴴ f) (⋆ⱽIdL idⱽ i) (⋆ⱽIdL idⱽ i))
+        (λᴴ f ⋆ⱽSq λᴴ⁻ f) idⱽSq
+    λᴴ⁻λᴴ : ∀ {x y} (f : Homᴴ[ x , y ]) →
+      PathP (λ i → Sq f f (⋆ⱽIdL idⱽ i) (⋆ⱽIdL idⱽ i))
+        (λᴴ⁻ f ⋆ⱽSq λᴴ f) idⱽSq
+    -- Warning: in practice, in concrete cases naturalities
+    -- of the unitors and associators are the most complex to inhabit
+    -- because of the composition of paths in the base path
+    -- of the following PathP
+    -- In Cubical.Categories.Double.BaseW, we experiment with
+    -- an alternative presentation using a primitive
+    -- whiskering operation to make this nicer
+    λᴴ-nat : ∀ {x y z w} {f : Homᴴ[ x , y ]} {g : Homᴴ[ z , w ]}
+               {v : Homⱽ[ x , z ]} {u : Homⱽ[ y , w ]} (α : Sq f g v u) →
+      PathP (λ i → Sq (idᴴ ⋆ᴴ f) g
+                     ((⋆ⱽIdR v ∙ sym (⋆ⱽIdL v)) i)
+                     ((⋆ⱽIdR u ∙ sym (⋆ⱽIdL u)) i))
+             ((idᴴSq ⋆ᴴSq α) ⋆ⱽSq λᴴ g)
+             (λᴴ f ⋆ⱽSq α)
+
+    -- right unitor
+    ρᴴ : ∀ {x y} (f : Homᴴ[ x , y ]) → GlobSq (f ⋆ᴴ idᴴ) f
+    ρᴴ⁻ : ∀ {x y} (f : Homᴴ[ x , y ]) → GlobSq f (f ⋆ᴴ idᴴ)
+    ρᴴρᴴ⁻ : ∀ {x y} (f : Homᴴ[ x , y ]) →
+      PathP (λ i → Sq (f ⋆ᴴ idᴴ) (f ⋆ᴴ idᴴ) (⋆ⱽIdL idⱽ i) (⋆ⱽIdL idⱽ i))
+        (ρᴴ f ⋆ⱽSq ρᴴ⁻ f) idⱽSq
+    ρᴴ⁻ρᴴ : ∀ {x y} (f : Homᴴ[ x , y ]) →
+      PathP (λ i → Sq f f (⋆ⱽIdL idⱽ i) (⋆ⱽIdL idⱽ i))
+        (ρᴴ⁻ f ⋆ⱽSq ρᴴ f) idⱽSq
+    -- Warning: gross
+    ρᴴ-nat : ∀ {x y z w} {f : Homᴴ[ x , y ]} {g : Homᴴ[ z , w ]}
+               {v : Homⱽ[ x , z ]} {u : Homⱽ[ y , w ]} (α : Sq f g v u) →
+      PathP (λ i → Sq (f ⋆ᴴ idᴴ) g
+                     ((⋆ⱽIdR v ∙ sym (⋆ⱽIdL v)) i)
+                     ((⋆ⱽIdR u ∙ sym (⋆ⱽIdL u)) i))
+             ((α ⋆ᴴSq idᴴSq) ⋆ⱽSq ρᴴ g)
+             (ρᴴ f ⋆ⱽSq α)
+
+    -- associator
+    αᴴ : ∀ {x y z w}
+      (f : Homᴴ[ x , y ]) (g : Homᴴ[ y , z ]) (h : Homᴴ[ z , w ])
+           → GlobSq ((f ⋆ᴴ g) ⋆ᴴ h) (f ⋆ᴴ (g ⋆ᴴ h))
+    αᴴ⁻ : ∀ {x y z w}
+      (f : Homᴴ[ x , y ]) (g : Homᴴ[ y , z ]) (h : Homᴴ[ z , w ])
+           → GlobSq (f ⋆ᴴ (g ⋆ᴴ h)) ((f ⋆ᴴ g) ⋆ᴴ h)
+    αᴴαᴴ⁻ : ∀ {x y z w}
+      (f : Homᴴ[ x , y ]) (g : Homᴴ[ y , z ]) (h : Homᴴ[ z , w ]) →
+      PathP (λ i → Sq ((f ⋆ᴴ g) ⋆ᴴ h) ((f ⋆ᴴ g) ⋆ᴴ h) (⋆ⱽIdL idⱽ i) (⋆ⱽIdL idⱽ i))
+        (αᴴ f g h ⋆ⱽSq αᴴ⁻ f g h ) idⱽSq
+    αᴴ⁻αᴴ : ∀ {x y z w}
+      (f : Homᴴ[ x , y ]) (g : Homᴴ[ y , z ]) (h : Homᴴ[ z , w ]) →
+      PathP (λ i → Sq (f ⋆ᴴ (g ⋆ᴴ h)) (f ⋆ᴴ (g ⋆ᴴ h)) (⋆ⱽIdL idⱽ i) (⋆ⱽIdL idⱽ i))
+        (αᴴ⁻ f g h ⋆ⱽSq αᴴ f g h ) idⱽSq
+    -- Warning: gross
+    αᴴ-nat : ∀ {x₁ x₂ x₃ x₄ y₁ y₂ y₃ y₄}
+      {f₁ : Homᴴ[ x₁ , x₂ ]} {f₂ : Homᴴ[ x₂ , x₃ ]} {f₃ : Homᴴ[ x₃ , x₄ ]}
+      {g₁ : Homᴴ[ y₁ , y₂ ]} {g₂ : Homᴴ[ y₂ , y₃ ]} {g₃ : Homᴴ[ y₃ , y₄ ]}
+      {v₁ : Homⱽ[ x₁ , y₁ ]} {v₂ : Homⱽ[ x₂ , y₂ ]}
+      {v₃ : Homⱽ[ x₃ , y₃ ]} {v₄ : Homⱽ[ x₄ , y₄ ]}
+      (α₁ : Sq f₁ g₁ v₁ v₂) (α₂ : Sq f₂ g₂ v₂ v₃) (α₃ : Sq f₃ g₃ v₃ v₄) →
+      PathP (λ i → Sq ((f₁ ⋆ᴴ f₂) ⋆ᴴ f₃) (g₁ ⋆ᴴ (g₂ ⋆ᴴ g₃))
+                      ((⋆ⱽIdR v₁ ∙ sym (⋆ⱽIdL v₁)) i)
+                      ((⋆ⱽIdR v₄ ∙ sym (⋆ⱽIdL v₄)) i))
+        (((α₁ ⋆ᴴSq α₂) ⋆ᴴSq α₃) ⋆ⱽSq αᴴ g₁ g₂ g₃)
+        (αᴴ f₁ f₂ f₃ ⋆ⱽSq (α₁ ⋆ᴴSq (α₂ ⋆ᴴSq α₃)))
+
+    -- Coherence
+    pentagon : ∀ {v w x y z}
+      (f : Homᴴ[ v , w ]) (g : Homᴴ[ w , x ]) (h : Homᴴ[ x , y ]) (k : Homᴴ[ y , z ]) →
+      PathP (λ i → Sq (((f ⋆ᴴ g) ⋆ᴴ h) ⋆ᴴ k) (f ⋆ᴴ (g ⋆ᴴ (h ⋆ᴴ k)))
+        (⋆ⱽIdL (idⱽ ⋆ⱽ idⱽ) (~ i))
+        (⋆ⱽIdL (idⱽ ⋆ⱽ idⱽ) (~ i)))
+        (αᴴ (f ⋆ᴴ g) h k ⋆ⱽSq αᴴ f g (h ⋆ᴴ k))
+        ((αᴴ f g h ⋆ᴴSq idⱽSq) ⋆ⱽSq αᴴ f (g ⋆ᴴ h) k ⋆ⱽSq (idⱽSq ⋆ᴴSq αᴴ g h k))
+
+    triangle : ∀ {x y z} (f : Homᴴ[ x , y ]) (g : Homᴴ[ y , z ]) →
+      PathP (λ i → Sq ((f ⋆ᴴ idᴴ) ⋆ᴴ g) (f ⋆ᴴ g)
+                      (⋆ⱽIdL idⱽ i) (⋆ⱽIdL idⱽ i))
+        (αᴴ f idᴴ g ⋆ⱽSq (idⱽSq ⋆ᴴSq λᴴ g))
+        (ρᴴ f ⋆ᴴSq idⱽSq)
+
+    interchange : ∀ {u1 u2 u3 m1 m2 m3 d1 d2 d3}
+        {↑f : Homᴴ[ u1 , u2 ]} {↑f' : Homᴴ[ u2 , u3 ]}
+        {↓f : Homᴴ[ d1 , d2 ]} {↓f' : Homᴴ[ d2 , d3 ]}
+        {←f : Homⱽ[ u1 , m1 ]} {←f' : Homⱽ[ m1 , d1 ]}
+        {→f : Homⱽ[ u3 , m3 ]} {→f' : Homⱽ[ m3 , d3 ]}
+        {←g : Homᴴ[ m1 , m2 ]} {↑g : Homⱽ[ u2 , m2 ]}
+        {→g : Homᴴ[ m2 , m3 ]} {↓g : Homⱽ[ m2 , d2 ]}
+        (ul : Sq ↑f ←g ←f ↑g) (ur : Sq ↑f' →g ↑g →f)
+        (dl : Sq ←g ↓f ←f' ↓g) (dr : Sq →g ↓f' ↓g →f') →
+        (ul ⋆ⱽSq dl) ⋆ᴴSq (ur ⋆ⱽSq dr) ≡ (ul ⋆ᴴSq ur) ⋆ⱽSq (dl ⋆ᴴSq dr)

--- a/Cubical/Categories/Double/BaseW.agda
+++ b/Cubical/Categories/Double/BaseW.agda
@@ -1,0 +1,235 @@
+{-# OPTIONS --lossy-unification #-}
+-- Made by Claude
+--
+-- Experimental variant of Cubical.Categories.Double.Base using primitive
+-- whiskering and globular vertical composition, so that the naturality
+-- axioms for the unitors and associator become plain equations
+--
+-- This (and other files with the W suffix) was (were) automatically generated
+-- by Claude from their ordinary variants
+-- Preliminarily, usage of a primitive whiskering operation does
+-- indeed make concrete instantiations easier
+-- Compare the naturality proofs in Double.Instances.Prof and Double.Instances.ProfW
+-- to see
+module Cubical.Categories.Double.BaseW where
+
+open import Cubical.Foundations.Prelude
+open import Cubical.Foundations.HLevels
+
+private
+  variable
+    ℓC ℓV ℓH ℓS : Level
+
+-- A Pseudo Double Category, "whiskered" formulation.
+record DoubleCategoryW ℓC ℓH ℓV ℓS :
+  Type (ℓ-max (ℓ-suc (ℓ-max (ℓ-max ℓC ℓS) ℓH)) (ℓ-suc ℓV))
+  where
+  no-eta-equality
+  field
+    ob : Type ℓC
+
+    -- Strict vertical morphisms
+    Homⱽ[_,_] : (x y : ob) → Type ℓV
+    idⱽ   : ∀ {x} → Homⱽ[ x , x ]
+    _⋆ⱽ_  : ∀ {x y z} (f : Homⱽ[ x , y ]) (g : Homⱽ[ y , z ]) → Homⱽ[ x , z ]
+    ⋆ⱽIdL : ∀ {x y} (f : Homⱽ[ x , y ]) → idⱽ ⋆ⱽ f ≡ f
+    ⋆ⱽIdR : ∀ {x y} (f : Homⱽ[ x , y ]) → f ⋆ⱽ idⱽ ≡ f
+    ⋆ⱽAssoc : ∀ {x y z w} (f : Homⱽ[ x , y ]) (g : Homⱽ[ y , z ])
+                          (h : Homⱽ[ z , w ])
+           → (f ⋆ⱽ g) ⋆ⱽ h ≡ f ⋆ⱽ (g ⋆ⱽ h)
+
+    -- Weak horizontal morphisms
+    Homᴴ[_,_] : (x y : ob) → Type ℓH
+    idᴴ   : ∀ {x} → Homᴴ[ x , x ]
+    _⋆ᴴ_  : ∀ {x y z} (f : Homᴴ[ x , y ]) (g : Homᴴ[ y , z ]) → Homᴴ[ x , z ]
+
+  infixr 9 _⋆ᴴ_
+  infixr 9 _⋆ⱽ_
+
+  field
+    -- Squares
+    Sq : ∀ {x y z w} →
+      (fᴴ : Homᴴ[ x , y ]) → (gᴴ : Homᴴ[ z , w ]) →
+      (fⱽ : Homⱽ[ x , z ]) → (gⱽ : Homⱽ[ y , w ]) →
+      Type ℓS
+    isSetSq : ∀ {x y z w}
+      {fᴴ : Homᴴ[ x , y ]} {gᴴ : Homᴴ[ z , w ]}
+      {fⱽ : Homⱽ[ x , z ]} {gⱽ : Homⱽ[ y , w ]}
+      → isSet (Sq fᴴ gᴴ fⱽ gⱽ)
+
+  -- Globular Squares
+  GlobSq : ∀ {x y} → (f g : Homᴴ[ x , y ]) → Type ℓS
+  GlobSq f g = Sq f g idⱽ idⱽ
+
+  field
+    idⱽSq : ∀ {x y} → {h : Homᴴ[ x , y ]} → GlobSq h h
+    idᴴSq : ∀ {x y} → {v : Homⱽ[ x , y ]} → Sq idᴴ idᴴ v v
+
+    -- Strict vertical composition of squares
+    _⋆ⱽSq_ : ∀ {l1 r1 l2 r2 l3 r3}
+        {↑f : Homᴴ[ l1 , r1 ]} {←f : Homⱽ[ l1 , l2 ]} {↓f : Homᴴ[ l2 , r2 ]}
+        {→f : Homⱽ[ r1 , r2 ]} {←f' : Homⱽ[ l2 , l3 ]}
+        {↓f' : Homᴴ[ l3 , r3 ]} {→f' : Homⱽ[ r2 , r3 ]} →
+      Sq ↑f ↓f ←f →f →
+      Sq ↓f ↓f' ←f' →f' →
+      Sq ↑f ↓f' (←f ⋆ⱽ ←f') (→f ⋆ⱽ →f')
+
+    ⋆ⱽIdLSq : ∀ {u1 u2 d1 d2}
+        {↑f : Homᴴ[ u1 , u2 ]} {←f : Homⱽ[ u1 , d1 ]}
+        {↓f : Homᴴ[ d1 , d2 ]} {→f : Homⱽ[ u2 , d2 ]} →
+        (α : Sq ↑f ↓f ←f →f) →
+        PathP (λ i → Sq ↑f ↓f (⋆ⱽIdL ←f i) (⋆ⱽIdL →f i)) (idⱽSq ⋆ⱽSq α) α
+
+    ⋆ⱽIdRSq : ∀ {u1 u2 d1 d2}
+        {↑f : Homᴴ[ u1 , u2 ]} {←f : Homⱽ[ u1 , d1 ]}
+        {↓f : Homᴴ[ d1 , d2 ]} {→f : Homⱽ[ u2 , d2 ]} →
+        (α : Sq ↑f ↓f ←f →f) →
+        PathP (λ i → Sq ↑f ↓f (⋆ⱽIdR ←f i) (⋆ⱽIdR →f i)) (α ⋆ⱽSq idⱽSq) α
+
+    ⋆ⱽAssocSq : ∀ {l1 r1 l2 r2 r3 r4 l3 l4}
+        {↑f : Homᴴ[ l1 , r1 ]} {←f : Homⱽ[ l1 , l2 ]}
+        {↓f : Homᴴ[ l2 , r2 ]} {→f : Homⱽ[ r1 , r2 ]}
+        {↑f' : Homᴴ[ l3 , r3 ]} {←f' : Homⱽ[ l3 , l4 ]}
+        {↓f' : Homᴴ[ l4 , r4 ]} {→f' : Homⱽ[ r3 , r4 ]}
+        {←f'' : Homⱽ[ l2 , l3 ]}{→f'' : Homⱽ[ r2 , r3 ]} →
+        (α : Sq ↑f ↓f ←f →f) → (β : Sq ↓f ↑f' ←f'' →f'') →
+        (γ : Sq ↑f' ↓f' ←f' →f') →
+        PathP (λ i → Sq ↑f ↓f' (⋆ⱽAssoc ←f ←f'' ←f' i)
+                                 (⋆ⱽAssoc →f →f'' →f' i))
+          ((α ⋆ⱽSq β) ⋆ⱽSq γ) (α ⋆ⱽSq (β ⋆ⱽSq γ))
+
+    -- Weak horizontal composition of squares
+    _⋆ᴴSq_ : ∀ {u1 u2 d1 d2 u3 d3}
+        {↑f : Homᴴ[ u1 , u2 ]} {←f : Homⱽ[ u1 , d1 ]}
+        {↓f : Homᴴ[ d1 , d2 ]} {→f : Homⱽ[ u2 , d2 ]}
+        {↑f' : Homᴴ[ u2 , u3 ]} {↓f' : Homᴴ[ d2 , d3 ]}
+        {→f' : Homⱽ[ u3 , d3 ]} →
+      Sq ↑f ↓f ←f →f →
+      Sq ↑f' ↓f' →f →f' →
+      Sq (↑f ⋆ᴴ ↑f') (↓f ⋆ᴴ ↓f') ←f →f'
+
+  infixr 9 _⋆ᴴSq_
+  infixr 9 _⋆ⱽSq_
+
+  ----------------------------------------------------------------------
+  -- Whiskering primitives.
+  --
+  -- These are the key ingredients that let us state naturality of the
+  -- unitors and associator without a PathP base path.  Whiskering a
+  -- globular cell onto an ordinary square along a shared horizontal
+  -- edge produces a square whose vertical edges are *definitionally*
+  -- the original ones, rather than `v ⋆ⱽ idⱽ` or `idⱽ ⋆ⱽ v`.
+  ----------------------------------------------------------------------
+  field
+    -- Right whiskering: paste a globular cell below, keeping the outer
+    -- vertical edges.
+    _◃_ : ∀ {x y z w}
+          {f : Homᴴ[ x , y ]} {g h : Homᴴ[ z , w ]}
+          {v : Homⱽ[ x , z ]} {u : Homⱽ[ y , w ]} →
+          Sq f g v u → GlobSq g h → Sq f h v u
+
+    -- Left whiskering: paste a globular cell above, keeping the outer
+    -- vertical edges.
+    _▹_ : ∀ {x y z w}
+          {f g : Homᴴ[ x , y ]} {h : Homᴴ[ z , w ]}
+          {v : Homⱽ[ x , z ]} {u : Homⱽ[ y , w ]} →
+          GlobSq f g → Sq g h v u → Sq f h v u
+
+    -- Globular vertical composition: two globular cells compose to a
+    -- globular cell with *definitional* identity vertical edges.
+    _⊙ⱽ_ : ∀ {x y} {f g h : Homᴴ[ x , y ]} →
+           GlobSq f g → GlobSq g h → GlobSq f h
+
+  infixr 9 _◃_
+  infixr 9 _▹_
+  infixr 9 _⊙ⱽ_
+
+  field
+    -- Coherences relating the new primitives to ⋆ⱽSq.  These *do* have
+    -- PathP bases, but each base is a single unitor — NOT a composite
+    -- path like ⋆ⱽIdR v ∙ sym (⋆ⱽIdL v).  And they are stated only
+    -- once, here in the record, rather than at every naturality site.
+    ◃≡⋆ⱽSq : ∀ {x y z w}
+          {f : Homᴴ[ x , y ]} {g h : Homᴴ[ z , w ]}
+          {v : Homⱽ[ x , z ]} {u : Homⱽ[ y , w ]}
+          (α : Sq f g v u) (β : GlobSq g h) →
+          PathP (λ i → Sq f h (⋆ⱽIdR v i) (⋆ⱽIdR u i))
+                (α ⋆ⱽSq β) (α ◃ β)
+
+    ▹≡⋆ⱽSq : ∀ {x y z w}
+          {f g : Homᴴ[ x , y ]} {h : Homᴴ[ z , w ]}
+          {v : Homⱽ[ x , z ]} {u : Homⱽ[ y , w ]}
+          (α : GlobSq f g) (β : Sq g h v u) →
+          PathP (λ i → Sq f h (⋆ⱽIdL v i) (⋆ⱽIdL u i))
+                (α ⋆ⱽSq β) (α ▹ β)
+
+    ⊙ⱽ≡⋆ⱽSq : ∀ {x y} {f g h : Homᴴ[ x , y ]}
+          (α : GlobSq f g) (β : GlobSq g h) →
+          PathP (λ i → Sq f h (⋆ⱽIdR (idⱽ {x = x}) i)
+                                (⋆ⱽIdR (idⱽ {x = y}) i))
+                (α ⋆ⱽSq β) (α ⊙ⱽ β)
+
+  ----------------------------------------------------------------------
+  -- Unitors, associator, and their naturality -- now plain equations.
+  ----------------------------------------------------------------------
+  field
+    -- Left unitor
+    λᴴ : ∀ {x y} (f : Homᴴ[ x , y ]) → GlobSq (idᴴ ⋆ᴴ f) f
+    λᴴ⁻ : ∀ {x y} (f : Homᴴ[ x , y ]) → GlobSq f (idᴴ ⋆ᴴ f)
+    λᴴλᴴ⁻ : ∀ {x y} (f : Homᴴ[ x , y ]) → λᴴ f ⊙ⱽ λᴴ⁻ f ≡ idⱽSq
+    λᴴ⁻λᴴ : ∀ {x y} (f : Homᴴ[ x , y ]) → λᴴ⁻ f ⊙ⱽ λᴴ f ≡ idⱽSq
+    λᴴ-nat : ∀ {x y z w} {f : Homᴴ[ x , y ]} {g : Homᴴ[ z , w ]}
+               {v : Homⱽ[ x , z ]} {u : Homⱽ[ y , w ]} (α : Sq f g v u) →
+      (idᴴSq ⋆ᴴSq α) ◃ λᴴ g ≡ λᴴ f ▹ α
+
+    -- Right unitor
+    ρᴴ : ∀ {x y} (f : Homᴴ[ x , y ]) → GlobSq (f ⋆ᴴ idᴴ) f
+    ρᴴ⁻ : ∀ {x y} (f : Homᴴ[ x , y ]) → GlobSq f (f ⋆ᴴ idᴴ)
+    ρᴴρᴴ⁻ : ∀ {x y} (f : Homᴴ[ x , y ]) → ρᴴ f ⊙ⱽ ρᴴ⁻ f ≡ idⱽSq
+    ρᴴ⁻ρᴴ : ∀ {x y} (f : Homᴴ[ x , y ]) → ρᴴ⁻ f ⊙ⱽ ρᴴ f ≡ idⱽSq
+    ρᴴ-nat : ∀ {x y z w} {f : Homᴴ[ x , y ]} {g : Homᴴ[ z , w ]}
+               {v : Homⱽ[ x , z ]} {u : Homⱽ[ y , w ]} (α : Sq f g v u) →
+      (α ⋆ᴴSq idᴴSq) ◃ ρᴴ g ≡ ρᴴ f ▹ α
+
+    -- Associator
+    αᴴ : ∀ {x y z w}
+      (f : Homᴴ[ x , y ]) (g : Homᴴ[ y , z ]) (h : Homᴴ[ z , w ])
+           → GlobSq ((f ⋆ᴴ g) ⋆ᴴ h) (f ⋆ᴴ (g ⋆ᴴ h))
+    αᴴ⁻ : ∀ {x y z w}
+      (f : Homᴴ[ x , y ]) (g : Homᴴ[ y , z ]) (h : Homᴴ[ z , w ])
+           → GlobSq (f ⋆ᴴ (g ⋆ᴴ h)) ((f ⋆ᴴ g) ⋆ᴴ h)
+    αᴴαᴴ⁻ : ∀ {x y z w}
+      (f : Homᴴ[ x , y ]) (g : Homᴴ[ y , z ]) (h : Homᴴ[ z , w ]) →
+      αᴴ f g h ⊙ⱽ αᴴ⁻ f g h ≡ idⱽSq
+    αᴴ⁻αᴴ : ∀ {x y z w}
+      (f : Homᴴ[ x , y ]) (g : Homᴴ[ y , z ]) (h : Homᴴ[ z , w ]) →
+      αᴴ⁻ f g h ⊙ⱽ αᴴ f g h ≡ idⱽSq
+    αᴴ-nat : ∀ {x₁ x₂ x₃ x₄ y₁ y₂ y₃ y₄}
+      {f₁ : Homᴴ[ x₁ , x₂ ]} {f₂ : Homᴴ[ x₂ , x₃ ]} {f₃ : Homᴴ[ x₃ , x₄ ]}
+      {g₁ : Homᴴ[ y₁ , y₂ ]} {g₂ : Homᴴ[ y₂ , y₃ ]} {g₃ : Homᴴ[ y₃ , y₄ ]}
+      {v₁ : Homⱽ[ x₁ , y₁ ]} {v₂ : Homⱽ[ x₂ , y₂ ]}
+      {v₃ : Homⱽ[ x₃ , y₃ ]} {v₄ : Homⱽ[ x₄ , y₄ ]}
+      (α₁ : Sq f₁ g₁ v₁ v₂) (α₂ : Sq f₂ g₂ v₂ v₃) (α₃ : Sq f₃ g₃ v₃ v₄) →
+      ((α₁ ⋆ᴴSq α₂) ⋆ᴴSq α₃) ◃ αᴴ g₁ g₂ g₃
+      ≡ αᴴ f₁ f₂ f₃ ▹ (α₁ ⋆ᴴSq (α₂ ⋆ᴴSq α₃))
+
+    -- Coherence
+    pentagon : ∀ {v w x y z}
+      (f : Homᴴ[ v , w ]) (g : Homᴴ[ w , x ])
+      (h : Homᴴ[ x , y ]) (k : Homᴴ[ y , z ]) →
+      αᴴ (f ⋆ᴴ g) h k ⊙ⱽ αᴴ f g (h ⋆ᴴ k)
+      ≡ (αᴴ f g h ⋆ᴴSq idⱽSq) ⊙ⱽ αᴴ f (g ⋆ᴴ h) k ⊙ⱽ (idⱽSq ⋆ᴴSq αᴴ g h k)
+
+    triangle : ∀ {x y z} (f : Homᴴ[ x , y ]) (g : Homᴴ[ y , z ]) →
+      αᴴ f idᴴ g ⊙ⱽ (idⱽSq ⋆ᴴSq λᴴ g) ≡ ρᴴ f ⋆ᴴSq idⱽSq
+
+    interchange : ∀ {u1 u2 u3 m1 m2 m3 d1 d2 d3}
+        {↑f : Homᴴ[ u1 , u2 ]} {↑f' : Homᴴ[ u2 , u3 ]}
+        {↓f : Homᴴ[ d1 , d2 ]} {↓f' : Homᴴ[ d2 , d3 ]}
+        {←f : Homⱽ[ u1 , m1 ]} {←f' : Homⱽ[ m1 , d1 ]}
+        {→f : Homⱽ[ u3 , m3 ]} {→f' : Homⱽ[ m3 , d3 ]}
+        {←g : Homᴴ[ m1 , m2 ]} {↑g : Homⱽ[ u2 , m2 ]}
+        {→g : Homᴴ[ m2 , m3 ]} {↓g : Homⱽ[ m2 , d2 ]}
+        (ul : Sq ↑f ←g ←f ↑g) (ur : Sq ↑f' →g ↑g →f)
+        (dl : Sq ←g ↓f ←f' ↓g) (dr : Sq →g ↓f' ↓g →f') →
+        (ul ⋆ⱽSq dl) ⋆ᴴSq (ur ⋆ⱽSq dr) ≡ (ul ⋆ᴴSq ur) ⋆ⱽSq (dl ⋆ᴴSq dr)

--- a/Cubical/Categories/Double/Functor/Base.agda
+++ b/Cubical/Categories/Double/Functor/Base.agda
@@ -1,0 +1,101 @@
+{-# OPTIONS --lossy-unification #-}
+module Cubical.Categories.Double.Functor.Base where
+
+open import Cubical.Foundations.Prelude
+
+open import Cubical.Categories.Double.Base
+
+open DoubleCategory
+
+private
+  variable
+    ℓ₁ ℓ₂ ℓ₃ ℓ₄ ℓ₅ ℓ₆ ℓ₇ ℓ₈ : Level
+
+record LaxDoubleFunctor
+  (D : DoubleCategory ℓ₁ ℓ₂ ℓ₃ ℓ₄)
+  (E : DoubleCategory ℓ₅ ℓ₆ ℓ₇ ℓ₈)
+  : Type (ℓ-max (ℓ-max (ℓ-max ℓ₁ ℓ₂) (ℓ-max ℓ₃ ℓ₄))
+              (ℓ-max (ℓ-max ℓ₅ ℓ₆) (ℓ-max ℓ₇ ℓ₈)))
+  where
+  no-eta-equality
+  private
+    module D = DoubleCategory D
+    module E = DoubleCategory E
+
+  field
+    F₀ : D.ob → E.ob
+    Fⱽ : ∀ {x y} → D.Homⱽ[ x , y ] → E.Homⱽ[ F₀ x , F₀ y ]
+    Fᴴ : ∀ {x y} → D.Homᴴ[ x , y ] → E.Homᴴ[ F₀ x , F₀ y ]
+    Fˢ : ∀ {x y z w}
+      {fᴴ : D.Homᴴ[ x , y ]} {gᴴ : D.Homᴴ[ z , w ]}
+      {fⱽ : D.Homⱽ[ x , z ]} {gⱽ : D.Homⱽ[ y , w ]}
+      → D.Sq fᴴ gᴴ fⱽ gⱽ
+      → E.Sq (Fᴴ fᴴ) (Fᴴ gᴴ) (Fⱽ fⱽ) (Fⱽ gⱽ)
+
+    -- Strict vertical preservation
+    F-idⱽ : ∀ {x} → Fⱽ (D.idⱽ {x}) ≡ E.idⱽ
+    F-seqⱽ : ∀ {x y z} (f : D.Homⱽ[ x , y ]) (g : D.Homⱽ[ y , z ])
+      → Fⱽ (f D.⋆ⱽ g) ≡ Fⱽ f E.⋆ⱽ Fⱽ g
+
+    -- Lax horizontal cells (globular squares)
+    F-idᴴ : ∀ {x} → E.GlobSq E.idᴴ (Fᴴ (D.idᴴ {x}))
+    F-seqᴴ : ∀ {x y z} (f : D.Homᴴ[ x , y ]) (g : D.Homᴴ[ y , z ])
+      → E.GlobSq (Fᴴ f E.⋆ᴴ Fᴴ g) (Fᴴ (f D.⋆ᴴ g))
+
+    -- Strict vertical preservation of squares
+    F-idⱽSq : ∀ {x y} {h : D.Homᴴ[ x , y ]}
+      → PathP (λ i → E.Sq (Fᴴ h) (Fᴴ h) (F-idⱽ i) (F-idⱽ i))
+              (Fˢ D.idⱽSq) E.idⱽSq
+    F-seqⱽSq : ∀ {x y z w a b}
+      {↑f : D.Homᴴ[ x , y ]} {←f : D.Homⱽ[ x , z ]} {↓f : D.Homᴴ[ z , w ]}
+      {→f : D.Homⱽ[ y , w ]} {←f' : D.Homⱽ[ z , a ]} {↓f' : D.Homᴴ[ a , b ]}
+      {→f' : D.Homⱽ[ w , b ]}
+      (α : D.Sq ↑f ↓f ←f →f) (β : D.Sq ↓f ↓f' ←f' →f')
+      → PathP (λ i → E.Sq (Fᴴ ↑f) (Fᴴ ↓f') (F-seqⱽ ←f ←f' i) (F-seqⱽ →f →f' i))
+              (Fˢ (α D.⋆ⱽSq β)) (Fˢ α E.⋆ⱽSq Fˢ β)
+
+    -- Naturality of laxity cells
+    F-idᴴ-nat : ∀ {x y} (v : D.Homⱽ[ x , y ])
+      → PathP (λ i → E.Sq E.idᴴ (Fᴴ D.idᴴ)
+                ((E.⋆ⱽIdR (Fⱽ v) ∙ sym (E.⋆ⱽIdL (Fⱽ v))) i)
+                ((E.⋆ⱽIdR (Fⱽ v) ∙ sym (E.⋆ⱽIdL (Fⱽ v))) i))
+        (E.idᴴSq E.⋆ⱽSq F-idᴴ)
+        (F-idᴴ E.⋆ⱽSq Fˢ D.idᴴSq)
+
+    F-seqᴴ-nat : ∀ {x₁ x₂ x₃ y₁ y₂ y₃}
+      {f₁ : D.Homᴴ[ x₁ , x₂ ]} {f₂ : D.Homᴴ[ x₂ , x₃ ]}
+      {g₁ : D.Homᴴ[ y₁ , y₂ ]} {g₂ : D.Homᴴ[ y₂ , y₃ ]}
+      {v₁ : D.Homⱽ[ x₁ , y₁ ]} {v₂ : D.Homⱽ[ x₂ , y₂ ]} {v₃ : D.Homⱽ[ x₃ , y₃ ]}
+      (α₁ : D.Sq f₁ g₁ v₁ v₂) (α₂ : D.Sq f₂ g₂ v₂ v₃)
+      → PathP (λ i → E.Sq (Fᴴ f₁ E.⋆ᴴ Fᴴ f₂) (Fᴴ (g₁ D.⋆ᴴ g₂))
+                ((E.⋆ⱽIdR (Fⱽ v₁) ∙ sym (E.⋆ⱽIdL (Fⱽ v₁))) i)
+                ((E.⋆ⱽIdR (Fⱽ v₃) ∙ sym (E.⋆ⱽIdL (Fⱽ v₃))) i))
+        ((Fˢ α₁ E.⋆ᴴSq Fˢ α₂) E.⋆ⱽSq F-seqᴴ g₁ g₂)
+        (F-seqᴴ f₁ f₂ E.⋆ⱽSq Fˢ (α₁ D.⋆ᴴSq α₂))
+
+  field
+    -- Coherence with unitors and associator
+    -- LHS composites have sides E.idⱽ ⋆ⱽ (E.idⱽ ⋆ⱽ Fⱽ D.idⱽ),
+    -- RHS globular squares have sides E.idⱽ
+    F-unit-l : ∀ {x y} (f : D.Homᴴ[ x , y ])
+      → let pₗ = E.⋆ⱽIdL (E.idⱽ E.⋆ⱽ Fⱽ (D.idⱽ {x})) ∙ E.⋆ⱽIdL _ ∙ F-idⱽ
+            pᵣ = E.⋆ⱽIdL (E.idⱽ E.⋆ⱽ Fⱽ (D.idⱽ {y})) ∙ E.⋆ⱽIdL _ ∙ F-idⱽ
+        in PathP (λ i → E.Sq (E.idᴴ E.⋆ᴴ Fᴴ f) (Fᴴ f) (pₗ i) (pᵣ i))
+          ((F-idᴴ E.⋆ᴴSq E.idⱽSq) E.⋆ⱽSq F-seqᴴ D.idᴴ f E.⋆ⱽSq Fˢ (D.λᴴ f))
+          (E.λᴴ (Fᴴ f))
+
+    F-unit-r : ∀ {x y} (f : D.Homᴴ[ x , y ])
+      → let pₗ = E.⋆ⱽIdL (E.idⱽ E.⋆ⱽ Fⱽ (D.idⱽ {x})) ∙ E.⋆ⱽIdL _ ∙ F-idⱽ
+            pᵣ = E.⋆ⱽIdL (E.idⱽ E.⋆ⱽ Fⱽ (D.idⱽ {y})) ∙ E.⋆ⱽIdL _ ∙ F-idⱽ
+        in PathP (λ i → E.Sq (Fᴴ f E.⋆ᴴ E.idᴴ) (Fᴴ f) (pₗ i) (pᵣ i))
+          ((E.idⱽSq E.⋆ᴴSq F-idᴴ) E.⋆ⱽSq F-seqᴴ f D.idᴴ E.⋆ⱽSq Fˢ (D.ρᴴ f))
+          (E.ρᴴ (Fᴴ f))
+
+    F-assoc : ∀ {x y z w}
+      (f : D.Homᴴ[ x , y ]) (g : D.Homᴴ[ y , z ]) (h : D.Homᴴ[ z , w ])
+      → let pₗ = cong (λ v → E.idⱽ E.⋆ⱽ (E.idⱽ E.⋆ⱽ v)) (F-idⱽ {x})
+            pᵣ = cong (λ v → E.idⱽ E.⋆ⱽ (E.idⱽ E.⋆ⱽ v)) (F-idⱽ {w})
+        in PathP (λ i → E.Sq ((Fᴴ f E.⋆ᴴ Fᴴ g) E.⋆ᴴ Fᴴ h) (Fᴴ (f D.⋆ᴴ (g D.⋆ᴴ h)))
+                            (pₗ i) (pᵣ i))
+          ((F-seqᴴ f g E.⋆ᴴSq E.idⱽSq) E.⋆ⱽSq F-seqᴴ (f D.⋆ᴴ g) h E.⋆ⱽSq Fˢ (D.αᴴ f g h))
+          (E.αᴴ (Fᴴ f) (Fᴴ g) (Fᴴ h) E.⋆ⱽSq (E.idⱽSq E.⋆ᴴSq F-seqᴴ g h) E.⋆ⱽSq F-seqᴴ f (g D.⋆ᴴ h))

--- a/Cubical/Categories/Double/Instances/1Category.agda
+++ b/Cubical/Categories/Double/Instances/1Category.agda
@@ -1,0 +1,174 @@
+{-# OPTIONS --lossy-unification #-}
+module Cubical.Categories.Double.Instances.1Category where
+
+open import Cubical.Foundations.Prelude
+open import Cubical.Foundations.GroupoidLaws
+open import Cubical.Foundations.More
+open import Cubical.Foundations.HLevels
+open import Cubical.Foundations.Function
+
+open import Cubical.Data.Sigma
+import Cubical.Data.Equality as Eq
+import Cubical.Data.Equality.More as Eq
+
+open import Cubical.Categories.Category
+open import Cubical.Categories.Double.Base
+
+open DoubleCategory
+
+module _ {ℓ ℓ'} (C : Category ℓ ℓ') where
+  private
+    module C = Category C
+
+  -- Category structure of C encoded with vertical morphisms
+  -- Only identity horizontal morphisms and squares
+  1Cat→DoubleCatⱽ : DoubleCategory _ _ _ _
+  1Cat→DoubleCatⱽ .ob = C.ob
+  1Cat→DoubleCatⱽ .Homⱽ[_,_] = C.Hom[_,_]
+  1Cat→DoubleCatⱽ .idⱽ = C.id
+  1Cat→DoubleCatⱽ ._⋆ⱽ_ = C._⋆_
+  1Cat→DoubleCatⱽ .⋆ⱽIdL = C.⋆IdL
+  1Cat→DoubleCatⱽ .⋆ⱽIdR = C.⋆IdR
+  1Cat→DoubleCatⱽ .⋆ⱽAssoc = C.⋆Assoc
+  1Cat→DoubleCatⱽ .Homᴴ[_,_] c c' = c Eq.≡ c'
+  1Cat→DoubleCatⱽ .idᴴ = Eq.refl
+  1Cat→DoubleCatⱽ ._⋆ᴴ_ = Eq._∙_
+  1Cat→DoubleCatⱽ .Sq Eq.refl Eq.refl f g = f Eq.≡ g
+  1Cat→DoubleCatⱽ .isSetSq {fᴴ = Eq.refl} {gᴴ = Eq.refl} =
+    isProp→isSet $ Eq.isSet→isSetEq C.isSetHom
+  1Cat→DoubleCatⱽ .idⱽSq {h = Eq.refl} = Eq.refl
+  1Cat→DoubleCatⱽ .idᴴSq = Eq.refl
+  1Cat→DoubleCatⱽ ._⋆ⱽSq_ {↑f = Eq.refl} {↓f = Eq.refl} {↓f' = Eq.refl}
+    Eq.refl Eq.refl = Eq.refl
+  1Cat→DoubleCatⱽ .⋆ⱽIdLSq {↑f = Eq.refl} {↓f = Eq.refl} Eq.refl i = Eq.refl
+  1Cat→DoubleCatⱽ .⋆ⱽIdRSq {↑f = Eq.refl} {↓f = Eq.refl} Eq.refl i = Eq.refl
+  1Cat→DoubleCatⱽ .⋆ⱽAssocSq
+    {↑f = Eq.refl} {↓f = Eq.refl}
+    {↑f' = Eq.refl} {↓f' = Eq.refl} Eq.refl Eq.refl Eq.refl i = Eq.refl
+  1Cat→DoubleCatⱽ ._⋆ᴴSq_
+    {↑f = Eq.refl} {↓f = Eq.refl}
+    {↑f' = Eq.refl} {↓f' = Eq.refl} Eq.refl Eq.refl = Eq.refl
+  1Cat→DoubleCatⱽ .λᴴ Eq.refl = Eq.refl
+  1Cat→DoubleCatⱽ .λᴴ⁻ Eq.refl = Eq.refl
+  1Cat→DoubleCatⱽ .λᴴλᴴ⁻ Eq.refl i = Eq.refl
+  1Cat→DoubleCatⱽ .λᴴ⁻λᴴ Eq.refl i = Eq.refl
+  1Cat→DoubleCatⱽ .λᴴ-nat {f = Eq.refl} {g = Eq.refl} Eq.refl i = Eq.refl
+  1Cat→DoubleCatⱽ .ρᴴ Eq.refl = Eq.refl
+  1Cat→DoubleCatⱽ .ρᴴ⁻ Eq.refl = Eq.refl
+  1Cat→DoubleCatⱽ .ρᴴρᴴ⁻ Eq.refl i = Eq.refl
+  1Cat→DoubleCatⱽ .ρᴴ⁻ρᴴ Eq.refl i = Eq.refl
+  1Cat→DoubleCatⱽ .ρᴴ-nat {f = Eq.refl} {g = Eq.refl} Eq.refl i = Eq.refl
+  1Cat→DoubleCatⱽ .αᴴ Eq.refl Eq.refl Eq.refl = Eq.refl
+  1Cat→DoubleCatⱽ .αᴴ⁻ Eq.refl Eq.refl Eq.refl = Eq.refl
+  1Cat→DoubleCatⱽ .αᴴαᴴ⁻  Eq.refl Eq.refl Eq.refl i = Eq.refl
+  1Cat→DoubleCatⱽ .αᴴ⁻αᴴ Eq.refl Eq.refl Eq.refl i = Eq.refl
+  1Cat→DoubleCatⱽ .αᴴ-nat
+    {f₁ = Eq.refl} {f₂ = Eq.refl} {f₃ = Eq.refl}
+    {g₁ = Eq.refl} {g₂ = Eq.refl} {g₃ = Eq.refl}
+    Eq.refl Eq.refl Eq.refl i = Eq.refl
+  1Cat→DoubleCatⱽ .pentagon Eq.refl Eq.refl Eq.refl Eq.refl i = Eq.refl
+  1Cat→DoubleCatⱽ .triangle Eq.refl Eq.refl i = Eq.refl
+  1Cat→DoubleCatⱽ .interchange
+    {↑f = Eq.refl} {↑f' = Eq.refl}
+    {↓f = Eq.refl} {↓f' = Eq.refl}
+    {←g = Eq.refl} {→g = Eq.refl}
+    Eq.refl Eq.refl Eq.refl Eq.refl = refl
+
+  -- Category structure of C encoded with horizontal morphisms
+  -- Only identity vertical morphisms and squares
+  1Cat→DoubleCatᴴ : DoubleCategory _ _ _ _
+  1Cat→DoubleCatᴴ .ob = C.ob
+  1Cat→DoubleCatᴴ .Homⱽ[_,_] = _≡_
+  1Cat→DoubleCatᴴ .idⱽ = refl
+  1Cat→DoubleCatᴴ ._⋆ⱽ_ = _∙_
+  1Cat→DoubleCatᴴ .⋆ⱽIdL f = sym $ lUnit f
+  1Cat→DoubleCatᴴ .⋆ⱽIdR f = sym $ rUnit f
+  1Cat→DoubleCatᴴ .⋆ⱽAssoc f g h = sym $ assoc f g h
+  1Cat→DoubleCatᴴ .Homᴴ[_,_] = C.Hom[_,_]
+  1Cat→DoubleCatᴴ .idᴴ = C.id
+  1Cat→DoubleCatᴴ ._⋆ᴴ_ = C._⋆_
+  1Cat→DoubleCatᴴ .Sq f g e e' = PathP (λ i → C [ e i , e' i ]) f g
+  1Cat→DoubleCatᴴ .isSetSq = isProp→isSet (isOfHLevelPathP' 1 C.isSetHom _ _)
+  1Cat→DoubleCatᴴ .idⱽSq = refl
+  1Cat→DoubleCatᴴ .idᴴSq {v = p} i = C.id
+  1Cat→DoubleCatᴴ ._⋆ⱽSq_ {←f = ←f} {→f = →f} {←f' = ←f'} {→f' = →f'} α β i =
+    comp (λ j → C [ compPath-filler ←f ←f' j i , compPath-filler →f →f' j i ])
+         (λ j → λ { (i = i0) → α i0 ; (i = i1) → β j })
+         (α i)
+  1Cat→DoubleCatᴴ .⋆ⱽIdLSq _ =
+    isSet→SquareP (λ _ _ → C.isSetHom) _ _ _ _
+  1Cat→DoubleCatᴴ .⋆ⱽIdRSq _ =
+    isSet→SquareP (λ _ _ → C.isSetHom) _ _ _ _
+  1Cat→DoubleCatᴴ .⋆ⱽAssocSq _ _ _ =
+    isSet→SquareP (λ _ _ → C.isSetHom) _ _ _ _
+  1Cat→DoubleCatᴴ ._⋆ᴴSq_ α β i = α i C.⋆ β i
+  1Cat→DoubleCatᴴ .λᴴ = C.⋆IdL
+  1Cat→DoubleCatᴴ .λᴴ⁻ f = sym (C.⋆IdL f)
+  1Cat→DoubleCatᴴ .λᴴλᴴ⁻ _ = isSet→SquareP (λ _ _ → C.isSetHom) _ _ _ _
+  1Cat→DoubleCatᴴ .λᴴ⁻λᴴ _ = isSet→SquareP (λ _ _ → C.isSetHom) _ _ _ _
+  1Cat→DoubleCatᴴ .λᴴ-nat _ = isSet→SquareP (λ _ _ → C.isSetHom) _ _ _ _
+  1Cat→DoubleCatᴴ .ρᴴ = C.⋆IdR
+  1Cat→DoubleCatᴴ .ρᴴ⁻ f = sym (C.⋆IdR f)
+  1Cat→DoubleCatᴴ .ρᴴρᴴ⁻ _ = isSet→SquareP (λ _ _ → C.isSetHom) _ _ _ _
+  1Cat→DoubleCatᴴ .ρᴴ⁻ρᴴ _ = isSet→SquareP (λ _ _ → C.isSetHom) _ _ _ _
+  1Cat→DoubleCatᴴ .ρᴴ-nat _ = isSet→SquareP (λ _ _ → C.isSetHom) _ _ _ _
+  1Cat→DoubleCatᴴ .αᴴ = C.⋆Assoc
+  1Cat→DoubleCatᴴ .αᴴ⁻ f g h = sym (C.⋆Assoc f g h)
+  1Cat→DoubleCatᴴ .αᴴαᴴ⁻ _ _ _ = isSet→SquareP (λ _ _ → C.isSetHom) _ _ _ _
+  1Cat→DoubleCatᴴ .αᴴ⁻αᴴ _ _ _ = isSet→SquareP (λ _ _ → C.isSetHom) _ _ _ _
+  1Cat→DoubleCatᴴ .αᴴ-nat _ _ _ = isSet→SquareP (λ _ _ → C.isSetHom) _ _ _ _
+  1Cat→DoubleCatᴴ .pentagon _ _ _ _ = isSet→SquareP (λ _ _ → C.isSetHom) _ _ _ _
+  1Cat→DoubleCatᴴ .triangle _ _ = isSet→SquareP (λ _ _ → C.isSetHom) _ _ _ _
+  1Cat→DoubleCatᴴ .interchange _ _ _ _ = isSet→SquareP (λ _ _ → C.isSetHom) _ _ _ _
+
+  1Cat→DoubleCatᴴEq : DoubleCategory _ _ _ _
+  1Cat→DoubleCatᴴEq .ob = C.ob
+  1Cat→DoubleCatᴴEq .Homⱽ[_,_] = Eq._≡_
+  1Cat→DoubleCatᴴEq .idⱽ = Eq.refl
+  1Cat→DoubleCatᴴEq ._⋆ⱽ_ = Eq._∙_
+  1Cat→DoubleCatᴴEq .⋆ⱽIdL Eq.refl = refl
+  1Cat→DoubleCatᴴEq .⋆ⱽIdR Eq.refl = refl
+  1Cat→DoubleCatᴴEq .⋆ⱽAssoc Eq.refl Eq.refl Eq.refl = refl
+  1Cat→DoubleCatᴴEq .Homᴴ[_,_] = C.Hom[_,_]
+  1Cat→DoubleCatᴴEq .idᴴ = C.id
+  1Cat→DoubleCatᴴEq ._⋆ᴴ_ = C._⋆_
+  1Cat→DoubleCatᴴEq .Sq f g Eq.refl Eq.refl = f Eq.≡ g
+  1Cat→DoubleCatᴴEq .isSetSq {fⱽ = Eq.refl} {gⱽ = Eq.refl} =
+    isProp→isSet (Eq.isSet→isSetEq C.isSetHom)
+  1Cat→DoubleCatᴴEq .idⱽSq = Eq.refl
+  1Cat→DoubleCatᴴEq .idᴴSq {v = Eq.refl} = Eq.refl
+  1Cat→DoubleCatᴴEq ._⋆ⱽSq_ {←f = Eq.refl} {→f = Eq.refl}
+                            {←f' = Eq.refl} {→f' = Eq.refl} = Eq._∙_
+  1Cat→DoubleCatᴴEq .⋆ⱽIdLSq {←f = Eq.refl} {→f = Eq.refl} Eq.refl = refl
+  1Cat→DoubleCatᴴEq .⋆ⱽIdRSq {←f = Eq.refl} {→f = Eq.refl} Eq.refl = refl
+  1Cat→DoubleCatᴴEq .⋆ⱽAssocSq
+    {←f = Eq.refl} {→f = Eq.refl}
+    {←f' = Eq.refl} {→f' = Eq.refl}
+    {←f'' = Eq.refl} {→f'' = Eq.refl} Eq.refl Eq.refl Eq.refl = refl
+  1Cat→DoubleCatᴴEq ._⋆ᴴSq_
+    {←f = Eq.refl} {→f = Eq.refl} {→f' = Eq.refl} Eq.refl Eq.refl = Eq.refl
+  1Cat→DoubleCatᴴEq .λᴴ = Eq.pathToEq ∘ C.⋆IdL
+  1Cat→DoubleCatᴴEq .λᴴ⁻ = Eq.pathToEq ∘ sym ∘ C.⋆IdL
+  1Cat→DoubleCatᴴEq .λᴴλᴴ⁻ _ = isProp→PathP (λ i → Eq.isSet→isSetEq C.isSetHom) _ _
+  1Cat→DoubleCatᴴEq .λᴴ⁻λᴴ _ = isProp→PathP (λ i → Eq.isSet→isSetEq C.isSetHom) _ _
+  1Cat→DoubleCatᴴEq .λᴴ-nat {v = Eq.refl}{u = Eq.refl} α =
+    toPathP (Eq.isSet→isSetEq C.isSetHom _ _)
+  1Cat→DoubleCatᴴEq .ρᴴ = Eq.pathToEq ∘ C.⋆IdR
+  1Cat→DoubleCatᴴEq .ρᴴ⁻ = Eq.pathToEq ∘ sym ∘ C.⋆IdR
+  1Cat→DoubleCatᴴEq .ρᴴρᴴ⁻ _ = isProp→PathP (λ i → Eq.isSet→isSetEq C.isSetHom) _ _
+  1Cat→DoubleCatᴴEq .ρᴴ⁻ρᴴ _ = isProp→PathP (λ i → Eq.isSet→isSetEq C.isSetHom) _ _
+  1Cat→DoubleCatᴴEq .ρᴴ-nat {v = Eq.refl}{u = Eq.refl} α =
+    toPathP (Eq.isSet→isSetEq C.isSetHom _ _)
+  1Cat→DoubleCatᴴEq .αᴴ _ _ _ = Eq.pathToEq $ C.⋆Assoc _ _ _
+  1Cat→DoubleCatᴴEq .αᴴ⁻ _ _ _ = Eq.pathToEq $ sym $ C.⋆Assoc _ _ _
+  1Cat→DoubleCatᴴEq .αᴴαᴴ⁻ _ _ _ = isProp→PathP (λ i → Eq.isSet→isSetEq C.isSetHom) _ _
+  1Cat→DoubleCatᴴEq .αᴴ⁻αᴴ _ _ _ = isProp→PathP (λ i → Eq.isSet→isSetEq C.isSetHom) _ _
+  1Cat→DoubleCatᴴEq .αᴴ-nat
+    {v₁ = Eq.refl} {v₂ = Eq.refl} {v₃ = Eq.refl} {v₄ = Eq.refl} α₁ α₂ α₃ =
+    toPathP (Eq.isSet→isSetEq C.isSetHom _ _)
+  1Cat→DoubleCatᴴEq .pentagon _ _ _ _ = isProp→PathP (λ i → Eq.isSet→isSetEq C.isSetHom) _ _
+  1Cat→DoubleCatᴴEq .triangle _ _ = isProp→PathP (λ i → Eq.isSet→isSetEq C.isSetHom) _ _
+  1Cat→DoubleCatᴴEq .interchange
+    {←f = Eq.refl} {←f' = Eq.refl}
+    {→f = Eq.refl} {→f' = Eq.refl}
+    {↑g = Eq.refl} {↓g = Eq.refl} _ _ _ _ = isProp→PathP (λ i → Eq.isSet→isSetEq C.isSetHom) _ _

--- a/Cubical/Categories/Double/Instances/1CategoryW.agda
+++ b/Cubical/Categories/Double/Instances/1CategoryW.agda
@@ -1,0 +1,104 @@
+{-# OPTIONS --lossy-unification #-}
+-- Test instance of DoubleCategoryW: turn a 1-category into a double
+-- category using its hom as horizontal arrows and cubical paths for
+-- verticals.  Adapted from 1Cat→DoubleCatᴴ in
+-- Cubical.Categories.Double.Instances.1Category.
+--
+-- This exists primarily to verify that the naturality axioms of
+-- DoubleCategoryW can be inhabited as plain equations, without any
+-- PathP gymnastics over `⋆ⱽIdR v ∙ sym (⋆ⱽIdL v)`.
+module Cubical.Categories.Double.Instances.1CategoryW where
+
+open import Cubical.Foundations.Prelude
+open import Cubical.Foundations.GroupoidLaws
+open import Cubical.Foundations.HLevels
+open import Cubical.Foundations.Function
+
+open import Cubical.Categories.Category
+open import Cubical.Categories.Double.BaseW
+
+open DoubleCategoryW
+
+module _ {ℓ ℓ'} (C : Category ℓ ℓ') where
+  private
+    module C = Category C
+
+  -- Category structure of C encoded with horizontal morphisms, only
+  -- identity vertical morphisms and squares.  Same shape as
+  -- 1Cat→DoubleCatᴴ, but inhabiting the whiskered record.
+  1Cat→DoubleCatWᴴ : DoubleCategoryW _ _ _ _
+  1Cat→DoubleCatWᴴ .ob = C.ob
+  1Cat→DoubleCatWᴴ .Homⱽ[_,_] = _≡_
+  1Cat→DoubleCatWᴴ .idⱽ = refl
+  1Cat→DoubleCatWᴴ ._⋆ⱽ_ = _∙_
+  1Cat→DoubleCatWᴴ .⋆ⱽIdL f = sym $ lUnit f
+  1Cat→DoubleCatWᴴ .⋆ⱽIdR f = sym $ rUnit f
+  1Cat→DoubleCatWᴴ .⋆ⱽAssoc f g h = sym $ assoc f g h
+  1Cat→DoubleCatWᴴ .Homᴴ[_,_] = C.Hom[_,_]
+  1Cat→DoubleCatWᴴ .idᴴ = C.id
+  1Cat→DoubleCatWᴴ ._⋆ᴴ_ = C._⋆_
+  1Cat→DoubleCatWᴴ .Sq f g e e' = PathP (λ i → C [ e i , e' i ]) f g
+  1Cat→DoubleCatWᴴ .isSetSq = isProp→isSet (isOfHLevelPathP' 1 C.isSetHom _ _)
+  1Cat→DoubleCatWᴴ .idⱽSq = refl
+  1Cat→DoubleCatWᴴ .idᴴSq {v = p} i = C.id
+  1Cat→DoubleCatWᴴ ._⋆ⱽSq_ {←f = ←f} {→f = →f} {←f' = ←f'} {→f' = →f'} α β i =
+    comp (λ j → C [ compPath-filler ←f ←f' j i , compPath-filler →f →f' j i ])
+         (λ j → λ { (i = i0) → α i0 ; (i = i1) → β j })
+         (α i)
+  1Cat→DoubleCatWᴴ .⋆ⱽIdLSq _ =
+    isSet→SquareP (λ _ _ → C.isSetHom) _ _ _ _
+  1Cat→DoubleCatWᴴ .⋆ⱽIdRSq _ =
+    isSet→SquareP (λ _ _ → C.isSetHom) _ _ _ _
+  1Cat→DoubleCatWᴴ .⋆ⱽAssocSq _ _ _ =
+    isSet→SquareP (λ _ _ → C.isSetHom) _ _ _ _
+  1Cat→DoubleCatWᴴ ._⋆ᴴSq_ α β i = α i C.⋆ β i
+
+  -- Whiskering: the vertical side of Sq is a PathP over C.Hom; ◃/▹
+  -- extend its right/left endpoint along a globular cell (a path in
+  -- C.Hom) via hcomp.  ⊙ⱽ is plain path composition since both sides
+  -- live in a fixed hom-set.
+  1Cat→DoubleCatWᴴ ._◃_ α β i =
+    hcomp (λ j → λ { (i = i0) → α i0
+                   ; (i = i1) → β j })
+          (α i)
+  1Cat→DoubleCatWᴴ ._▹_ α β i =
+    hcomp (λ j → λ { (i = i0) → α (~ j)
+                   ; (i = i1) → β i1 })
+          (β i)
+  1Cat→DoubleCatWᴴ ._⊙ⱽ_ α β = α ∙ β
+
+  -- All coherences between whiskering and ⋆ⱽSq are squares in the set
+  -- C.Hom, filled automatically.
+  1Cat→DoubleCatWᴴ .◃≡⋆ⱽSq _ _ =
+    isSet→SquareP (λ _ _ → C.isSetHom) _ _ _ _
+  1Cat→DoubleCatWᴴ .▹≡⋆ⱽSq _ _ =
+    isSet→SquareP (λ _ _ → C.isSetHom) _ _ _ _
+  1Cat→DoubleCatWᴴ .⊙ⱽ≡⋆ⱽSq _ _ =
+    isSet→SquareP (λ _ _ → C.isSetHom) _ _ _ _
+
+  1Cat→DoubleCatWᴴ .λᴴ = C.⋆IdL
+  1Cat→DoubleCatWᴴ .λᴴ⁻ f = sym (C.⋆IdL f)
+  -- Isomorphism and naturality axioms: equalities between squares,
+  -- which unfold to 2-dimensional fillings in C.Hom (a set).
+  1Cat→DoubleCatWᴴ .λᴴλᴴ⁻ _ = isSet→SquareP (λ _ _ → C.isSetHom) _ _ _ _
+  1Cat→DoubleCatWᴴ .λᴴ⁻λᴴ _ = isSet→SquareP (λ _ _ → C.isSetHom) _ _ _ _
+  -- Naturality: plain equation between squares, no composite base.
+  1Cat→DoubleCatWᴴ .λᴴ-nat _ = isSet→SquareP (λ _ _ → C.isSetHom) _ _ _ _
+
+  1Cat→DoubleCatWᴴ .ρᴴ = C.⋆IdR
+  1Cat→DoubleCatWᴴ .ρᴴ⁻ f = sym (C.⋆IdR f)
+  1Cat→DoubleCatWᴴ .ρᴴρᴴ⁻ _ = isSet→SquareP (λ _ _ → C.isSetHom) _ _ _ _
+  1Cat→DoubleCatWᴴ .ρᴴ⁻ρᴴ _ = isSet→SquareP (λ _ _ → C.isSetHom) _ _ _ _
+  1Cat→DoubleCatWᴴ .ρᴴ-nat _ = isSet→SquareP (λ _ _ → C.isSetHom) _ _ _ _
+
+  1Cat→DoubleCatWᴴ .αᴴ = C.⋆Assoc
+  1Cat→DoubleCatWᴴ .αᴴ⁻ f g h = sym (C.⋆Assoc f g h)
+  1Cat→DoubleCatWᴴ .αᴴαᴴ⁻ _ _ _ = isSet→SquareP (λ _ _ → C.isSetHom) _ _ _ _
+  1Cat→DoubleCatWᴴ .αᴴ⁻αᴴ _ _ _ = isSet→SquareP (λ _ _ → C.isSetHom) _ _ _ _
+  -- αᴴ-nat: the key one.  Plain equation, no composite base path.
+  1Cat→DoubleCatWᴴ .αᴴ-nat _ _ _ = isSet→SquareP (λ _ _ → C.isSetHom) _ _ _ _
+
+  1Cat→DoubleCatWᴴ .pentagon _ _ _ _ = isSet→SquareP (λ _ _ → C.isSetHom) _ _ _ _
+  1Cat→DoubleCatWᴴ .triangle _ _ = isSet→SquareP (λ _ _ → C.isSetHom) _ _ _ _
+  1Cat→DoubleCatWᴴ .interchange _ _ _ _ =
+    isSet→SquareP (λ _ _ → C.isSetHom) _ _ _ _


### PR DESCRIPTION
- Defines double categories. I think these are _psuedo_ double categories. The naturalities of the unitors and associator are quite ugly. There are comments warning about this, and I also provide an alternative file as an experiment on making this nicer
- Defines lax double functors
- Defines coercions of 1-categories into double categories. We give both the vertical and horizontal double categories, and variants of each of these that use an `Eq` rather than a `Path` for the identities. It seems that the `Eq` version is nicer to use