### PR TITLE
Add SPAN, PROF, and PROFW as double category instances

### DIFF
--- a/Cubical/Categories/Double/Instances/Prof.agda
+++ b/Cubical/Categories/Double/Instances/Prof.agda
@@ -1,0 +1,366 @@
+{-# OPTIONS --lossy-unification #-}
+-- Double category of categories, functors, and profunctors
+--
+-- In this file, we opt for a strict notion of functor,
+-- see Cubical.Categories.Functors.Strict.Base for an
+-- alternative definition of functors that is definitionally
+-- unital and associative, to give better definitional equalities
+--
+-- Correspondingly, we also use variants of presheaves, bifunctors,
+-- and PshHom that are related to this notion of StrictFunctor
+--
+-- I'm not sure how much is genuinely necessary. Certainly the
+-- usage of StrictFunctor is crucial in allowing usage of
+-- makeSPshHomPath in several places, as in the non-strict variant we would
+-- be forced to use a genuine PathP
+module Cubical.Categories.Double.Instances.Prof where
+
+open import Cubical.Foundations.Prelude
+open import Cubical.Foundations.GroupoidLaws
+open import Cubical.Foundations.HLevels
+open import Cubical.Foundations.Function
+open import Cubical.Foundations.More
+
+open import Cubical.Data.Sigma
+import Cubical.Data.Equality as Eq
+
+open import Cubical.Categories.Category
+open import Cubical.Categories.Functors.Strict.Base
+open import Cubical.Categories.Functors.Strict.Presheaf
+open import Cubical.Categories.Functors.Strict.Bifunctor
+open import Cubical.Categories.Bifunctor
+open import Cubical.Categories.Instances.Sets
+open import Cubical.Categories.Instances.BinProduct as BP
+open import Cubical.Categories.Presheaf.Constructions.Tensor as ⊗
+open import Cubical.Categories.Presheaf.Base
+open import Cubical.Categories.Presheaf.Morphism.Alt
+open import Cubical.Categories.Presheaf.StrictHom as Strict
+open import Cubical.Categories.Profunctor.Relator
+open import Cubical.Categories.Profunctor.StrictHom as Strict
+open import Cubical.Categories.Profunctor.StrictHom.Constructions.Extension
+
+open import Cubical.Categories.Double.Base
+
+open DoubleCategory
+open PshHomStrict
+open PshIsoStrict
+open StrictFunctor
+open Bifunctor
+open BifunctorSepAx
+
+private
+  variable
+    ℓc ℓc' ℓd ℓd' ℓe ℓe' : Level
+
+-- Whisker a RelatorHomStrict by a pair of StrictFunctors.
+module _ {ℓP ℓQ}
+  {C : Category ℓc ℓc'}
+  {D : Category ℓd ℓd'}
+  {P : StrictPresheaf D ℓP}{Q : StrictPresheaf D ℓQ}
+  where
+  -- This probably belongs elsewhere
+  _∘ˡS_ : SPshHom P Q
+        → (F : StrictFunctor C D)
+        → SPshHom (P S∘ (F ^opS)) (Q S∘ (F ^opS))
+  (α ∘ˡS F) .SPshHom.N-ob = λ c → α .SPshHom.N-ob ((F ^opS) .F-ob c)
+  (α ∘ˡS F) .SPshHom.N-hom = λ c c' f →
+                                α .SPshHom.N-hom ((F ^opS) .F-ob c) ((F ^opS) .F-ob c')
+                                ((F ^opS) .F-hom f)
+
+module _ {ℓ}
+  {C₁ C₂ C₃ C₄ : Category ℓ ℓ}
+  (f : StrictRelatoro* C₁ ℓ C₂)
+  (g : StrictRelatoro* C₂ ℓ C₃)
+  (h : StrictRelatoro* C₃ ℓ C₄)
+  where
+  private
+    fg = scompLRS ⊗-BifS (StrictCurryBifunctor f)
+                         (StrictCurryBifunctor (StrictSym g))
+    gh = scompLRS ⊗-BifS (StrictCurryBifunctor g)
+                         (StrictCurryBifunctor (StrictSym h))
+  module _ (c : Category.ob C₁) (d : Category.ob C₄) where
+    αᴴ-Nob :
+      (appL (StrictBif→Bif fg) c) ⊗ (appL (StrictBif→Bif (StrictSym h)) d) →
+      (appL (StrictBif→Bif f) c) ⊗ (appL (StrictBif→Bif (StrictSym gh)) d)
+    αᴴ-Nob = rec _ _ isSet⊗ (rec _ _ (isSet→ isSet⊗)
+        (λ {x = x₂} p q q₁ → p Tensor.,⊗ (q Tensor.,⊗ q₁))
+        (λ p f q → funExt λ _ → Tensor.swap p f (q Tensor.,⊗ _)))
+        (ind _ _ (λ _ → isPropΠ2 λ _ _ → isSet⊗ _ _)
+        (λ p q g q' → congS (p Tensor.,⊗_) (Tensor.swap _ _ _)))
+
+    αᴴ⁻-Nob :
+      (appL (StrictBif→Bif f) c) ⊗ (appL (StrictBif→Bif (StrictSym gh)) d) →
+      (appL (StrictBif→Bif fg) c) ⊗ (appL (StrictBif→Bif (StrictSym h)) d)
+    αᴴ⁻-Nob = rec _ _ isSet⊗
+        (λ p → rec _ _ isSet⊗
+          (λ q r → (p Tensor.,⊗ q) Tensor.,⊗ r)
+          (λ q n r → Tensor.swap (p Tensor.,⊗ q) n r))
+        (λ p n → ind _ _ (λ _ → isSet⊗ _ _)
+          (λ q r → congS (Tensor._,⊗ r) (Tensor.swap p n q)))
+
+module _ (ℓ ℓ' : Level) where
+  PROF : DoubleCategory _ _ _ _
+  PROF .ob = Category ℓ ℓ
+  PROF .Homⱽ[_,_] = StrictFunctor
+  PROF .idⱽ = SId
+  PROF ._⋆ⱽ_ F G = G S∘ F
+  PROF .⋆ⱽIdL F = refl
+  PROF .⋆ⱽIdR F = refl
+  PROF .⋆ⱽAssoc F G H = refl
+  PROF .Homᴴ[_,_] C D = StrictRelatoro* C ℓ D
+  PROF .idᴴ {x = C} = StrictHomBif C
+  PROF ._⋆ᴴ_ S R =
+    scompLRS ⊗-BifS (StrictCurryBifunctor S)
+                    (StrictCurryBifunctor (StrictSym R))
+  PROF .Sq S R F G =
+    SPshHom (StrictRelator→Psh S)
+            (StrictRelator→Psh (scompLRS R (F ^opS) G))
+  PROF .isSetSq {fᴴ = f}{gᴴ = g}{fⱽ = v}{gⱽ = u} =
+    isSetSPshHom (StrictRelator→Psh f)
+                 (StrictRelator→Psh (scompLRS g (v ^opS) u))
+  PROF .idⱽSq = spshhom (λ c z → z) (λ c c' f p' p z → z)
+  PROF .idᴴSq {v = F} .SPshHom.N-ob (c , c') f = F .F-hom f
+  PROF .idᴴSq {y = D}{v = F} .SPshHom.N-hom (c , c') (c1 , c1') (f₁ , f₃) p' p eq =
+    cong (D._⋆ F .F-hom f₃) (sym (F .F-seq f₁ p' _ refl))
+    ∙ sym (F .F-seq _ f₃ p eq)
+    where module D = Category D
+  PROF ._⋆ⱽSq_ {←f = v}{→f = u} α β =
+    spshhom
+     (λ c z →
+        β .SPshHom.N-ob (v .F-ob (c .fst) , u .F-ob (c .snd))
+        (α .SPshHom.N-ob c z))
+     (λ c c' f p' p z →
+        β .SPshHom.N-hom (v .F-ob (c .fst) , u .F-ob (c .snd))
+        (v .F-ob (c' .fst) , u .F-ob (c' .snd))
+        (v .F-hom (f .fst) , u .F-hom (f .snd)) (α .SPshHom.N-ob c' p')
+        (α .SPshHom.N-ob c p) (α .SPshHom.N-hom c c' f p' p z))
+  PROF .⋆ⱽIdLSq _ = refl -- nice
+  PROF .⋆ⱽIdRSq _ = refl
+  PROF .⋆ⱽAssocSq _ _ _ = refl
+  PROF ._⋆ᴴSq_ {↑f = ↑f} {←f = ←f} {↓f = ↓f} {→f = →f}
+                {↑f' = ↑f'} {↓f' = ↓f'} {→f' = →f'} α β .SPshHom.N-ob (c , c3) =
+     rec _ _ isSet⊗
+     (λ {d} s r → α .SPshHom.N-ob (c , d) s Tensor.,⊗ β .SPshHom.N-ob (d , c3) r)
+      (λ {d}{d'} s g r →
+        cong₂ Tensor._,⊗_ refl (natLS ↑f' (scompLRS ↓f' (→f ^opS) →f') β g r)
+        ∙ Tensor.swap _ (→f .F-hom g) _
+        ∙ cong₂ Tensor._,⊗_ (sym (natRS ↑f (scompLRS ↓f (←f ^opS) →f) α g s)) refl)
+  PROF ._⋆ᴴSq_ {↑f = ↑f} {←f = ←f} {↓f = ↓f} {→f = →f}
+                {↑f' = ↑f'} {↓f' = ↓f'} {→f' = →f'} α β .SPshHom.N-hom
+                (c1 , c3) (c1' , c3') (f₁ , f₃) =
+    ind _ _
+      (λ _ → isPropΠ λ _ → isPropΠ λ _ → isSet⊗ _ _)
+      (λ {d} s r → ind _ _ (λ _ → isPropΠ λ _ → isSet⊗ _ _)
+        (λ {d'} u v e →
+          cong₂ Tensor._,⊗_
+            (sym (natLS ↑f (scompLRS ↓f (←f ^opS) →f) α f₁ s))
+            (sym (natRS ↑f' (scompLRS ↓f' (→f ^opS) →f') β f₃ r))
+          ∙ cong ϕ e))
+      where
+      module LHS = ⊗.Tensor (appL (StrictBif→Bif ↑f) c1)
+                             (appL (StrictBif→Bif (StrictSym ↑f')) c3)
+      module RHS = ⊗.Tensor (appL (StrictBif→Bif ↓f) (←f .F-ob c1))
+                            (appL (StrictBif→Bif (StrictSym ↓f')) (→f' .F-ob c3))
+      ϕ : LHS._⊗_ → RHS._⊗_
+      ϕ = LHS.rec RHS.isSet⊗
+        (λ {d'} u v → α .SPshHom.N-ob (c1 , d') u RHS.,⊗ β .SPshHom.N-ob (d' , c3) v)
+        (λ {d'}{d''} u g v →
+          cong₂ RHS._,⊗_ refl (natLS ↑f' (scompLRS ↓f' (→f ^opS) →f') β g v)
+          ∙ RHS.swap _ (→f .F-hom g) _
+          ∙ cong₂ RHS._,⊗_ (sym (natRS ↑f (scompLRS ↓f (←f ^opS) →f) α g u)) refl)
+  -- the left unitor uses a version of CoYoneda that I had Claude port over
+  -- into the strict world
+  -- This should probably be rewritten to be more high-level
+  PROF .λᴴ  f .SPshHom.N-ob (c , d) = λRel-ob f c d
+  PROF .λᴴ {x = C} f .SPshHom.N-hom (c , d) (c' , d') (f₁ , f₃) p' p eq =
+    helper p' ∙ cong (λRel-ob f c d) eq
+    where
+      module T = ⊗.Tensor
+        (appL (StrictBif→Bif (StrictHomBif C)) c')
+        (appL (StrictBif→Bif (StrictSym f)) d')
+      helper : ∀ q
+        → StrictBifunctor.Bif-hom× f f₁ f₃ (λRel-ob f c' d' q)
+        ≡ λRel-ob f c d (StrictRelator→Psh (PROF ._⋆ᴴ_ (PROF .idᴴ {x = C}) f)
+              .F-hom (f₁ , f₃) q)
+      helper = T.ind
+        (λ _ → f .StrictBifunctor.Bif-ob c d .snd _ _)
+        (λ {x} g r →
+          sym (funExt⁻ (f .StrictBifunctor.Bif-LR-fuse f₁ f₃)
+                       (f .StrictBifunctor.Bif-homL g d' r))
+          ∙ cong (f .StrictBifunctor.Bif-homR c f₃)
+                 (sym (funExt⁻ (f .StrictBifunctor.Bif-L-seq g f₁ _ refl) r))
+          ∙ funExt⁻ (f .StrictBifunctor.Bif-LR-fuse
+                       (Category._⋆_ (C ^op) g f₁) f₃) r
+          ∙ sym (funExt⁻ (f .StrictBifunctor.Bif-RL-fuse
+                             (Category._⋆_ (C ^op) g f₁) f₃) r))
+  PROF .λᴴ⁻ f .SPshHom.N-ob (c , d) = λRel⁻-ob f c d
+  PROF .λᴴ⁻ {x = C} f .SPshHom.N-hom (c , d) (c' , d') (f₁ , f₃) p' p eq =
+    cong (T._,⊗ q) (C.⋆IdR f₁ ∙ sym (C.⋆IdL f₁))
+    ∙ sym (T.swap C.id f₁ q)
+    ∙ cong (C.id T.,⊗_) (funExt⁻ (f .StrictBifunctor.Bif-RL-fuse f₁ f₃) p' ∙ eq)
+    where
+      module C = Category C
+      module T = ⊗.Tensor
+        (appL (StrictBif→Bif (StrictHomBif C)) c)
+        (appL (StrictBif→Bif (StrictSym f)) d)
+      q = f .StrictBifunctor.Bif-homR c' f₃ p'
+  PROF .λᴴλᴴ⁻ {x = C}{y = D} f = makeSPshHomPath
+    (funExt λ (c , d) → funExt (λRel-ret f c d))
+  PROF .λᴴ⁻λᴴ {x = C}{y = D} f = makeSPshHomPath
+    (funExt λ (c , d) → funExt (λRel-sec f c d))
+  PROF .λᴴ-nat {x = X}{y = Y}{z = Z}{w = W}{f = f}{g = g}{v = v}{u = u} α =
+    -- gross
+    subst2
+      (λ pv pu → PathP
+        (λ i → PROF .Sq {x = X}{y = Y}{z = Z}{w = W}
+                         (PROF ._⋆ᴴ_ (PROF .idᴴ {x = X}) f) g (pv i) (pu i))
+        (PROF ._⋆ⱽSq_ (PROF ._⋆ᴴSq_ (PROF .idᴴSq {v = v}) α) (PROF .λᴴ g))
+        (PROF ._⋆ⱽSq_ (PROF .λᴴ f) α))
+      (rUnit refl) (rUnit refl)
+      (makeSPshHomPath
+        (funExt λ (c , c3) →
+          let module T = ⊗.Tensor
+                (appL (StrictBif→Bif (StrictHomBif X)) c)
+                (appL (StrictBif→Bif (StrictSym f)) c3)
+          in funExt
+            (T.ind
+              (λ _ → (g .StrictBifunctor.Bif-ob (v .F-ob c) (u .F-ob c3)) .snd _ _)
+              (λ {d} s r →
+                sym (natLS f (scompLRS g (v ^opS) u) α s r)))))
+
+  -- The right unitor should definitely be rewritten to be more high-level
+  -- and reuse the ideas invoked in the left unitor rather than reimplementing
+  -- them ad-hoc
+  PROF .ρᴴ {x = C}{y = D} f .SPshHom.N-ob (c , d) =
+    T.rec (f .StrictBifunctor.Bif-ob c d .snd)
+      (λ {d'} p h → f .StrictBifunctor.Bif-homR c h p)
+      (λ {d''}{d'} p g h →
+        funExt⁻ (f .StrictBifunctor.Bif-R-seq g h _ refl) p)
+    where
+      module T = ⊗.Tensor (appL (StrictBif→Bif f) c)
+                          (appL (StrictBif→Bif (StrictSym (StrictHomBif D))) d)
+  PROF .ρᴴ {x = C}{y = D} f .SPshHom.N-hom
+    (c , d) (c' , d') (f₁ , f₃) p' p eq =
+    helper p' ∙ cong (ρ-ob c d) eq
+    where
+      module Dm = Category D
+      module T' = ⊗.Tensor
+        (appL (StrictBif→Bif f) c')
+        (appL (StrictBif→Bif (StrictSym (StrictHomBif D))) d')
+      ρ-ob : ∀ c d → _
+      ρ-ob c d = T.rec (f .StrictBifunctor.Bif-ob c d .snd)
+        (λ {d'} p h → f .StrictBifunctor.Bif-homR c h p)
+        (λ {d''}{d'} p g h →
+          funExt⁻ (f .StrictBifunctor.Bif-R-seq g h _ refl) p)
+        where
+          module T = ⊗.Tensor (appL (StrictBif→Bif f) c)
+                              (appL (StrictBif→Bif (StrictSym (StrictHomBif D))) d)
+      helper : ∀ q
+        → f .StrictBifunctor.Bif-hom× f₁ f₃ (ρ-ob c' d' q)
+        ≡ ρ-ob c d
+            (StrictRelator→Psh (PROF ._⋆ᴴ_ f (PROF .idᴴ {x = D}))
+              .F-hom (f₁ , f₃) q)
+      helper = T'.ind
+        (λ _ → f .StrictBifunctor.Bif-ob c d .snd _ _)
+        (λ {x} s h →
+          sym (funExt⁻ (f .StrictBifunctor.Bif-LR-fuse f₁ f₃)
+                       (f .StrictBifunctor.Bif-homR c' h s))
+          ∙ cong (f .StrictBifunctor.Bif-homR c f₃)
+                 (funExt⁻ (f .StrictBifunctor.Bif-RL-fuse f₁ h) s
+                  ∙ sym (funExt⁻ (f .StrictBifunctor.Bif-LR-fuse f₁ h) s))
+          ∙ sym (funExt⁻ (f .StrictBifunctor.Bif-R-seq h f₃ _ refl)
+                         (f .StrictBifunctor.Bif-homL f₁ x s)))
+  PROF .ρᴴ⁻ {x = C}{y = D} f .SPshHom.N-ob (c , d) p = p T.,⊗ Category.id D
+    where
+      module T = ⊗.Tensor (appL (StrictBif→Bif f) c)
+                          (appL (StrictBif→Bif (StrictSym (StrictHomBif D))) d)
+  PROF .ρᴴ⁻ {y = D} f .SPshHom.N-hom (c , d) (c' , d') (f₁ , f₃) p' p eq =
+    cong (q T.,⊗_) (D.⋆IdL f₃ ∙ sym (D.⋆IdR f₃))
+    ∙ T.swap q f₃ D.id
+    ∙ cong (T._,⊗ D.id) (funExt⁻ (f .StrictBifunctor.Bif-LR-fuse f₁ f₃) p' ∙ eq)
+    where
+      module D = Category D
+      module T = ⊗.Tensor
+        (appL (StrictBif→Bif f) c)
+        (appL (StrictBif→Bif (StrictSym (StrictHomBif D))) d)
+      q = f .StrictBifunctor.Bif-homL f₁ d' p'
+  PROF .ρᴴρᴴ⁻ {x = C}{y = D} f = makeSPshHomPath
+    (funExt λ (c , d) → funExt
+      (T.ind (λ _ → T.isSet⊗ _ _)
+        (λ {d'} p h →
+          sym (T.swap p h (Category.id D))
+          ∙ cong (p T.,⊗_) (Category.⋆IdR D h))))
+    where
+      module _ {c : Category.ob C} {d : Category.ob D} where
+        module T = ⊗.Tensor (appL (StrictBif→Bif f) c)
+                            (appL (StrictBif→Bif (StrictSym (StrictHomBif D))) d)
+  PROF .ρᴴ⁻ρᴴ {y = D} f = makeSPshHomPath
+    (funExt λ (c , d) → funExt
+      (λ p → funExt⁻ (f .StrictBifunctor.Bif-R-id (Category.id D) refl) p))
+  PROF .ρᴴ-nat {x = X}{y = Y}{z = Z}{w = W}{f = f}{g = g}{v = v}{u = u} α =
+    subst2 (λ pv pu → PathP
+        (λ i → PROF .Sq {x = X}{y = Y}{z = Z}{w = W}
+                         (PROF ._⋆ᴴ_ f (PROF .idᴴ {x = Y})) g (pv i) (pu i))
+        (PROF ._⋆ⱽSq_ (PROF ._⋆ᴴSq_ α (PROF .idᴴSq {v = u})) (PROF .ρᴴ g))
+        (PROF ._⋆ⱽSq_ (PROF .ρᴴ f) α))
+      (rUnit refl) (rUnit refl)
+      (makeSPshHomPath
+        (funExt λ (c , c3) →
+          let module T = ⊗.Tensor
+                (appL (StrictBif→Bif f) c)
+                (appL (StrictBif→Bif (StrictSym (StrictHomBif Y))) c3)
+          in funExt
+            (T.ind
+              (λ _ → (g .StrictBifunctor.Bif-ob (v .F-ob c) (u .F-ob c3)) .snd _ _)
+              (λ {d'} p h →
+                sym (natRS f (scompLRS g (v ^opS) u) α h p)))))
+  PROF .αᴴ f g h .SPshHom.N-ob (c , d) = αᴴ-Nob f g h c d
+  PROF .αᴴ f g h .SPshHom.N-hom (c , d) (c' , d') (f₁ , f₃) =
+    ind _ _ (λ _ → isPropΠ λ _ → isPropΠ λ _ → isSet⊗ _ _)
+      (ind _ _ (λ _ → isPropΠ3 λ _ _ _ → isSet⊗ _ _)
+        (λ w x y → ind _ _ (λ _ → isPropΠ λ _ → isSet⊗ _ _)
+          (ind _ _ (λ _ → isPropΠ2 λ _ _ → isSet⊗ _ _)
+            (λ u v r e → cong (αᴴ-Nob f g h c d) e))))
+  PROF .αᴴ⁻ f g h .SPshHom.N-ob (c , d) = αᴴ⁻-Nob f g h c d
+  PROF .αᴴ⁻ f g h .SPshHom.N-hom (c , d) (c' , d') (f₁ , f₃) =
+    ind _ _ (λ _ → isPropΠ λ _ → isPropΠ λ _ → isSet⊗ _ _)
+      (λ p → ind _ _ (λ _ → isPropΠ2 λ _ _ → isSet⊗ _ _)
+        (λ q r p₂ eq → cong (αᴴ⁻-Nob f g h c d) eq))
+  PROF .αᴴαᴴ⁻ f g h = makeSPshHomPath (funExt λ _ → funExt
+    (ind _ _ (λ _ → isSet⊗ _ _) (ind _ _ (λ _ → isPropΠ λ _ → isSet⊗ _ _)
+      (λ _ _ _ → refl))))
+  PROF .αᴴ⁻αᴴ f g h = makeSPshHomPath (funExt λ _ → funExt
+    (ind _ _ (λ _ → isSet⊗ _ _)
+      (λ p → ind _ _ (λ _ → isSet⊗ _ _) (λ _ _ → refl))))
+  PROF .αᴴ-nat {x₁ = X₁}{x₄ = X₄}{y₁ = Y₁}{y₄ = Y₄}
+               {f₁ = f₁}{f₂ = f₂}{f₃ = f₃}
+               {g₁ = g₁}{g₂ = g₂}{g₃ = g₃} α₁ α₂ α₃ =
+    subst2
+      (λ pv pu → PathP
+        (λ i → PROF .Sq {x = X₁}{y = X₄}{z = Y₁}{w = Y₄}
+                         (PROF ._⋆ᴴ_ (PROF ._⋆ᴴ_ f₁ f₂) f₃)
+                         (PROF ._⋆ᴴ_ g₁ (PROF ._⋆ᴴ_ g₂ g₃))
+                         (pv i) (pu i))
+        (PROF ._⋆ⱽSq_ (PROF ._⋆ᴴSq_ (PROF ._⋆ᴴSq_ α₁ α₂) α₃)
+                       (PROF .αᴴ g₁ g₂ g₃))
+        (PROF ._⋆ⱽSq_ (PROF .αᴴ f₁ f₂ f₃)
+                       (PROF ._⋆ᴴSq_ α₁ (PROF ._⋆ᴴSq_ α₂ α₃))))
+      (rUnit refl) (rUnit refl)
+      (makeSPshHomPath (funExt λ _ → funExt
+        (ind _ _ (λ _ → isSet⊗ _ _)
+          (ind _ _ (λ _ → isPropΠ λ _ → isSet⊗ _ _)
+            (λ _ _ _ → refl)))))
+  PROF .pentagon _ _ _ _ =
+    makeSPshHomPath (funExt λ _ → funExt
+      (ind _ _ (λ _ → isSet⊗ _ _)
+        (ind _ _ (λ _ → isPropΠ λ _ → isSet⊗ _ _)
+          (ind _ _ (λ _ → isPropΠ2 λ _ _ → isSet⊗ _ _)
+            (λ _ _ _ _ → refl)))))
+  PROF .triangle f g =
+    makeSPshHomPath (funExt λ _ → funExt
+      (ind _ _ (λ _ → isSet⊗ _ _)
+        (ind _ _ (λ _ → isPropΠ λ _ → isSet⊗ _ _)
+          (λ w x y → Tensor.swap w x y))))
+  PROF .interchange α β γ δ =
+    makeSPshHomPath (funExt λ _ → funExt
+      (ind _ _ (λ _ → isSet⊗ _ _) (λ _ _ → refl)))

--- a/Cubical/Categories/Double/Instances/ProfW.agda
+++ b/Cubical/Categories/Double/Instances/ProfW.agda
@@ -1,0 +1,366 @@
+{-# OPTIONS --lossy-unification #-}
+-- PROF as a double category, using the whiskered formulation
+-- DoubleCategoryW from Cubical.Categories.Double.BaseW.
+--
+-- The whole point of this file is to test the hypothesis that the
+-- whiskered formulation is nicer for PROF: in particular, the λᴴ-nat,
+-- ρᴴ-nat and αᴴ-nat fields in Prof.agda are wrapped in
+-- `subst2 (λ pv pu → PathP ... pv pu) (rUnit refl) (rUnit refl) ...`
+-- because the PathP base path `⋆ⱽIdR v ∙ sym (⋆ⱽIdL v)` reduces to
+-- `refl ∙ refl` (and NOT to `refl`).
+--
+-- In DoubleCategoryW the naturality fields are plain equations, so the
+-- `subst2`/`rUnit` wrappers disappear.  Since in PROF the vertical
+-- identity laws are definitional (⋆ⱽIdL F = refl, ⋆ⱽIdR F = refl), the
+-- new primitives `_◃_`, `_▹_`, `_⊙ⱽ_` are all literally `_⋆ⱽSq_`, and
+-- their coherence PathPs are `refl`.
+module Cubical.Categories.Double.Instances.ProfW where
+
+open import Cubical.Foundations.Prelude
+open import Cubical.Foundations.GroupoidLaws
+open import Cubical.Foundations.HLevels
+open import Cubical.Foundations.Function
+open import Cubical.Foundations.More
+
+open import Cubical.Data.Sigma
+import Cubical.Data.Equality as Eq
+
+open import Cubical.Categories.Category
+open import Cubical.Categories.Functors.Strict.Base
+open import Cubical.Categories.Functors.Strict.Presheaf
+open import Cubical.Categories.Functors.Strict.Bifunctor
+open import Cubical.Categories.Bifunctor
+open import Cubical.Categories.Instances.Sets
+open import Cubical.Categories.Instances.BinProduct as BP
+open import Cubical.Categories.Presheaf.Constructions.Tensor as ⊗
+open import Cubical.Categories.Presheaf.Base
+open import Cubical.Categories.Presheaf.Morphism.Alt
+open import Cubical.Categories.Presheaf.StrictHom as Strict
+open import Cubical.Categories.Profunctor.Relator
+open import Cubical.Categories.Profunctor.StrictHom as Strict
+open import Cubical.Categories.Profunctor.StrictHom.Constructions.Extension
+
+open import Cubical.Categories.Double.BaseW
+
+open DoubleCategoryW
+open PshHomStrict
+open PshIsoStrict
+open StrictFunctor
+open Bifunctor
+open BifunctorSepAx
+
+private
+  variable
+    ℓc ℓc' ℓd ℓd' ℓe ℓe' : Level
+
+-- Whisker a RelatorHomStrict by a pair of StrictFunctors.
+module _ {ℓP ℓQ}
+  {C : Category ℓc ℓc'}
+  {D : Category ℓd ℓd'}
+  {P : StrictPresheaf D ℓP}{Q : StrictPresheaf D ℓQ}
+  where
+  _∘ˡS_ : SPshHom P Q
+        → (F : StrictFunctor C D)
+        → SPshHom (P S∘ (F ^opS)) (Q S∘ (F ^opS))
+  (α ∘ˡS F) .SPshHom.N-ob = λ c → α .SPshHom.N-ob ((F ^opS) .F-ob c)
+  (α ∘ˡS F) .SPshHom.N-hom = λ c c' f →
+                                α .SPshHom.N-hom ((F ^opS) .F-ob c) ((F ^opS) .F-ob c')
+                                ((F ^opS) .F-hom f)
+
+module _ {ℓ}
+  {C₁ C₂ C₃ C₄ : Category ℓ ℓ}
+  (f : StrictRelatoro* C₁ ℓ C₂)
+  (g : StrictRelatoro* C₂ ℓ C₃)
+  (h : StrictRelatoro* C₃ ℓ C₄)
+  where
+  private
+    fg = scompLRS ⊗-BifS (StrictCurryBifunctor f)
+                         (StrictCurryBifunctor (StrictSym g))
+    gh = scompLRS ⊗-BifS (StrictCurryBifunctor g)
+                         (StrictCurryBifunctor (StrictSym h))
+  module _ (c : Category.ob C₁) (d : Category.ob C₄) where
+    αᴴ-Nob :
+      (appL (StrictBif→Bif fg) c) ⊗ (appL (StrictBif→Bif (StrictSym h)) d) →
+      (appL (StrictBif→Bif f) c) ⊗ (appL (StrictBif→Bif (StrictSym gh)) d)
+    αᴴ-Nob = rec _ _ isSet⊗ (rec _ _ (isSet→ isSet⊗)
+        (λ {x = x₂} p q q₁ → p Tensor.,⊗ (q Tensor.,⊗ q₁))
+        (λ p f q → funExt λ _ → Tensor.swap p f (q Tensor.,⊗ _)))
+        (ind _ _ (λ _ → isPropΠ2 λ _ _ → isSet⊗ _ _)
+        (λ p q g q' → congS (p Tensor.,⊗_) (Tensor.swap _ _ _)))
+
+    αᴴ⁻-Nob :
+      (appL (StrictBif→Bif f) c) ⊗ (appL (StrictBif→Bif (StrictSym gh)) d) →
+      (appL (StrictBif→Bif fg) c) ⊗ (appL (StrictBif→Bif (StrictSym h)) d)
+    αᴴ⁻-Nob = rec _ _ isSet⊗
+        (λ p → rec _ _ isSet⊗
+          (λ q r → (p Tensor.,⊗ q) Tensor.,⊗ r)
+          (λ q n r → Tensor.swap (p Tensor.,⊗ q) n r))
+        (λ p n → ind _ _ (λ _ → isSet⊗ _ _)
+          (λ q r → congS (Tensor._,⊗ r) (Tensor.swap p n q)))
+
+module _ (ℓ ℓ' : Level) where
+  PROFW : DoubleCategoryW _ _ _ _
+  PROFW .ob = Category ℓ ℓ
+  PROFW .Homⱽ[_,_] = StrictFunctor
+  PROFW .idⱽ = SId
+  PROFW ._⋆ⱽ_ F G = G S∘ F
+  PROFW .⋆ⱽIdL F = refl
+  PROFW .⋆ⱽIdR F = refl
+  PROFW .⋆ⱽAssoc F G H = refl
+  PROFW .Homᴴ[_,_] C D = StrictRelatoro* C ℓ D
+  PROFW .idᴴ {x = C} = StrictHomBif C
+  PROFW ._⋆ᴴ_ S R =
+    scompLRS ⊗-BifS (StrictCurryBifunctor S)
+                    (StrictCurryBifunctor (StrictSym R))
+  PROFW .Sq S R F G =
+    SPshHom (StrictRelator→Psh S)
+            (StrictRelator→Psh (scompLRS R (F ^opS) G))
+  PROFW .isSetSq {fᴴ = f}{gᴴ = g}{fⱽ = v}{gⱽ = u} =
+    isSetSPshHom (StrictRelator→Psh f)
+                 (StrictRelator→Psh (scompLRS g (v ^opS) u))
+  PROFW .idⱽSq = spshhom (λ c z → z) (λ c c' f p' p z → z)
+  PROFW .idᴴSq {v = F} .SPshHom.N-ob (c , c') f = F .F-hom f
+  PROFW .idᴴSq {y = D}{v = F} .SPshHom.N-hom (c , c') (c1 , c1') (f₁ , f₃) p' p eq =
+    cong (D._⋆ F .F-hom f₃) (sym (F .F-seq f₁ p' _ refl))
+    ∙ sym (F .F-seq _ f₃ p eq)
+    where module D = Category D
+  PROFW ._⋆ⱽSq_ {←f = v}{→f = u} α β =
+    spshhom
+     (λ c z →
+        β .SPshHom.N-ob (v .F-ob (c .fst) , u .F-ob (c .snd))
+        (α .SPshHom.N-ob c z))
+     (λ c c' f p' p z →
+        β .SPshHom.N-hom (v .F-ob (c .fst) , u .F-ob (c .snd))
+        (v .F-ob (c' .fst) , u .F-ob (c' .snd))
+        (v .F-hom (f .fst) , u .F-hom (f .snd)) (α .SPshHom.N-ob c' p')
+        (α .SPshHom.N-ob c p) (α .SPshHom.N-hom c c' f p' p z))
+  PROFW .⋆ⱽIdLSq _ = refl
+  PROFW .⋆ⱽIdRSq _ = refl
+  PROFW .⋆ⱽAssocSq _ _ _ = refl
+  PROFW ._⋆ᴴSq_ {↑f = ↑f} {←f = ←f} {↓f = ↓f} {→f = →f}
+                {↑f' = ↑f'} {↓f' = ↓f'} {→f' = →f'} α β .SPshHom.N-ob (c , c3) =
+     rec _ _ isSet⊗
+     (λ {d} s r → α .SPshHom.N-ob (c , d) s Tensor.,⊗ β .SPshHom.N-ob (d , c3) r)
+      (λ {d}{d'} s g r →
+        cong₂ Tensor._,⊗_ refl (natLS ↑f' (scompLRS ↓f' (→f ^opS) →f') β g r)
+        ∙ Tensor.swap _ (→f .F-hom g) _
+        ∙ cong₂ Tensor._,⊗_ (sym (natRS ↑f (scompLRS ↓f (←f ^opS) →f) α g s)) refl)
+  PROFW ._⋆ᴴSq_ {↑f = ↑f} {←f = ←f} {↓f = ↓f} {→f = →f}
+                {↑f' = ↑f'} {↓f' = ↓f'} {→f' = →f'} α β .SPshHom.N-hom
+                (c1 , c3) (c1' , c3') (f₁ , f₃) =
+    ind _ _
+      (λ _ → isPropΠ λ _ → isPropΠ λ _ → isSet⊗ _ _)
+      (λ {d} s r → ind _ _ (λ _ → isPropΠ λ _ → isSet⊗ _ _)
+        (λ {d'} u v e →
+          cong₂ Tensor._,⊗_
+            (sym (natLS ↑f (scompLRS ↓f (←f ^opS) →f) α f₁ s))
+            (sym (natRS ↑f' (scompLRS ↓f' (→f ^opS) →f') β f₃ r))
+          ∙ cong ϕ e))
+      where
+      module LHS = ⊗.Tensor (appL (StrictBif→Bif ↑f) c1)
+                             (appL (StrictBif→Bif (StrictSym ↑f')) c3)
+      module RHS = ⊗.Tensor (appL (StrictBif→Bif ↓f) (←f .F-ob c1))
+                            (appL (StrictBif→Bif (StrictSym ↓f')) (→f' .F-ob c3))
+      ϕ : LHS._⊗_ → RHS._⊗_
+      ϕ = LHS.rec RHS.isSet⊗
+        (λ {d'} u v → α .SPshHom.N-ob (c1 , d') u RHS.,⊗ β .SPshHom.N-ob (d' , c3) v)
+        (λ {d'}{d''} u g v →
+          cong₂ RHS._,⊗_ refl (natLS ↑f' (scompLRS ↓f' (→f ^opS) →f') β g v)
+          ∙ RHS.swap _ (→f .F-hom g) _
+          ∙ cong₂ RHS._,⊗_ (sym (natRS ↑f (scompLRS ↓f (←f ^opS) →f) α g u)) refl)
+
+  ----------------------------------------------------------------------
+  -- Whiskering primitives.
+  --
+  -- In PROF, `F ⋆ⱽ idⱽ = F` and `idⱽ ⋆ⱽ F = F` *definitionally* (the
+  -- record fields ⋆ⱽIdL/⋆ⱽIdR are refl).  That means
+  --   α ⋆ⱽSq β : Sq f h (v ⋆ⱽ idⱽ) (u ⋆ⱽ idⱽ)
+  -- already has type Sq f h v u when β is globular, and similarly for
+  -- the other two whiskerings.  So all three primitives are literally
+  -- ⋆ⱽSq, and their coherence fields are refl.
+  ----------------------------------------------------------------------
+  PROFW ._◃_ α β = PROFW ._⋆ⱽSq_ α β
+  PROFW ._▹_ α β = PROFW ._⋆ⱽSq_ α β
+  PROFW ._⊙ⱽ_ α β = PROFW ._⋆ⱽSq_ α β
+
+  PROFW .◃≡⋆ⱽSq _ _ = refl
+  PROFW .▹≡⋆ⱽSq _ _ = refl
+  PROFW .⊙ⱽ≡⋆ⱽSq _ _ = refl
+
+  PROFW .λᴴ  f .SPshHom.N-ob (c , d) = λRel-ob f c d
+  PROFW .λᴴ {x = C} f .SPshHom.N-hom (c , d) (c' , d') (f₁ , f₃) p' p eq =
+    helper p' ∙ cong (λRel-ob f c d) eq
+    where
+      module T = ⊗.Tensor
+        (appL (StrictBif→Bif (StrictHomBif C)) c')
+        (appL (StrictBif→Bif (StrictSym f)) d')
+      helper : ∀ q
+        → StrictBifunctor.Bif-hom× f f₁ f₃ (λRel-ob f c' d' q)
+        ≡ λRel-ob f c d (StrictRelator→Psh (PROFW ._⋆ᴴ_ (PROFW .idᴴ {x = C}) f)
+              .F-hom (f₁ , f₃) q)
+      helper = T.ind
+        (λ _ → f .StrictBifunctor.Bif-ob c d .snd _ _)
+        (λ {x} g r →
+          sym (funExt⁻ (f .StrictBifunctor.Bif-LR-fuse f₁ f₃)
+                       (f .StrictBifunctor.Bif-homL g d' r))
+          ∙ cong (f .StrictBifunctor.Bif-homR c f₃)
+                 (sym (funExt⁻ (f .StrictBifunctor.Bif-L-seq g f₁ _ refl) r))
+          ∙ funExt⁻ (f .StrictBifunctor.Bif-LR-fuse
+                       (Category._⋆_ (C ^op) g f₁) f₃) r
+          ∙ sym (funExt⁻ (f .StrictBifunctor.Bif-RL-fuse
+                             (Category._⋆_ (C ^op) g f₁) f₃) r))
+  PROFW .λᴴ⁻ f .SPshHom.N-ob (c , d) = λRel⁻-ob f c d
+  PROFW .λᴴ⁻ {x = C} f .SPshHom.N-hom (c , d) (c' , d') (f₁ , f₃) p' p eq =
+    cong (T._,⊗ q) (C.⋆IdR f₁ ∙ sym (C.⋆IdL f₁))
+    ∙ sym (T.swap C.id f₁ q)
+    ∙ cong (C.id T.,⊗_) (funExt⁻ (f .StrictBifunctor.Bif-RL-fuse f₁ f₃) p' ∙ eq)
+    where
+      module C = Category C
+      module T = ⊗.Tensor
+        (appL (StrictBif→Bif (StrictHomBif C)) c)
+        (appL (StrictBif→Bif (StrictSym f)) d)
+      q = f .StrictBifunctor.Bif-homR c' f₃ p'
+  PROFW .λᴴλᴴ⁻ {x = C}{y = D} f = makeSPshHomPath
+    (funExt λ (c , d) → funExt (λRel-ret f c d))
+  PROFW .λᴴ⁻λᴴ {x = C}{y = D} f = makeSPshHomPath
+    (funExt λ (c , d) → funExt (λRel-sec f c d))
+
+  -- NOTE: compare to Prof.agda:191 — NO `subst2 ... (rUnit refl)` wrapper.
+  -- The naturality is now a plain equation, filled directly by the
+  -- inner proof.
+  PROFW .λᴴ-nat {x = X}{y = Y}{z = Z}{w = W}{f = f}{g = g}{v = v}{u = u} α =
+    makeSPshHomPath
+      (funExt λ (c , c3) →
+        let module T = ⊗.Tensor
+              (appL (StrictBif→Bif (StrictHomBif X)) c)
+              (appL (StrictBif→Bif (StrictSym f)) c3)
+        in funExt
+          (T.ind
+            (λ _ → (g .StrictBifunctor.Bif-ob (v .F-ob c) (u .F-ob c3)) .snd _ _)
+            (λ {d} s r →
+              sym (natLS f (scompLRS g (v ^opS) u) α s r))))
+
+  PROFW .ρᴴ {x = C}{y = D} f .SPshHom.N-ob (c , d) =
+    T.rec (f .StrictBifunctor.Bif-ob c d .snd)
+      (λ {d'} p h → f .StrictBifunctor.Bif-homR c h p)
+      (λ {d''}{d'} p g h →
+        funExt⁻ (f .StrictBifunctor.Bif-R-seq g h _ refl) p)
+    where
+      module T = ⊗.Tensor (appL (StrictBif→Bif f) c)
+                          (appL (StrictBif→Bif (StrictSym (StrictHomBif D))) d)
+  PROFW .ρᴴ {x = C}{y = D} f .SPshHom.N-hom
+    (c , d) (c' , d') (f₁ , f₃) p' p eq =
+    helper p' ∙ cong (ρ-ob c d) eq
+    where
+      module Dm = Category D
+      module T' = ⊗.Tensor
+        (appL (StrictBif→Bif f) c')
+        (appL (StrictBif→Bif (StrictSym (StrictHomBif D))) d')
+      ρ-ob : ∀ c d → _
+      ρ-ob c d = T.rec (f .StrictBifunctor.Bif-ob c d .snd)
+        (λ {d'} p h → f .StrictBifunctor.Bif-homR c h p)
+        (λ {d''}{d'} p g h →
+          funExt⁻ (f .StrictBifunctor.Bif-R-seq g h _ refl) p)
+        where
+          module T = ⊗.Tensor (appL (StrictBif→Bif f) c)
+                              (appL (StrictBif→Bif (StrictSym (StrictHomBif D))) d)
+      helper : ∀ q
+        → f .StrictBifunctor.Bif-hom× f₁ f₃ (ρ-ob c' d' q)
+        ≡ ρ-ob c d
+            (StrictRelator→Psh (PROFW ._⋆ᴴ_ f (PROFW .idᴴ {x = D}))
+              .F-hom (f₁ , f₃) q)
+      helper = T'.ind
+        (λ _ → f .StrictBifunctor.Bif-ob c d .snd _ _)
+        (λ {x} s h →
+          sym (funExt⁻ (f .StrictBifunctor.Bif-LR-fuse f₁ f₃)
+                       (f .StrictBifunctor.Bif-homR c' h s))
+          ∙ cong (f .StrictBifunctor.Bif-homR c f₃)
+                 (funExt⁻ (f .StrictBifunctor.Bif-RL-fuse f₁ h) s
+                  ∙ sym (funExt⁻ (f .StrictBifunctor.Bif-LR-fuse f₁ h) s))
+          ∙ sym (funExt⁻ (f .StrictBifunctor.Bif-R-seq h f₃ _ refl)
+                         (f .StrictBifunctor.Bif-homL f₁ x s)))
+  PROFW .ρᴴ⁻ {x = C}{y = D} f .SPshHom.N-ob (c , d) p = p T.,⊗ Category.id D
+    where
+      module T = ⊗.Tensor (appL (StrictBif→Bif f) c)
+                          (appL (StrictBif→Bif (StrictSym (StrictHomBif D))) d)
+  PROFW .ρᴴ⁻ {y = D} f .SPshHom.N-hom (c , d) (c' , d') (f₁ , f₃) p' p eq =
+    cong (q T.,⊗_) (D.⋆IdL f₃ ∙ sym (D.⋆IdR f₃))
+    ∙ T.swap q f₃ D.id
+    ∙ cong (T._,⊗ D.id) (funExt⁻ (f .StrictBifunctor.Bif-LR-fuse f₁ f₃) p' ∙ eq)
+    where
+      module D = Category D
+      module T = ⊗.Tensor
+        (appL (StrictBif→Bif f) c)
+        (appL (StrictBif→Bif (StrictSym (StrictHomBif D))) d)
+      q = f .StrictBifunctor.Bif-homL f₁ d' p'
+  PROFW .ρᴴρᴴ⁻ {x = C}{y = D} f = makeSPshHomPath
+    (funExt λ (c , d) → funExt
+      (T.ind (λ _ → T.isSet⊗ _ _)
+        (λ {d'} p h →
+          sym (T.swap p h (Category.id D))
+          ∙ cong (p T.,⊗_) (Category.⋆IdR D h))))
+    where
+      module _ {c : Category.ob C} {d : Category.ob D} where
+        module T = ⊗.Tensor (appL (StrictBif→Bif f) c)
+                            (appL (StrictBif→Bif (StrictSym (StrictHomBif D))) d)
+  PROFW .ρᴴ⁻ρᴴ {y = D} f = makeSPshHomPath
+    (funExt λ (c , d) → funExt
+      (λ p → funExt⁻ (f .StrictBifunctor.Bif-R-id (Category.id D) refl) p))
+
+  -- NOTE: compare to Prof.agda:275 — no subst2/rUnit.
+  PROFW .ρᴴ-nat {x = X}{y = Y}{z = Z}{w = W}{f = f}{g = g}{v = v}{u = u} α =
+    makeSPshHomPath
+      (funExt λ (c , c3) →
+        let module T = ⊗.Tensor
+              (appL (StrictBif→Bif f) c)
+              (appL (StrictBif→Bif (StrictSym (StrictHomBif Y))) c3)
+        in funExt
+          (T.ind
+            (λ _ → (g .StrictBifunctor.Bif-ob (v .F-ob c) (u .F-ob c3)) .snd _ _)
+            (λ {d'} p h →
+              sym (natRS f (scompLRS g (v ^opS) u) α h p))))
+
+  PROFW .αᴴ f g h .SPshHom.N-ob (c , d) = αᴴ-Nob f g h c d
+  PROFW .αᴴ f g h .SPshHom.N-hom (c , d) (c' , d') (f₁ , f₃) =
+    ind _ _ (λ _ → isPropΠ λ _ → isPropΠ λ _ → isSet⊗ _ _)
+      (ind _ _ (λ _ → isPropΠ3 λ _ _ _ → isSet⊗ _ _)
+        (λ w x y → ind _ _ (λ _ → isPropΠ λ _ → isSet⊗ _ _)
+          (ind _ _ (λ _ → isPropΠ2 λ _ _ → isSet⊗ _ _)
+            (λ u v r e → cong (αᴴ-Nob f g h c d) e))))
+  PROFW .αᴴ⁻ f g h .SPshHom.N-ob (c , d) = αᴴ⁻-Nob f g h c d
+  PROFW .αᴴ⁻ f g h .SPshHom.N-hom (c , d) (c' , d') (f₁ , f₃) =
+    ind _ _ (λ _ → isPropΠ λ _ → isPropΠ λ _ → isSet⊗ _ _)
+      (λ p → ind _ _ (λ _ → isPropΠ2 λ _ _ → isSet⊗ _ _)
+        (λ q r p₂ eq → cong (αᴴ⁻-Nob f g h c d) eq))
+  PROFW .αᴴαᴴ⁻ f g h = makeSPshHomPath (funExt λ _ → funExt
+    (ind _ _ (λ _ → isSet⊗ _ _) (ind _ _ (λ _ → isPropΠ λ _ → isSet⊗ _ _)
+      (λ _ _ _ → refl))))
+  PROFW .αᴴ⁻αᴴ f g h = makeSPshHomPath (funExt λ _ → funExt
+    (ind _ _ (λ _ → isSet⊗ _ _)
+      (λ p → ind _ _ (λ _ → isSet⊗ _ _) (λ _ _ → refl))))
+
+  -- NOTE: compare to Prof.agda:310 — no subst2/rUnit.  This is the
+  -- main saving: αᴴ-nat is now a plain equation, fillable directly by
+  -- the pointwise proof.
+  PROFW .αᴴ-nat {x₁ = X₁}{x₄ = X₄}{y₁ = Y₁}{y₄ = Y₄}
+               {f₁ = f₁}{f₂ = f₂}{f₃ = f₃}
+               {g₁ = g₁}{g₂ = g₂}{g₃ = g₃} α₁ α₂ α₃ =
+    makeSPshHomPath (funExt λ _ → funExt
+      (ind _ _ (λ _ → isSet⊗ _ _)
+        (ind _ _ (λ _ → isPropΠ λ _ → isSet⊗ _ _)
+          (λ _ _ _ → refl))))
+
+  PROFW .pentagon _ _ _ _ =
+    makeSPshHomPath (funExt λ _ → funExt
+      (ind _ _ (λ _ → isSet⊗ _ _)
+        (ind _ _ (λ _ → isPropΠ λ _ → isSet⊗ _ _)
+          (ind _ _ (λ _ → isPropΠ2 λ _ _ → isSet⊗ _ _)
+            (λ _ _ _ _ → refl)))))
+  PROFW .triangle f g =
+    makeSPshHomPath (funExt λ _ → funExt
+      (ind _ _ (λ _ → isSet⊗ _ _)
+        (ind _ _ (λ _ → isPropΠ λ _ → isSet⊗ _ _)
+          (λ w x y → Tensor.swap w x y))))
+  PROFW .interchange α β γ δ =
+    makeSPshHomPath (funExt λ _ → funExt
+      (ind _ _ (λ _ → isSet⊗ _ _) (λ _ _ → refl)))

--- a/Cubical/Categories/Double/Instances/Span.agda
+++ b/Cubical/Categories/Double/Instances/Span.agda
@@ -1,0 +1,99 @@
+{-# OPTIONS --lossy-unification #-}
+-- Double category of spans for a category with pullbacks
+module Cubical.Categories.Double.Instances.Span where
+
+open import Cubical.Foundations.Prelude
+open import Cubical.Foundations.HLevels
+open import Cubical.Foundations.Function
+
+open import Cubical.Data.Sigma
+
+open import Cubical.Categories.Category
+open import Cubical.Categories.Limits.Pullback.Alt
+
+open import Cubical.Categories.Displayed.Base
+
+open import Cubical.Categories.Double.Base
+
+-- For performance reasons, these needed to be all in separate files
+open import Cubical.Categories.Double.Instances.Span.Base
+open import Cubical.Categories.Double.Instances.Span.LeftUnitor
+open import Cubical.Categories.Double.Instances.Span.RightUnitor
+open import Cubical.Categories.Double.Instances.Span.Associator
+open import Cubical.Categories.Double.Instances.Span.Pentagon
+open import Cubical.Categories.Double.Instances.Span.Triangle
+open import Cubical.Categories.Double.Instances.Span.Interchange
+
+open DoubleCategory
+open Categoryᴰ
+
+module _ {ℓC ℓC'}
+  (C : Category ℓC ℓC')
+  (pbs : Pullbacks C)
+  where
+  private
+    module C = Category C
+
+  open SpanDefs C pbs
+  open SpanLeftUnitor C pbs
+  open SpanRightUnitor C pbs
+  open SpanAssociator C pbs
+  open SpanTriangle C pbs
+  open SpanPentagon C pbs
+  open SpanInterchange C pbs
+  open PullbackNotation
+
+  SPAN : DoubleCategory _ _ _ _
+  SPAN .ob = C.ob
+  SPAN .Homⱽ[_,_] = C.Hom[_,_]
+  SPAN .idⱽ = C.id
+  SPAN ._⋆ⱽ_ = C._⋆_
+  SPAN .⋆ⱽIdL = C.⋆IdL
+  SPAN .⋆ⱽIdR = C.⋆IdR
+  SPAN .⋆ⱽAssoc = C.⋆Assoc
+  SPAN .Homᴴ[_,_] = Span
+  SPAN .idᴴ = idSpan
+  SPAN ._⋆ᴴ_ = seqSpan
+  SPAN .Sq = SpanSquare
+  SPAN .isSetSq = isSetΣ C.isSetHom
+    (λ _ → isSet× (isProp→isSet $ C.isSetHom _ _) (isProp→isSet $ C.isSetHom _ _))
+  SPAN .DoubleCategory.idⱽSq = SpanDefs.idⱽSq C pbs
+  SPAN .idᴴSq {v = v} = v , (C.⋆IdL _ ∙ sym (C.⋆IdR _)) , (C.⋆IdL _ ∙ sym (C.⋆IdR _))
+  SPAN ._⋆ⱽSq_ = seqⱽSq
+  SPAN .⋆ⱽIdLSq _ = makeSpanSquarePathP (C.⋆IdL _)
+  SPAN .⋆ⱽIdRSq _ = makeSpanSquarePathP (C.⋆IdR _)
+  SPAN .⋆ⱽAssocSq _ _ _ = makeSpanSquarePathP (C.⋆Assoc _ _ _)
+  SPAN ._⋆ᴴSq_ = seqᴴSq
+  -- Left unitor
+  SPAN .λᴴ = spanλᴴ
+  SPAN .λᴴ⁻ = spanλᴴ⁻
+  SPAN .λᴴλᴴ⁻ s = makeSpanSquarePathP (spanλᴴλᴴ⁻-apex s)
+  SPAN .λᴴ⁻λᴴ s = makeSpanSquarePathP (spanλᴴ⁻λᴴ-apex s)
+  SPAN .λᴴ-nat {f = xyf} {g = zwg} {v = v} {u = u} sq =
+    makeSpanSquarePathP $
+      C.⟨ pbg.pbIntro≡ (sym (pbg.pbβ₁
+        {e = C.⋆IdR _ ∙ (C.⟨ (sym $ C.⋆IdR _) ∙ pbf.pbCommutes ⟩⋆⟨ refl ⟩ ∙ C.⋆Assoc _ _ _)
+          ∙ C.⟨ refl ⟩⋆⟨ sq .snd .fst ⟩ ∙ sym (C.⋆Assoc _ _ _)}))
+        (sym pbg.pbβ₂) ⟩⋆⟨ refl ⟩ ∙ pbg.pbβ₂
+    where
+    module pbf = PullbackNotation (pbs (C.id {x = _}) (xyf .snd .fst))
+    module pbg = PullbackNotation (pbs (C.id {x = _}) (zwg .snd .fst))
+  -- Right unitor
+  SPAN .ρᴴ = spanρᴴ
+  SPAN .ρᴴ⁻ = spanρᴴ⁻
+  SPAN .ρᴴρᴴ⁻ s = makeSpanSquarePathP (spanρᴴρᴴ⁻-apex s)
+  SPAN .ρᴴ⁻ρᴴ s = makeSpanSquarePathP (spanρᴴ⁻ρᴴ-apex s)
+  SPAN .ρᴴ-nat {f = xyf} {g = zwg} sq =
+    makeSpanSquarePathP pbg.pbβ₁
+    where
+    module pbg = PullbackNotation (pbs (zwg .snd .snd) (C.id {x = _}))
+  -- Associator
+  SPAN .αᴴ = spanαᴴ
+  SPAN .αᴴ⁻ = spanαᴴ⁻
+  SPAN .αᴴαᴴ⁻ s t u = makeSpanSquarePathP (spanαᴴαᴴ⁻-apex s t u)
+  SPAN .αᴴ⁻αᴴ s t u = makeSpanSquarePathP (spanαᴴ⁻αᴴ-apex s t u)
+  SPAN .αᴴ-nat α₁ α₂ α₃ = makeSpanSquarePathP (spanαᴴ-nat-apex α₁ α₂ α₃)
+  -- Coherence
+  SPAN .pentagon f g h k = makeSpanSquarePathP (spanPentagon-apex f g h k)
+  SPAN .triangle f g = makeSpanSquarePathP (spanTriangle-apex f g)
+  SPAN .interchange ul ur dl dr = makeSpanSquarePathP (spanInterchange-apex ul ur dl dr)

--- a/Cubical/Categories/Double/Instances/Span/Associator.agda
+++ b/Cubical/Categories/Double/Instances/Span/Associator.agda
@@ -1,0 +1,162 @@
+{-# OPTIONS --lossy-unification #-}
+-- Written by Claude
+module Cubical.Categories.Double.Instances.Span.Associator where
+
+open import Cubical.Foundations.Prelude
+open import Cubical.Foundations.HLevels
+
+open import Cubical.Data.Sigma
+
+open import Cubical.Categories.Category
+open import Cubical.Categories.Limits.Pullback.Alt
+
+open import Cubical.Categories.Double.Instances.Span.Base
+
+module SpanAssociator {ℓC ℓC'}
+  (C : Category ℓC ℓC')
+  (pbs : Pullbacks C)
+  where
+  open SpanDefs C pbs
+  private
+    module C = Category C
+
+  -- The four pullback modules for the associator
+  module AssocPBs {x y z w : C.ob}
+    (s : Span x y) (t : Span y z) (u : Span z w) where
+    -- (s⋆t)⋆u: outer pullback
+    module pb = PullbackNotation
+      (pbs (pbπ₂ (pbs (s .snd .snd) (t .snd .fst)) C.⋆ t .snd .snd) (u .snd .fst))
+    -- s⋆(t⋆u): outer pullback
+    module pb' = PullbackNotation
+      (pbs (s .snd .snd) (pbπ₁ (pbs (t .snd .snd) (u .snd .fst)) C.⋆ t .snd .fst))
+    -- s⋆t: inner pullback
+    module pb'' = PullbackNotation (pbs (s .snd .snd) (t .snd .fst))
+    -- t⋆u: inner pullback
+    module pb''' = PullbackNotation (pbs (t .snd .snd) (u .snd .fst))
+
+  spanαᴴ : ∀ {x y z w}
+    (s : Span x y) (t : Span y z) (u : Span z w) →
+    SpanSquare (seqSpan (seqSpan s t) u) (seqSpan s (seqSpan t u)) C.id C.id
+  spanαᴴ s t u =
+    h ,
+    C.⋆IdR _ ∙ sym (C.⋆Assoc _ _ _)
+      ∙ C.⟨ sym pb'.pbβ₁ ⟩⋆⟨ refl ⟩ ∙ C.⋆Assoc _ _ _ ,
+    C.⋆IdR _ ∙ C.⟨ sym pb'''.pbβ₂ ⟩⋆⟨ refl ⟩ ∙ C.⋆Assoc _ _ _
+      ∙ C.⟨ sym pb'.pbβ₂ ⟩⋆⟨ refl ⟩ ∙ C.⋆Assoc _ _ _
+    where
+    open AssocPBs s t u
+    g' = pb'''.pbIntro (pb.pbπ₁ C.⋆ pb''.pbπ₂) pb.pbπ₂
+      (C.⋆Assoc _ _ _ ∙ pb.pbCommutes)
+    abstract
+      p : (pb.pbπ₁ C.⋆ pb''.pbπ₁) C.⋆ s .snd .snd ≡ g' C.⋆ pb'''.pbπ₁ C.⋆ t .snd .fst
+      p = (C.⋆Assoc _ _ _ ∙ C.⟨ refl ⟩⋆⟨ pb''.pbCommutes ⟩
+          ∙ sym (C.⋆Assoc _ _ _) ∙ C.⟨ sym pb'''.pbβ₁ ⟩⋆⟨ refl ⟩ ∙ C.⋆Assoc _ _ _)
+    h = pb'.pbIntro (pb.pbπ₁ C.⋆ pb''.pbπ₁) g' p
+
+  spanαᴴ⁻ : ∀ {x y z w}
+    (s : Span x y) (t : Span y z) (u : Span z w) →
+    SpanSquare (seqSpan s (seqSpan t u)) (seqSpan (seqSpan s t) u) C.id C.id
+  spanαᴴ⁻ s t u =
+    h⁻ ,
+    C.⋆IdR _ ∙ C.⟨ sym pb''.pbβ₁ ⟩⋆⟨ refl ⟩ ∙ C.⋆Assoc _ _ _
+      ∙ C.⟨ sym pb.pbβ₁ ⟩⋆⟨ refl ⟩ ∙ C.⋆Assoc _ _ _ ,
+    C.⋆IdR _ ∙ sym (C.⋆Assoc _ _ _)
+      ∙ C.⟨ sym pb.pbβ₂ ⟩⋆⟨ refl ⟩ ∙ C.⋆Assoc _ _ _
+    where
+    open AssocPBs s t u
+    abstract
+      p : pb'.pbπ₁ C.⋆ s .snd .snd ≡ (pb'.pbπ₂ C.⋆ pb'''.pbπ₁) C.⋆ t .snd .fst
+      p  = (pb'.pbCommutes ∙ sym (C.⋆Assoc _ _ _))
+
+    f'⁻ = pb''.pbIntro pb'.pbπ₁ (pb'.pbπ₂ C.⋆ pb'''.pbπ₁) p
+
+    abstract
+      q : f'⁻ C.⋆ pb''.pbπ₂ C.⋆ t .snd .snd ≡ (pb'.pbπ₂ C.⋆ pb'''.pbπ₂) C.⋆ u .snd .fst
+      q = (sym (C.⋆Assoc _ _ _) ∙ C.⟨ pb''.pbβ₂ ⟩⋆⟨ refl ⟩ ∙ C.⋆Assoc _ _ _
+        ∙ C.⟨ refl ⟩⋆⟨ pb'''.pbCommutes ⟩ ∙ sym (C.⋆Assoc _ _ _))
+
+    h⁻ = pb.pbIntro f'⁻ (pb'.pbπ₂ C.⋆ pb'''.pbπ₂) q
+
+  spanαᴴαᴴ⁻-apex : ∀ {x y z w}
+    (s : Span x y) (t : Span y z) (u : Span z w) →
+    spanαᴴ s t u .fst C.⋆ spanαᴴ⁻ s t u .fst ≡ C.id
+  spanαᴴαᴴ⁻-apex s t u =
+    pb.pbExtensionality
+      (C.⋆Assoc _ _ _ ∙ C.⟨ refl ⟩⋆⟨ pb.pbβ₁ ⟩
+        ∙ pb''.pbExtensionality
+          (C.⋆Assoc _ _ _ ∙ C.⟨ refl ⟩⋆⟨ pb''.pbβ₁ ⟩ ∙ pb'.pbβ₁)
+          (C.⋆Assoc _ _ _ ∙ C.⟨ refl ⟩⋆⟨ pb''.pbβ₂ ⟩
+            ∙ sym (C.⋆Assoc _ _ _) ∙ C.⟨ pb'.pbβ₂ ⟩⋆⟨ refl ⟩ ∙ pb'''.pbβ₁)
+        ∙ sym (C.⋆IdL _))
+      (C.⋆Assoc _ _ _ ∙ C.⟨ refl ⟩⋆⟨ pb.pbβ₂ ⟩
+        ∙ sym (C.⋆Assoc _ _ _) ∙ C.⟨ pb'.pbβ₂ ⟩⋆⟨ refl ⟩ ∙ pb'''.pbβ₂
+        ∙ sym (C.⋆IdL _))
+    where open AssocPBs s t u
+
+  spanαᴴ⁻αᴴ-apex : ∀ {x y z w}
+    (s : Span x y) (t : Span y z) (u : Span z w) →
+    spanαᴴ⁻ s t u .fst C.⋆ spanαᴴ s t u .fst ≡ C.id
+  spanαᴴ⁻αᴴ-apex s t u =
+    pb'.pbExtensionality
+      (C.⋆Assoc _ _ _ ∙ C.⟨ refl ⟩⋆⟨ pb'.pbβ₁ ⟩
+        ∙ sym (C.⋆Assoc _ _ _) ∙ C.⟨ pb.pbβ₁ ⟩⋆⟨ refl ⟩ ∙ pb''.pbβ₁
+        ∙ sym (C.⋆IdL _))
+      (C.⋆Assoc _ _ _ ∙ C.⟨ refl ⟩⋆⟨ pb'.pbβ₂ ⟩
+        ∙ pb'''.pbExtensionality
+          (C.⋆Assoc _ _ _ ∙ C.⟨ refl ⟩⋆⟨ pb'''.pbβ₁ ⟩
+            ∙ sym (C.⋆Assoc _ _ _) ∙ C.⟨ pb.pbβ₁ ⟩⋆⟨ refl ⟩ ∙ pb''.pbβ₂)
+          (C.⋆Assoc _ _ _ ∙ C.⟨ refl ⟩⋆⟨ pb'''.pbβ₂ ⟩ ∙ pb.pbβ₂)
+        ∙ sym (C.⋆IdL _))
+    where open AssocPBs s t u
+
+  spanαᴴ-nat-apex : ∀ {x₁ x₂ x₃ x₄ y₁ y₂ y₃ y₄}
+    {f₁ : Span x₁ x₂} {f₂ : Span x₂ x₃} {f₃ : Span x₃ x₄}
+    {g₁ : Span y₁ y₂} {g₂ : Span y₂ y₃} {g₃ : Span y₃ y₄}
+    {v₁ : C [ x₁ , y₁ ]} {v₂ : C [ x₂ , y₂ ]}
+    {v₃ : C [ x₃ , y₃ ]} {v₄ : C [ x₄ , y₄ ]}
+    (α₁ : SpanSquare f₁ g₁ v₁ v₂) (α₂ : SpanSquare f₂ g₂ v₂ v₃)
+    (α₃ : SpanSquare f₃ g₃ v₃ v₄) →
+    seqᴴSq (seqᴴSq α₁ α₂) α₃ .fst C.⋆ spanαᴴ g₁ g₂ g₃ .fst
+      ≡ spanαᴴ f₁ f₂ f₃ .fst C.⋆ seqᴴSq α₁ (seqᴴSq α₂ α₃) .fst
+  spanαᴴ-nat-apex {f₁ = f₁} {f₂} {f₃} {g₁} {g₂} {g₃} α₁ α₂ α₃ =
+    G.pb'.pbExtensionality π₁-eq (G.pb'''.pbExtensionality π₂₁-eq π₂₂-eq)
+    where
+    module F = AssocPBs f₁ f₂ f₃
+    module G = AssocPBs g₁ g₂ g₃
+    -- π₁: both sides → F.pb.pbπ₁ ⋆ (F.pb''.pbπ₁ ⋆ α₁ .fst)
+    π₁-eq =
+      (C.⋆Assoc _ _ _ ∙ C.⟨ refl ⟩⋆⟨ G.pb'.pbβ₁ ⟩
+        ∙ sym (C.⋆Assoc _ _ _) ∙ C.⟨ G.pb.pbβ₁ ⟩⋆⟨ refl ⟩
+        ∙ C.⋆Assoc _ _ _ ∙ C.⟨ refl ⟩⋆⟨ G.pb''.pbβ₁ ⟩)
+      ∙ sym
+        (C.⋆Assoc _ _ _ ∙ C.⟨ refl ⟩⋆⟨ G.pb'.pbβ₁ ⟩
+        ∙ sym (C.⋆Assoc _ _ _) ∙ C.⟨ F.pb'.pbβ₁ ⟩⋆⟨ refl ⟩
+        ∙ C.⋆Assoc _ _ _)
+    -- π₂∘π₁: both sides → F.pb.pbπ₁ ⋆ (F.pb''.pbπ₂ ⋆ α₂ .fst)
+    π₂₁-eq =
+      (C.⟨ C.⋆Assoc _ _ _ ∙ C.⟨ refl ⟩⋆⟨ G.pb'.pbβ₂ ⟩ ⟩⋆⟨ refl ⟩
+        ∙ C.⋆Assoc _ _ _ ∙ C.⟨ refl ⟩⋆⟨ G.pb'''.pbβ₁ ⟩
+        ∙ sym (C.⋆Assoc _ _ _) ∙ C.⟨ G.pb.pbβ₁ ⟩⋆⟨ refl ⟩
+        ∙ C.⋆Assoc _ _ _ ∙ C.⟨ refl ⟩⋆⟨ G.pb''.pbβ₂ ⟩)
+      ∙ sym
+        (C.⟨ C.⋆Assoc _ _ _ ∙ C.⟨ refl ⟩⋆⟨ G.pb'.pbβ₂ ⟩ ⟩⋆⟨ refl ⟩
+        ∙ C.⋆Assoc _ _ _
+        ∙ C.⟨ refl ⟩⋆⟨ C.⋆Assoc _ _ _ ∙ C.⟨ refl ⟩⋆⟨ G.pb'''.pbβ₁ ⟩ ⟩
+        ∙ C.⟨ refl ⟩⋆⟨ sym (C.⋆Assoc _ _ _) ⟩
+        ∙ sym (C.⋆Assoc _ _ _)
+        ∙ C.⟨ sym (C.⋆Assoc _ _ _) ∙ C.⟨ F.pb'.pbβ₂ ⟩⋆⟨ refl ⟩
+            ∙ F.pb'''.pbβ₁ ⟩⋆⟨ refl ⟩
+        ∙ C.⋆Assoc _ _ _)
+    -- π₂∘π₂: both sides → F.pb.pbπ₂ ⋆ α₃ .fst
+    π₂₂-eq =
+      (C.⟨ C.⋆Assoc _ _ _ ∙ C.⟨ refl ⟩⋆⟨ G.pb'.pbβ₂ ⟩ ⟩⋆⟨ refl ⟩
+        ∙ C.⋆Assoc _ _ _ ∙ C.⟨ refl ⟩⋆⟨ G.pb'''.pbβ₂ ⟩
+        ∙ G.pb.pbβ₂)
+      ∙ sym
+        (C.⟨ C.⋆Assoc _ _ _ ∙ C.⟨ refl ⟩⋆⟨ G.pb'.pbβ₂ ⟩ ⟩⋆⟨ refl ⟩
+        ∙ C.⋆Assoc _ _ _
+        ∙ C.⟨ refl ⟩⋆⟨ C.⋆Assoc _ _ _ ∙ C.⟨ refl ⟩⋆⟨ G.pb'''.pbβ₂ ⟩ ⟩
+        ∙ C.⟨ refl ⟩⋆⟨ sym (C.⋆Assoc _ _ _) ⟩
+        ∙ sym (C.⋆Assoc _ _ _)
+        ∙ C.⟨ sym (C.⋆Assoc _ _ _) ∙ C.⟨ F.pb'.pbβ₂ ⟩⋆⟨ refl ⟩
+            ∙ F.pb'''.pbβ₂ ⟩⋆⟨ refl ⟩)

--- a/Cubical/Categories/Double/Instances/Span/Base.agda
+++ b/Cubical/Categories/Double/Instances/Span/Base.agda
@@ -1,0 +1,148 @@
+{-# OPTIONS --lossy-unification #-}
+module Cubical.Categories.Double.Instances.Span.Base where
+
+open import Cubical.Foundations.Prelude
+open import Cubical.Foundations.HLevels
+
+open import Cubical.Data.Sigma
+
+open import Cubical.Categories.Category
+open import Cubical.Categories.Instances.TotalCategory.Base
+open import Cubical.Categories.Functor
+open import Cubical.Categories.Presheaf.Base
+open import Cubical.Categories.Presheaf.More
+open import Cubical.Categories.Instances.Sets
+open import Cubical.Categories.Limits.Pullback.Alt
+open import Cubical.Categories.Presheaf.Morphism.Alt
+open import Cubical.Categories.Presheaf.Constructions.BinProduct
+
+open import Cubical.Categories.Displayed.Base
+open import Cubical.Categories.Displayed.Instances.Graph.Presheaf
+
+open Categoryᴰ
+
+module SpanDefs {ℓC ℓC'}
+  (C : Category ℓC ℓC')
+  (pbs : Pullbacks C)
+  where
+  private
+    module C = Category C
+
+  open PullbackNotation public
+
+  module _ (l r : C.ob) where
+    SpanPsh : Presheaf C _
+    SpanPsh = (C [-, l ]) ×Psh (C [-, r ])
+
+    SpanPshElt : Categoryᴰ C _ _
+    SpanPshElt = Element SpanPsh
+
+    SpanCat : Category _ _
+    SpanCat = ∫C SpanPshElt
+
+    Span : Type _
+    Span = SpanCat .Category.ob
+
+  module _ {x y z w : C.ob}
+    ((xy , f , g) : Span x y) ((zw , u , v) : Span z w)
+    (x→z : C [ x , z ]) (y→w : C [ y , w ]) where
+    SpanSquare : Type _
+    SpanSquare = Σ[ xy→zw ∈ C [ xy , zw ] ]
+      (f C.⋆ x→z ≡ xy→zw C.⋆ u) × (g C.⋆ y→w ≡ xy→zw C.⋆ v)
+
+  module _ {x y z w : C.ob}
+    {s : Span x y} {t : Span z w}
+    {x→z : I → C [ x , z ]} {y→w : I → C [ y , w ]}
+    {sq : SpanSquare s t (x→z i0) (y→w i0)}
+    {sq' : SpanSquare s t (x→z i1) (y→w i1)}
+    where
+    makeSpanSquarePathP :
+      sq .fst ≡ sq' .fst →
+      PathP (λ i → SpanSquare s t (x→z i) (y→w i)) sq sq'
+    makeSpanSquarePathP =
+      ΣPathPProp (λ _ → isProp× (C.isSetHom _ _) (C.isSetHom _ _))
+
+  idSpan : ∀ {x} → Span x x
+  idSpan = _ , C.id , C.id
+
+  abstract
+    seqⱽSq-path : ∀ {o₁ o₂ o₃ o₄ o₅ o₆ : C.ob}
+      {a : C [ o₁ , o₂ ]} {v : C [ o₂ , o₃ ]}
+      {h : C [ o₁ , o₄ ]} {d : C [ o₄ , o₃ ]}
+      {v' : C [ o₃ , o₅ ]} {h' : C [ o₄ , o₆ ]} {c : C [ o₆ , o₅ ]}
+      → a C.⋆ v ≡ h C.⋆ d
+      → d C.⋆ v' ≡ h' C.⋆ c
+      → a C.⋆ (v C.⋆ v') ≡ (h C.⋆ h') C.⋆ c
+    seqⱽSq-path p q =
+      sym (C.⋆Assoc _ _ _) ∙ C.⟨ p ⟩⋆⟨ refl ⟩ ∙ C.⋆Assoc _ _ _
+        ∙ C.⟨ refl ⟩⋆⟨ q ⟩ ∙ sym (C.⋆Assoc _ _ _)
+
+    idⱽSq-path : ∀ {o₁ o₂ : C.ob} {f : C [ o₁ , o₂ ]}
+      → f C.⋆ C.id ≡ C.id C.⋆ f
+    idⱽSq-path = C.⋆IdR _ ∙ sym (C.⋆IdL _)
+
+    seqᴴSq-path : ∀ {o₁ o₂ o₃ o₄ o₅ o₆ : C.ob}
+      {π : C [ o₁ , o₂ ]} {a : C [ o₂ , o₃ ]} {v : C [ o₃ , o₄ ]}
+      {h : C [ o₂ , o₅ ]} {b : C [ o₅ , o₄ ]}
+      {med : C [ o₁ , o₆ ]} {π' : C [ o₆ , o₅ ]}
+      → a C.⋆ v ≡ h C.⋆ b
+      → med C.⋆ π' ≡ π C.⋆ h
+      → (π C.⋆ a) C.⋆ v ≡ med C.⋆ (π' C.⋆ b)
+    seqᴴSq-path p β =
+      C.⋆Assoc _ _ _ ∙ C.⟨ refl ⟩⋆⟨ p ⟩ ∙ sym (C.⋆Assoc _ _ _)
+        ∙ C.⟨ sym β ⟩⋆⟨ refl ⟩ ∙ C.⋆Assoc _ _ _
+
+    seqᴴSq-med-path : ∀ {o₁ o₂ o₃ o₄ o₅ o₆ o₇ : C.ob}
+      {π₁ : C [ o₁ , o₂ ]} {a : C [ o₂ , o₃ ]}
+      {π₂ : C [ o₁ , o₄ ]} {b : C [ o₄ , o₃ ]}
+      {h₁ : C [ o₂ , o₅ ]} {c : C [ o₅ , o₆ ]}
+      {h₂ : C [ o₄ , o₇ ]} {d : C [ o₇ , o₆ ]}
+      {u : C [ o₃ , o₆ ]}
+      → π₁ C.⋆ a ≡ π₂ C.⋆ b
+      → a C.⋆ u ≡ h₁ C.⋆ c
+      → b C.⋆ u ≡ h₂ C.⋆ d
+      → (π₁ C.⋆ h₁) C.⋆ c ≡ (π₂ C.⋆ h₂) C.⋆ d
+    seqᴴSq-med-path comm p q =
+      C.⋆Assoc _ _ _ ∙ C.⟨ refl ⟩⋆⟨ sym p ⟩ ∙ sym (C.⋆Assoc _ _ _)
+        ∙ C.⟨ comm ⟩⋆⟨ refl ⟩ ∙ C.⋆Assoc _ _ _
+        ∙ C.⟨ refl ⟩⋆⟨ q ⟩ ∙ sym (C.⋆Assoc _ _ _)
+
+  idⱽSq : ∀ {x y} {s : Span x y} → SpanSquare s s C.id C.id
+  idⱽSq = C.id , idⱽSq-path , idⱽSq-path
+
+  seqSpan : ∀ {x y z} → Span x y → Span y z → Span x z
+  seqSpan (xy , f , g) (yz , u , v) =
+    pb.vert , (pb.pbπ₁ C.⋆ f) , (pb.pbπ₂ C.⋆ v)
+    where module pb = PullbackNotation (pbs g u)
+
+  seqⱽSq : ∀ {x y z w a b}
+    {s : Span x y} {t : Span z w} {r : Span a b}
+    {v₁ : C [ x , z ]} {u₁ : C [ y , w ]}
+    {v₂ : C [ z , a ]} {u₂ : C [ w , b ]}
+    → SpanSquare s t v₁ u₁ → SpanSquare t r v₂ u₂
+    → SpanSquare s r (v₁ C.⋆ v₂) (u₁ C.⋆ u₂)
+  seqⱽSq sq sq' =
+    sq .fst C.⋆ sq' .fst ,
+    seqⱽSq-path (sq .snd .fst) (sq' .snd .fst) ,
+    seqⱽSq-path (sq .snd .snd) (sq' .snd .snd)
+
+  seqᴴSq : ∀ {x₁ x₂ x₃ y₁ y₂ y₃}
+    {↑f : Span x₁ x₂} {↓f : Span y₁ y₂}
+    {↑f' : Span x₂ x₃} {↓f' : Span y₂ y₃}
+    {v : C [ x₁ , y₁ ]} {u : C [ x₂ , y₂ ]} {w : C [ x₃ , y₃ ]}
+    → SpanSquare ↑f ↓f v u → SpanSquare ↑f' ↓f' u w
+    → SpanSquare (seqSpan ↑f ↑f') (seqSpan ↓f ↓f') v w
+  seqᴴSq {↑f = ↑f} {↓f = ↓f} {↑f' = ↑f'} {↓f' = ↓f'} sq sq' =
+    med ,
+    seqᴴSq-path (sq .snd .fst) pb↓.pbβ₁ ,
+    seqᴴSq-path (sq' .snd .snd) pb↓.pbβ₂
+    where
+    module pb↓ = PullbackNotation (pbs (↓f .snd .snd) (↓f' .snd .fst))
+    module pb↑ = PullbackNotation (pbs (↑f .snd .snd) (↑f' .snd .fst))
+    abstract
+      med-comm : (pb↑.pbπ₁ C.⋆ sq .fst) C.⋆ (↓f .snd .snd)
+        ≡ (pb↑.pbπ₂ C.⋆ sq' .fst) C.⋆ (↓f' .snd .fst)
+      med-comm = seqᴴSq-med-path pb↑.pbCommutes
+        (sq .snd .snd) (sq' .snd .fst)
+    med = pb↓.pbIntro (pb↑.pbπ₁ C.⋆ sq .fst) (pb↑.pbπ₂ C.⋆ sq' .fst)
+      med-comm

--- a/Cubical/Categories/Double/Instances/Span/Interchange.agda
+++ b/Cubical/Categories/Double/Instances/Span/Interchange.agda
@@ -1,0 +1,44 @@
+{-# OPTIONS --lossy-unification #-}
+module Cubical.Categories.Double.Instances.Span.Interchange where
+
+open import Cubical.Foundations.Prelude
+open import Cubical.Foundations.HLevels
+
+open import Cubical.Data.Sigma
+
+open import Cubical.Categories.Category
+open import Cubical.Categories.Limits.Pullback.Alt
+
+open import Cubical.Categories.Double.Instances.Span.Base
+
+module SpanInterchange {ℓC ℓC'}
+  (C : Category ℓC ℓC')
+  (pbs : Pullbacks C)
+  where
+  open SpanDefs C pbs
+  private
+    module C = Category C
+
+  spanInterchange-apex : ∀ {u1 u2 u3 m1 m2 m3 d1 d2 d3}
+    {↑f : Span u1 u2} {↑f' : Span u2 u3}
+    {↓f : Span d1 d2} {↓f' : Span d2 d3}
+    {←f : C [ u1 , m1 ]} {←f' : C [ m1 , d1 ]}
+    {→f : C [ u3 , m3 ]} {→f' : C [ m3 , d3 ]}
+    {←g : Span m1 m2} {↑g : C [ u2 , m2 ]}
+    {→g : Span m2 m3} {↓g : C [ m2 , d2 ]}
+    (ul : SpanSquare ↑f ←g ←f ↑g) (ur : SpanSquare ↑f' →g ↑g →f)
+    (dl : SpanSquare ←g ↓f ←f' ↓g) (dr : SpanSquare →g ↓f' ↓g →f') →
+    seqᴴSq (seqⱽSq ul dl) (seqⱽSq ur dr) .fst
+      ≡ seqⱽSq (seqᴴSq ul ur) (seqᴴSq dl dr) .fst
+  spanInterchange-apex {↑f = ↑f} {↑f' = ↑f'} {↓f = ↓f} {↓f' = ↓f'}
+      {←g = ←g} {→g = →g} ul ur dl dr =
+    pb↓.pbIntro≡
+      (sym (C.⋆Assoc _ _ _ ∙ C.⟨ refl ⟩⋆⟨ pb↓.pbβ₁ ⟩
+        ∙ sym (C.⋆Assoc _ _ _) ∙ C.⟨ pbm.pbβ₁ ⟩⋆⟨ refl ⟩
+        ∙ C.⋆Assoc _ _ _))
+      (sym (C.⋆Assoc _ _ _ ∙ C.⟨ refl ⟩⋆⟨ pb↓.pbβ₂ ⟩
+        ∙ sym (C.⋆Assoc _ _ _) ∙ C.⟨ pbm.pbβ₂ ⟩⋆⟨ refl ⟩
+        ∙ C.⋆Assoc _ _ _))
+    where
+    module pb↓ = PullbackNotation (pbs (↓f .snd .snd) (↓f' .snd .fst))
+    module pbm = PullbackNotation (pbs (←g .snd .snd) (→g .snd .fst))

--- a/Cubical/Categories/Double/Instances/Span/LeftUnitor.agda
+++ b/Cubical/Categories/Double/Instances/Span/LeftUnitor.agda
@@ -1,0 +1,53 @@
+{-# OPTIONS --lossy-unification #-}
+-- Written by Claude
+module Cubical.Categories.Double.Instances.Span.LeftUnitor where
+
+open import Cubical.Foundations.Prelude
+open import Cubical.Foundations.HLevels
+
+open import Cubical.Data.Sigma
+
+open import Cubical.Categories.Category
+open import Cubical.Categories.Limits.Pullback.Alt
+
+open import Cubical.Categories.Double.Instances.Span.Base
+
+module SpanLeftUnitor {ℓC ℓC'}
+  (C : Category ℓC ℓC')
+  (pbs : Pullbacks C)
+  where
+  open SpanDefs C pbs
+  private
+    module C = Category C
+
+  spanλᴴ : ∀ {x y} (s : Span x y) →
+    SpanSquare (seqSpan idSpan s) s C.id C.id
+  spanλᴴ {x = x} (xy , f , g) =
+    pb.pbπ₂ ,
+    C.⋆IdR _ ∙ pb.pbCommutes ,
+    C.⋆IdR _
+    where module pb = PullbackNotation (pbs (C.id {x = x}) f)
+
+  spanλᴴ⁻ : ∀ {x y} (s : Span x y) →
+    SpanSquare s (seqSpan idSpan s) C.id C.id
+  spanλᴴ⁻ {x = x} (xy , f , g) =
+    pb.pbIntro f C.id (C.⋆IdR _ ∙ sym (C.⋆IdL _)) ,
+    C.⟨ sym pb.pbβ₁ ⟩⋆⟨ refl ⟩ ∙ C.⋆Assoc _ _ _ ,
+    C.⋆IdR _ ∙ sym (C.⋆IdL _) ∙ C.⟨ sym pb.pbβ₂ ⟩⋆⟨ refl ⟩ ∙ C.⋆Assoc _ _ _
+    where
+    module pb = PullbackNotation (pbs (C.id {x = x}) f)
+
+  spanλᴴλᴴ⁻-apex : ∀ {x y} (s : Span x y) →
+    spanλᴴ s .fst C.⋆ spanλᴴ⁻ s .fst ≡ C.id
+  spanλᴴλᴴ⁻-apex {x = x} (xy , f , g) =
+    pb.pbExtensionality
+      (C.⋆Assoc _ _ _ ∙ C.⟨ refl ⟩⋆⟨ pb.pbβ₁ ⟩
+        ∙ sym pb.pbCommutes ∙ C.⋆IdR _ ∙ sym (C.⋆IdL _))
+      (C.⋆Assoc _ _ _ ∙ C.⟨ refl ⟩⋆⟨ pb.pbβ₂ ⟩ ∙ C.⋆IdR _ ∙ sym (C.⋆IdL _))
+    where
+    module pb = PullbackNotation (pbs (C.id {x = x}) f)
+
+  spanλᴴ⁻λᴴ-apex : ∀ {x y} (s : Span x y) →
+    spanλᴴ⁻ s .fst C.⋆ spanλᴴ s .fst ≡ C.id
+  spanλᴴ⁻λᴴ-apex {x = x} (xy , f , g) = pb.pbβ₂
+    where module pb = PullbackNotation (pbs (C.id {x = x}) f)

--- a/Cubical/Categories/Double/Instances/Span/Pentagon.agda
+++ b/Cubical/Categories/Double/Instances/Span/Pentagon.agda
@@ -1,0 +1,141 @@
+{-# OPTIONS --lossy-unification #-}
+-- Written by Claude
+module Cubical.Categories.Double.Instances.Span.Pentagon where
+
+open import Cubical.Foundations.Prelude
+open import Cubical.Foundations.HLevels
+
+open import Cubical.Data.Sigma
+
+open import Cubical.Categories.Category
+open import Cubical.Categories.Limits.Pullback.Alt
+
+open import Cubical.Categories.Double.Instances.Span.Base
+open import Cubical.Categories.Double.Instances.Span.Associator
+
+module SpanPentagon {ℓC ℓC'}
+  (C : Category ℓC ℓC')
+  (pbs : Pullbacks C)
+  where
+  open SpanDefs C pbs
+  open SpanAssociator C pbs
+  private
+    module C = Category C
+
+  spanPentagon-apex : ∀ {v w x y z}
+    (f : Span v w) (g : Span w x) (h : Span x y) (k : Span y z) →
+    spanαᴴ (seqSpan f g) h k .fst C.⋆ spanαᴴ f g (seqSpan h k) .fst
+      ≡ seqᴴSq (spanαᴴ f g h) (idⱽSq {s = k}) .fst
+        C.⋆ (spanαᴴ f (seqSpan g h) k .fst
+        C.⋆ seqᴴSq (idⱽSq {s = f}) (spanαᴴ g h k) .fst)
+  spanPentagon-apex f g h k =
+    A2.pb'.pbExtensionality π₁-eq
+      (A2.pb'''.pbExtensionality π₂₁-eq
+        (A1.pb'''.pbExtensionality π₂₂₁-eq π₂₂₂-eq))
+    where
+    module A1 = AssocPBs (seqSpan f g) h k
+    module A2 = AssocPBs f g (seqSpan h k)
+    module A3 = AssocPBs f g h
+    module A4 = AssocPBs f (seqSpan g h) k
+    module A5 = AssocPBs g h k
+
+    π₁-eq =
+      -- LHS → A1.pb.π₁ ⋆ (A1.pb''.π₁ ⋆ A2.pb''.π₁)
+      (C.⋆Assoc _ _ _
+      ∙ C.⟨ refl ⟩⋆⟨ A2.pb'.pbβ₁ ⟩
+      ∙ sym (C.⋆Assoc _ _ _)
+      ∙ C.⟨ A1.pb'.pbβ₁ ⟩⋆⟨ refl ⟩
+      ∙ C.⋆Assoc _ _ _)
+      ∙ sym
+      -- RHS → A1.pb.π₁ ⋆ (A1.pb''.π₁ ⋆ A2.pb''.π₁)
+      (C.⋆Assoc _ _ _
+      ∙ C.⟨ refl ⟩⋆⟨ C.⋆Assoc _ _ _ ⟩
+      ∙ C.⟨ refl ⟩⋆⟨ C.⟨ refl ⟩⋆⟨ A2.pb'.pbβ₁ ⟩ ⟩
+      ∙ C.⟨ refl ⟩⋆⟨ C.⟨ refl ⟩⋆⟨ C.⋆IdR _ ⟩ ⟩
+      ∙ C.⟨ refl ⟩⋆⟨ A4.pb'.pbβ₁ ⟩
+      ∙ sym (C.⋆Assoc _ _ _)
+      ∙ C.⟨ A4.pb.pbβ₁ ⟩⋆⟨ refl ⟩
+      ∙ C.⋆Assoc _ _ _
+      ∙ C.⟨ refl ⟩⋆⟨ A3.pb'.pbβ₁ ⟩)
+
+    π₂₁-eq =
+      -- LHS → A1.pb.π₁ ⋆ (A1.pb''.π₁ ⋆ A2.pb''.π₂)
+      (C.⟨ C.⋆Assoc _ _ _ ∙ C.⟨ refl ⟩⋆⟨ A2.pb'.pbβ₂ ⟩ ⟩⋆⟨ refl ⟩
+      ∙ C.⋆Assoc _ _ _
+      ∙ C.⟨ refl ⟩⋆⟨ A2.pb'''.pbβ₁ ⟩
+      ∙ sym (C.⋆Assoc _ _ _)
+      ∙ C.⟨ A1.pb'.pbβ₁ ⟩⋆⟨ refl ⟩
+      ∙ C.⋆Assoc _ _ _)
+      ∙ sym
+      -- RHS → A1.pb.π₁ ⋆ (A1.pb''.π₁ ⋆ A2.pb''.π₂)
+      (C.⟨ C.⋆Assoc _ _ _
+          ∙ C.⟨ refl ⟩⋆⟨ C.⋆Assoc _ _ _ ⟩
+          ∙ C.⟨ refl ⟩⋆⟨ C.⟨ refl ⟩⋆⟨ A2.pb'.pbβ₂ ⟩ ⟩
+          ∙ C.⟨ refl ⟩⋆⟨ sym (C.⋆Assoc _ _ _) ⟩
+          ∙ C.⟨ refl ⟩⋆⟨ C.⟨ A4.pb'.pbβ₂ ⟩⋆⟨ refl ⟩ ⟩
+        ⟩⋆⟨ refl ⟩
+      ∙ C.⋆Assoc _ _ _
+      ∙ C.⟨ refl ⟩⋆⟨ C.⋆Assoc _ _ _ ⟩
+      ∙ C.⟨ refl ⟩⋆⟨ C.⟨ refl ⟩⋆⟨ A2.pb'''.pbβ₁ ⟩ ⟩
+      ∙ C.⟨ refl ⟩⋆⟨ sym (C.⋆Assoc _ _ _) ⟩
+      ∙ C.⟨ refl ⟩⋆⟨ C.⟨ A4.pb'''.pbβ₁ ⟩⋆⟨ refl ⟩ ⟩
+      ∙ C.⟨ refl ⟩⋆⟨ C.⋆Assoc _ _ _ ⟩
+      ∙ sym (C.⋆Assoc _ _ _)
+      ∙ C.⟨ A4.pb.pbβ₁ ⟩⋆⟨ refl ⟩
+      ∙ C.⋆Assoc _ _ _
+      ∙ C.⟨ refl ⟩⋆⟨ sym (C.⋆Assoc _ _ _) ⟩
+      ∙ C.⟨ refl ⟩⋆⟨ C.⟨ A3.pb'.pbβ₂ ⟩⋆⟨ refl ⟩ ⟩
+      ∙ C.⟨ refl ⟩⋆⟨ A3.pb'''.pbβ₁ ⟩)
+
+    π₂₂₁-eq =
+      -- LHS chain → A1.pb.π₁ ⋆ A1.pb''.π₂
+      (C.⟨ C.⟨ C.⋆Assoc _ _ _ ∙ C.⟨ refl ⟩⋆⟨ A2.pb'.pbβ₂ ⟩ ⟩⋆⟨ refl ⟩
+        ∙ C.⋆Assoc _ _ _ ∙ C.⟨ refl ⟩⋆⟨ A2.pb'''.pbβ₂ ⟩ ⟩⋆⟨ refl ⟩
+      ∙ C.⟨ A1.pb'.pbβ₂ ⟩⋆⟨ refl ⟩
+      ∙ A1.pb'''.pbβ₁)
+      ∙ sym
+      -- RHS chain → A1.pb.π₁ ⋆ A1.pb''.π₂
+      (C.⟨ C.⟨ C.⋆Assoc _ _ _
+          ∙ C.⟨ refl ⟩⋆⟨ C.⋆Assoc _ _ _ ⟩
+          ∙ C.⟨ refl ⟩⋆⟨ C.⟨ refl ⟩⋆⟨ A2.pb'.pbβ₂ ⟩ ⟩
+          ∙ C.⟨ refl ⟩⋆⟨ sym (C.⋆Assoc _ _ _) ⟩
+          ∙ C.⟨ refl ⟩⋆⟨ C.⟨ A4.pb'.pbβ₂ ⟩⋆⟨ refl ⟩ ⟩
+        ⟩⋆⟨ refl ⟩
+        ∙ C.⋆Assoc _ _ _
+        ∙ C.⟨ refl ⟩⋆⟨ C.⋆Assoc _ _ _ ⟩
+        ∙ C.⟨ refl ⟩⋆⟨ C.⟨ refl ⟩⋆⟨ A2.pb'''.pbβ₂ ⟩ ⟩
+      ⟩⋆⟨ refl ⟩
+      ∙ C.⋆Assoc _ _ _
+      ∙ C.⟨ refl ⟩⋆⟨ C.⋆Assoc _ _ _ ⟩
+      ∙ C.⟨ refl ⟩⋆⟨ C.⟨ refl ⟩⋆⟨ A1.pb'''.pbβ₁ ⟩ ⟩
+      ∙ C.⟨ refl ⟩⋆⟨ sym (C.⋆Assoc _ _ _) ⟩
+      ∙ C.⟨ refl ⟩⋆⟨ C.⟨ A4.pb'''.pbβ₁ ⟩⋆⟨ refl ⟩ ⟩
+      ∙ C.⟨ refl ⟩⋆⟨ C.⋆Assoc _ _ _ ⟩
+      ∙ sym (C.⋆Assoc _ _ _)
+      ∙ C.⟨ A4.pb.pbβ₁ ⟩⋆⟨ refl ⟩
+      ∙ C.⋆Assoc _ _ _
+      ∙ C.⟨ refl ⟩⋆⟨ sym (C.⋆Assoc _ _ _) ⟩
+      ∙ C.⟨ refl ⟩⋆⟨ C.⟨ A3.pb'.pbβ₂ ⟩⋆⟨ refl ⟩ ⟩
+      ∙ C.⟨ refl ⟩⋆⟨ A3.pb'''.pbβ₂ ⟩)
+
+    π₂₂₂-eq =
+      (C.⟨ C.⟨ C.⋆Assoc _ _ _ ∙ C.⟨ refl ⟩⋆⟨ A2.pb'.pbβ₂ ⟩ ⟩⋆⟨ refl ⟩
+        ∙ C.⋆Assoc _ _ _ ∙ C.⟨ refl ⟩⋆⟨ A2.pb'''.pbβ₂ ⟩ ⟩⋆⟨ refl ⟩
+      ∙ C.⟨ A1.pb'.pbβ₂ ⟩⋆⟨ refl ⟩
+      ∙ A1.pb'''.pbβ₂)
+      ∙ sym
+      (C.⟨ C.⟨ C.⋆Assoc _ _ _
+          ∙ C.⟨ refl ⟩⋆⟨ C.⋆Assoc _ _ _ ⟩
+          ∙ C.⟨ refl ⟩⋆⟨ C.⟨ refl ⟩⋆⟨ A2.pb'.pbβ₂ ⟩ ⟩
+          ∙ C.⟨ refl ⟩⋆⟨ sym (C.⋆Assoc _ _ _) ⟩
+          ∙ C.⟨ refl ⟩⋆⟨ C.⟨ A4.pb'.pbβ₂ ⟩⋆⟨ refl ⟩ ⟩
+        ⟩⋆⟨ refl ⟩
+        ∙ C.⋆Assoc _ _ _
+        ∙ C.⟨ refl ⟩⋆⟨ C.⋆Assoc _ _ _ ⟩
+        ∙ C.⟨ refl ⟩⋆⟨ C.⟨ refl ⟩⋆⟨ A2.pb'''.pbβ₂ ⟩ ⟩
+      ⟩⋆⟨ refl ⟩
+      ∙ C.⋆Assoc _ _ _
+      ∙ C.⟨ refl ⟩⋆⟨ C.⋆Assoc _ _ _ ⟩
+      ∙ C.⟨ refl ⟩⋆⟨ C.⟨ refl ⟩⋆⟨ A1.pb'''.pbβ₂ ⟩ ⟩
+      ∙ C.⟨ refl ⟩⋆⟨ A4.pb'''.pbβ₂ ⟩
+      ∙ A4.pb.pbβ₂ ∙ C.⋆IdR _)

--- a/Cubical/Categories/Double/Instances/Span/RightUnitor.agda
+++ b/Cubical/Categories/Double/Instances/Span/RightUnitor.agda
@@ -1,0 +1,48 @@
+{-# OPTIONS --lossy-unification #-}
+module Cubical.Categories.Double.Instances.Span.RightUnitor where
+
+open import Cubical.Foundations.Prelude
+open import Cubical.Foundations.HLevels
+
+open import Cubical.Data.Sigma
+
+open import Cubical.Categories.Category
+open import Cubical.Categories.Limits.Pullback.Alt
+
+open import Cubical.Categories.Double.Instances.Span.Base
+
+module SpanRightUnitor {ℓC ℓC'}
+  (C : Category ℓC ℓC')
+  (pbs : Pullbacks C)
+  where
+  open SpanDefs C pbs
+  private
+    module C = Category C
+
+  spanρᴴ : ∀ {x y} (s : Span x y) →
+    SpanSquare (seqSpan s idSpan) s C.id C.id
+  spanρᴴ (xy , f , g) =
+    pb.pbπ₁ , C.⋆IdR _ , C.⋆IdR _ ∙ sym pb.pbCommutes
+    where module pb = PullbackNotation (pbs g C.id)
+
+  spanρᴴ⁻ : ∀ {x y} (s : Span x y) →
+    SpanSquare s (seqSpan s idSpan) C.id C.id
+  spanρᴴ⁻ (xy , f , g) =
+    pb.pbIntro C.id g (C.⋆IdL _ ∙ sym (C.⋆IdR _)) ,
+    C.⋆IdR _ ∙ sym (C.⋆IdL _) ∙ C.⟨ sym pb.pbβ₁ ⟩⋆⟨ refl ⟩ ∙ C.⋆Assoc _ _ _ ,
+    C.⟨ sym pb.pbβ₂ ⟩⋆⟨ refl ⟩ ∙ C.⋆Assoc _ _ _
+    where module pb = PullbackNotation (pbs g C.id)
+
+  spanρᴴρᴴ⁻-apex : ∀ {x y} (s : Span x y) →
+    spanρᴴ s .fst C.⋆ spanρᴴ⁻ s .fst ≡ C.id
+  spanρᴴρᴴ⁻-apex (xy , f , g) =
+    pb.pbExtensionality
+      (C.⋆Assoc _ _ _ ∙ C.⟨ refl ⟩⋆⟨ pb.pbβ₁ ⟩ ∙ C.⋆IdR _ ∙ sym (C.⋆IdL _))
+      (C.⋆Assoc _ _ _ ∙ C.⟨ refl ⟩⋆⟨ pb.pbβ₂ ⟩
+        ∙ pb.pbCommutes ∙ C.⋆IdR _ ∙ sym (C.⋆IdL _))
+    where module pb = PullbackNotation (pbs g C.id)
+
+  spanρᴴ⁻ρᴴ-apex : ∀ {x y} (s : Span x y) →
+    spanρᴴ⁻ s .fst C.⋆ spanρᴴ s .fst ≡ C.id
+  spanρᴴ⁻ρᴴ-apex (xy , f , g) = pb.pbβ₁
+    where module pb = PullbackNotation (pbs g C.id)

--- a/Cubical/Categories/Double/Instances/Span/Triangle.agda
+++ b/Cubical/Categories/Double/Instances/Span/Triangle.agda
@@ -1,0 +1,44 @@
+{-# OPTIONS --lossy-unification #-}
+module Cubical.Categories.Double.Instances.Span.Triangle where
+
+open import Cubical.Foundations.Prelude
+open import Cubical.Foundations.HLevels
+
+open import Cubical.Data.Sigma
+
+open import Cubical.Categories.Category
+open import Cubical.Categories.Limits.Pullback.Alt
+
+open import Cubical.Categories.Double.Instances.Span.Base
+open import Cubical.Categories.Double.Instances.Span.LeftUnitor
+open import Cubical.Categories.Double.Instances.Span.RightUnitor
+open import Cubical.Categories.Double.Instances.Span.Associator
+
+module SpanTriangle {ℓC ℓC'}
+  (C : Category ℓC ℓC')
+  (pbs : Pullbacks C)
+  where
+  open SpanDefs C pbs
+  open SpanLeftUnitor C pbs
+  open SpanRightUnitor C pbs
+  open SpanAssociator C pbs
+  private
+    module C = Category C
+
+  spanTriangle-apex : ∀ {x y z}
+    (f : Span x y) (g : Span y z) →
+    spanαᴴ f idSpan g .fst C.⋆ seqᴴSq (idⱽSq {s = f}) (spanλᴴ g) .fst
+      ≡ seqᴴSq (spanρᴴ f) (idⱽSq {s = g}) .fst
+  spanTriangle-apex f g =
+    pb_fg.pbExtensionality
+      (C.⋆Assoc _ _ _ ∙ C.⟨ refl ⟩⋆⟨ pb_fg.pbβ₁ ⟩
+        ∙ sym (C.⋆Assoc _ _ _) ∙ C.⟨ pb'.pbβ₁ ⟩⋆⟨ refl ⟩
+        ∙ C.⋆IdR _
+        ∙ sym pb_fg.pbβ₁)
+      (C.⋆Assoc _ _ _ ∙ C.⟨ refl ⟩⋆⟨ pb_fg.pbβ₂ ⟩
+        ∙ sym (C.⋆Assoc _ _ _) ∙ C.⟨ pb'.pbβ₂ ⟩⋆⟨ refl ⟩
+        ∙ pb'''.pbβ₂
+        ∙ sym (C.⋆IdR _) ∙ sym pb_fg.pbβ₂)
+    where
+    open AssocPBs f idSpan g
+    module pb_fg = PullbackNotation (pbs (f .snd .snd) (g .snd .fst))


### PR DESCRIPTION
- Defines a double category of categories, functors, and profunctors. Additionally provides an alternative version using the whiskered double categories, and this whiskered version is marginally nicer for concrete instantiation
- Defines a double category of spans for a category with pullbacks