### PR TITLE
Guarded recursion on presheaves/families

### DIFF
--- a/Cubical/Categories/Direct/Base.agda
+++ b/Cubical/Categories/Direct/Base.agda
@@ -1,0 +1,137 @@
+-- Direct categories.
+module Cubical.Categories.Direct.Base where
+
+open import Cubical.Foundations.Prelude
+open import Cubical.Foundations.HLevels
+open import Cubical.Data.Sum
+open import Cubical.Data.Empty as ⊥
+open import Cubical.Relation.Nullary
+import Cubical.Data.Equality as Eq
+
+open import Cubical.Induction.WellFounded
+open import Cubical.Induction.WellFounded.More
+
+open import Cubical.Categories.Category
+open import Cubical.Categories.Functor
+
+private
+  variable
+    ℓC ℓC' ℓD ℓ< : Level
+
+record WFOrder (ℓD ℓ< : Level) : Type (ℓ-suc (ℓ-max ℓD ℓ<)) where
+  field
+    D       : Type ℓD
+    isSetD  : isSet D
+    _<_     : D → D → Type ℓ<
+    isProp< : ∀ a b → isProp (a < b)
+    trans<  : ∀ {a b c} → a < b → b < c → a < c
+    wf<     : WellFounded _<_
+
+  ¬<refl : ∀ {a} → ¬ (a < a)
+  ¬<refl = wf→x≮x wf<
+
+  -- less-than-or-equal-to is less-than or equal-to
+  _≤_ : D → D → Type (ℓ-max ℓD ℓ<)
+  a ≤ b = (a < b) ⊎ (a Eq.≡ b)
+
+  isProp≤ : ∀ {a b} → isProp (a ≤ b)
+  isProp≤ {a} {b} = isProp⊎ (isProp< a b) isPropEq
+    (λ a<b a≡b → ¬<refl (Eq.transport (a <_) (Eq.sym a≡b) a<b))
+    where
+      isPropEq : isProp (a Eq.≡ b)
+      isPropEq = isOfHLevelRetract 1
+        Eq.eqToPath Eq.pathToEq Eq.pathToEq-eqToPath (isSetD a b)
+
+  ≤-refl : ∀ {a} → a ≤ a
+  ≤-refl = inr Eq.refl
+
+  ≤-trans : ∀ {a b c} → a ≤ b → b ≤ c → a ≤ c
+  ≤-trans         (inl a<b) (inl b<c) = inl (trans< a<b b<c)
+  ≤-trans {a = a} (inl a<b) (inr b≡c) = inl (Eq.transport (a <_) b≡c a<b)
+  ≤-trans {c = c} (inr a≡b) (inl b<c) = inl (Eq.transport (_< c) (Eq.sym a≡b) b<c)
+  ≤-trans         (inr a≡b) (inr b≡c) = inr (a≡b Eq.∙ b≡c)
+
+  ≤-<-trans : ∀ {a b c} → a ≤ b → b < c → a < c
+  ≤-<-trans         (inl a<b) b<c = trans< a<b b<c
+  ≤-<-trans {c = c} (inr a≡b) b<c = Eq.transport (λ z → z < c) (Eq.sym a≡b) b<c
+
+  <-≤-trans : ∀ {a b c} → a < b → b ≤ c → a < c
+  <-≤-trans         a<b (inl b<c) = trans< a<b b<c
+  <-≤-trans {a = a} a<b (inr b≡c) = Eq.transport (λ z → a < z) b≡c a<b
+
+-- Pull a whole well-founded order back along a measure `A → D`.
+module _ {ℓA : Level} (Wo : WFOrder ℓD ℓ<)
+         {A : Type ℓA} (isSetA : isSet A) (meas : A → WFOrder.D Wo) where
+  private module Wo = WFOrder Wo
+  pullbackWFOrder : WFOrder ℓA ℓ<
+  pullbackWFOrder = record
+    { D       = A
+    ; isSetD  = isSetA
+    ; _<_     = λ a b → meas a Wo.< meas b
+    ; isProp< = λ a b → Wo.isProp< (meas a) (meas b)
+    ; trans<  = λ {a} {b} {c} → Wo.trans< {meas a} {meas b} {meas c}
+    ; wf<     = wfPullback meas Wo._<_ Wo.wf<
+    }
+
+-- The thin category on the reflexive closure of a well-founded order
+module _ (Wo : WFOrder ℓD ℓ<) where
+  private module Wo = WFOrder Wo
+  open Category
+
+  WFOrder→Cat : Category ℓD (ℓ-max ℓD ℓ<)
+  WFOrder→Cat .ob           = Wo.D
+  WFOrder→Cat .Hom[_,_]     = Wo._≤_
+  WFOrder→Cat .id           = Wo.≤-refl
+  WFOrder→Cat ._⋆_          = Wo.≤-trans
+  WFOrder→Cat .⋆IdL _       = Wo.isProp≤ _ _
+  WFOrder→Cat .⋆IdR _       = Wo.isProp≤ _ _
+  WFOrder→Cat .⋆Assoc _ _ _ = Wo.isProp≤ _ _
+  WFOrder→Cat .isSetHom     = isProp→isSet Wo.isProp≤
+
+module _ (C : Category ℓC ℓC') (Wo : WFOrder ℓD ℓ<) where
+  private
+    module C  = Category C
+    module Wo = WFOrder Wo
+
+  -- A direct structure on a category is a degree functor into a
+  -- well-founded order: morphisms flow in the same order as the
+  -- ordering on objects
+  DirectStr : Type _
+  DirectStr = Functor C (WFOrder→Cat Wo)
+
+  mkDirectStr :
+      (deg : C.ob → Wo.D)
+    → (non-dec : ∀ {x y} → C [ x , y ] → deg x Wo.≤ deg y)
+    → DirectStr
+  mkDirectStr deg non-dec .Functor.F-ob      = deg
+  mkDirectStr deg non-dec .Functor.F-hom     = non-dec
+  mkDirectStr deg non-dec .Functor.F-id      = Wo.isProp≤ _ _
+  mkDirectStr deg non-dec .Functor.F-seq _ _ = Wo.isProp≤ _ _
+
+module DirectNotation
+  {ℓC ℓC' ℓD ℓ< : Level} {C : Category ℓC ℓC'} {Wo : WFOrder ℓD ℓ<}
+  (dir : DirectStr C Wo) where
+  private
+    module C  = Category C
+    module Wo = WFOrder Wo
+
+  deg : C.ob → Wo.D
+  deg = dir .Functor.F-ob
+
+  non-dec : ∀ {x y} → C [ x , y ] → deg x Wo.≤ deg y
+  non-dec = dir .Functor.F-hom
+
+  _≺_ : C.ob → C.ob → Type ℓ<
+  x ≺ y = deg x Wo.< deg y
+
+  isProp≺ : ∀ x y → isProp (x ≺ y)
+  isProp≺ x y = Wo.isProp< _ _
+
+  wf≺ : WellFounded _≺_
+  wf≺ = wfPullback deg Wo._<_ Wo.wf<
+
+  ≺-precomp : ∀ {z y x} → C [ z , y ] → y ≺ x → z ≺ x
+  ≺-precomp f y≺x = Wo.≤-<-trans (non-dec f) y≺x
+
+  ≺-postcomp : ∀ {y x x'} → y ≺ x → C [ x , x' ] → y ≺ x'
+  ≺-postcomp y≺x f = Wo.<-≤-trans y≺x (non-dec f)

--- a/Cubical/Categories/Direct/LocallyContractive.agda
+++ b/Cubical/Categories/Direct/LocallyContractive.agda
@@ -1,0 +1,231 @@
+{-# OPTIONS --lossy-unification #-}
+module Cubical.Categories.Direct.LocallyContractive where
+
+open import Cubical.Foundations.Prelude
+open import Cubical.Foundations.HLevels
+open import Cubical.Foundations.Structure
+
+open import Cubical.Data.Sigma
+open import Cubical.Data.Unit
+
+open import Cubical.Categories.Category
+open import Cubical.Categories.Functor using (Functor ; _∘F_)
+import Cubical.Categories.Presheaf.Family.Base as FamBase
+open import Cubical.Categories.Presheaf.Base
+open import Cubical.Categories.Presheaf.Constructions.Unit
+open import Cubical.Categories.Presheaf.Constructions.BinProduct using (_×Psh_)
+open import Cubical.Categories.Presheaf.StrictHom.Base
+open import Cubical.Categories.Presheaf.StrictHom.CartesianClosed
+open import Cubical.Categories.Direct.Base
+open import Cubical.Categories.Direct.StrictDownset
+open import Cubical.Categories.Displayed.Instances.FunctorAlgebras.Recursive
+
+open Functor
+open PshHomStrict
+
+private
+  variable
+    ℓ ℓ' ℓD : Level
+
+module _ {C : Category ℓ ℓ'} {Wo : WFOrder ℓD ℓ'}
+         (dir : DirectStr C Wo) where
+  open Category C using (ob ; id ; _⋆_ ; ⋆IdL)
+  open DirectNotation dir using (_≺_)
+
+  private
+    ℓ▷ : Level
+    ℓ▷ = ℓ-max ℓ ℓ'
+
+    infixr 5 _⇒_
+    _⇒_ : Presheaf C ℓ▷ → Presheaf C ℓ▷ → Presheaf C ℓ▷
+    X ⇒ Y = X ⇒PshLargeStrict Y
+
+  ▷HomActionPsh : (Presheaf C ℓ▷ → Presheaf C ℓ▷) → Type _
+  ▷HomActionPsh F₀ =
+    {X Y : Presheaf C ℓ▷} → PshHomStrict (▷ dir .F-ob (X ⇒ Y)) (F₀ X ⇒ F₀ Y)
+
+  private
+    nm : {X Y : Presheaf C ℓ▷} (h : PshHomStrict X Y) (y : ob)
+       → ⟨ (X ⇒ Y) .F-ob y ⟩
+    nm h y .N-ob d (f , ξ) = h .N-ob d ξ
+    nm h y .N-hom d' d g (f' , ξ') (f , ξ) e =
+      h .N-hom d' d g ξ' ξ (cong snd e)
+
+  -- the transpose of h as a global element of ▷ (X ⇒ Y)
+  ▷transpose : {X Y : Presheaf C ℓ▷} (h : PshHomStrict X Y)
+        → PshHomStrict UnitPsh (▷ dir .F-ob (X ⇒ Y))
+  ▷transpose h .N-ob x _ =
+    pshhom (λ y _ → nm h y) (λ y' y g p' p e → makePshHomStrictPath refl)
+  ▷transpose h .N-hom x' x f _ _ _ = makePshHomStrictPath refl
+
+  -- F's hom-action factors through next, via Fδ
+  isContractiveHomAction :
+    (F : Functor (PRESHEAF C ℓ▷) (PRESHEAF C ℓ▷))
+    → ▷HomActionPsh (F .F-ob) → Type _
+  isContractiveHomAction F Fδ =
+    {X Y : Presheaf C ℓ▷} (h : PshHomStrict X Y)
+    → F .F-hom h ≡ eltPshHomStrict (▷transpose h ⋆PshHomStrict Fδ {X} {Y})
+
+  LocallyContractive : Type _
+  LocallyContractive =
+    Σ[ F ∈ Functor (PRESHEAF C ℓ▷) (PRESHEAF C ℓ▷) ]
+    Σ[ Fδ ∈ ▷HomActionPsh (F .F-ob) ]
+      isContractiveHomAction F Fδ
+
+  Fam : Category _ _
+  Fam = FamBase.Fam {ℓ = ℓ'} C
+
+  module HyloPsh (F : LocallyContractive)
+                 (X B : Presheaf C ℓ▷)
+                 (c : PshHomStrict X (F .fst .F-ob X))
+                 (a : PshHomStrict (F .fst .F-ob B) B)
+                 where
+    private
+      F₀ = F .fst .F-ob
+      Fδ = F .snd .fst
+      Fhom≡ = F .snd .snd
+
+    hyloBody : PshHomStrict ((▷ dir .F-ob (X ⇒ B)) ×Psh X) B
+    hyloBody =
+      (Fδ {X} {B} ×PshHomStrict c)
+        ⋆PshHomStrict appPshHomStrict (F₀ X) (F₀ B)
+        ⋆PshHomStrict a
+
+    hyloStep : PshHomStrict (▷ dir .F-ob (X ⇒ B)) (X ⇒ B)
+    hyloStep = λPshHomStrict X B hyloBody
+
+    hyloTranspose : PshHomStrict UnitPsh (X ⇒ B)
+    hyloTranspose = löb dir (X ⇒ B) hyloStep
+
+    private
+      hyloMap : PshHomStrict X B
+      hyloMap =
+        ×PshIntroStrict (UnitPsh-introStrict ⋆PshHomStrict hyloTranspose)
+          idPshHomStrict
+          ⋆PshHomStrict appPshHomStrict X B
+
+    hyloTranspose-fix :
+      hyloTranspose ≡ (hyloTranspose ⋆PshHomStrict next dir (X ⇒ B)) ⋆PshHomStrict hyloStep
+    hyloTranspose-fix = löb-fix dir (X ⇒ B) hyloStep
+
+    hyloTranspose-uniq :
+      (s : PshHomStrict UnitPsh (X ⇒ B))
+      → s ≡ (s ⋆PshHomStrict next dir (X ⇒ B)) ⋆PshHomStrict hyloStep
+      → s ≡ hyloTranspose
+    hyloTranspose-uniq = löb-uniq dir (X ⇒ B) hyloStep
+
+    hylo : Hylo (F .fst) (X , c) (B , a)
+    hylo .fst = hyloMap
+    hylo .snd = makePshHomStrictPath (funExt λ x → funExt λ p →
+      cong (λ s → s .N-ob x tt .N-ob x (id , p)) hyloTranspose-fix
+      ∙ cong (λ z → a .N-ob x (Fδ .N-ob x z .N-ob x (id , c .N-ob x p)))
+          (funExt⁻ (▷ dir .F-ob (X ⇒ B) .F-id)
+             (next dir (X ⇒ B) .N-ob x (hyloTranspose .N-ob x tt))
+           ∙ nextT≡▷transpose x)
+      ∙ cong (λ φ → a .N-ob x (φ .N-ob x (c .N-ob x p)))
+          (sym (Fhom≡ hyloMap)))
+      where
+      nextT≡▷transpose : ∀ x →
+        next dir (X ⇒ B) .N-ob x (hyloTranspose .N-ob x tt)
+          ≡ ▷transpose hyloMap .N-ob x tt
+      nextT≡▷transpose x = makePshHomStrictPath (funExt λ y → funExt λ (g , q) →
+        makePshHomStrictPath (funExt λ d → funExt λ (f , ξ) →
+          sym (cong (λ m → hyloTranspose .N-ob x tt .N-ob d (m , ξ))
+                 (⋆IdL (f ⋆ g)))
+          ∙ cong (λ α → α .N-ob d (id , ξ))
+              (hyloTranspose .N-hom d x (f ⋆ g) tt tt refl)))
+
+  _⇒Fam_ : Category.ob Fam → Category.ob Fam → Category.ob Fam
+  (A ⇒Fam B) x = (⟨ A x ⟩ → ⟨ B x ⟩) , isSet→ (B x .snd)
+
+  ▷HomActionFam : Functor Fam Fam → Type _
+  ▷HomActionFam H =
+    {A B : Category.ob Fam}
+    → Fam [ ▷Fam dir {ℓF = ℓ-zero} (A ⇒Fam B)
+          , (H .F-ob A ⇒Fam H .F-ob B) ]
+
+  -- apply a later function-family at a strict bound
+  ▷app : {A B : Category.ob Fam} {x y : ob}
+       → ⟨ ▷Fam dir {ℓF = ℓ-zero} (A ⇒Fam B) x ⟩
+       → C [ y , x ] → y ≺ x → ⟨ A y ⟩ → ⟨ B y ⟩
+  ▷app β g q = β .N-ob _ (g , q) _ id
+
+  -- ▷ preserves the pointwise product laxly
+  ▷× : {P Q : Presheaf C ℓ▷}
+     → PshHomStrict (▷ dir .F-ob P ×Psh ▷ dir .F-ob Q)
+                    (▷ dir .F-ob (P ×Psh Q))
+  ▷× .N-ob x (α , β) = ×PshIntroStrict α β
+  ▷× .N-hom x x' f (α' , β') (α , β) e =
+    makePshHomStrictPath refl
+    ∙ (λ i → ×PshIntroStrict (cong fst e i) (cong snd e i))
+
+  -- H's hom-action factors through nextFam, via Hδ
+  isContractiveHomActionFam :
+    (H : Functor Fam Fam) → ▷HomActionFam H → Type _
+  isContractiveHomActionFam H Hδ =
+    {A B : Category.ob Fam} (h : Fam [ A , B ]) (x : ob)
+    → H .F-hom h x
+      ≡ Hδ {A} {B} x (nextFam dir {ℓF = ℓ-zero} (A ⇒Fam B) h x)
+
+  LocallyContractiveFam : Type _
+  LocallyContractiveFam =
+    Σ[ H ∈ Functor Fam Fam ]
+    Σ[ Hδ ∈ ▷HomActionFam H ]
+      isContractiveHomActionFam H Hδ
+
+  module HyloFam (H : LocallyContractiveFam)
+                 (X B : Category.ob Fam)
+                 (c : Fam [ X , H .fst .F-ob X ])
+                 (a : Fam [ H .fst .F-ob B , B ])
+                 where
+    private
+      Hδ = H .snd .fst
+      Hhom≡ = H .snd .snd
+
+      hyloStep : ∀ x → ⟨ ▷Fam dir {ℓF = ℓ-zero} (X ⇒Fam B) x ⟩
+               → ⟨ (X ⇒Fam B) x ⟩
+      hyloStep x β ξ = a x (Hδ {X} {B} x β (c x ξ))
+
+    private
+      hyloMap : Fam [ X , B ]
+      hyloMap = löbFam dir {ℓF = ℓ-zero} (X ⇒Fam B) hyloStep
+
+    hylo : Hylo (H .fst) (X , c) (B , a)
+    hylo .fst = hyloMap
+    hylo .snd = funExt λ x →
+      löbFam-unfold dir {ℓF = ℓ-zero} (X ⇒Fam B) hyloStep x
+      ∙ cong (λ k → λ ξ → a x (k (c x ξ)))
+          (sym (Hhom≡ {X} {B} hyloMap x))
+
+    hylo-uniq : (h : Hylo (H .fst) (X , c) (B , a)) → h ≡ hylo
+    hylo-uniq (h , he) = ΣPathP (mapEq , path2)
+      where
+        mapEq : h ≡ hyloMap
+        mapEq =
+          löbFam-uniq-unfold dir {ℓF = ℓ-zero} (X ⇒Fam B) hyloStep h
+            λ x → funExt⁻ he x
+                  ∙ (λ i ξ → a x (Hhom≡ {X} {B} h x i (c x ξ)))
+
+        path2 : PathP
+          (λ i → mapEq i
+                 ≡ (λ x ξ → a x (H .fst .F-hom (mapEq i) x (c x ξ))))
+          he (hylo .snd)
+        path2 = isProp→PathP
+          (λ i → isSetΠ (λ x → isSet→ (B x .snd))
+                   (mapEq i)
+                   (λ x ξ → a x (H .fst .F-hom (mapEq i) x (c x ξ))))
+          he (hylo .snd)
+
+  -- local contractivity makes the hylomorphism profunctor trivial;
+  -- recursiveness and corecursiveness are its curried readings, and
+  -- finality/initiality at a fixed point follow from FixpointRecursion
+  module Recursiveness (H : LocallyContractiveFam) where
+    hyloTrivial : HYLOTrivial (H .fst)
+    hyloTrivial (X , c) (B , a) = HF.hylo , λ h → sym (HF.hylo-uniq h)
+      where module HF = HyloFam H X B c a
+
+    recursive : ∀ Xc → isRecursiveCoalgebra (H .fst) Xc
+    recursive = HYLOTrivial→recursive (H .fst) hyloTrivial
+
+    corecursive : ∀ Ba → isCorecursiveAlgebra (H .fst) Ba
+    corecursive = HYLOTrivial→corecursive (H .fst) hyloTrivial

--- a/Cubical/Categories/Direct/Predecessor.agda
+++ b/Cubical/Categories/Direct/Predecessor.agda
@@ -1,0 +1,165 @@
+{-# OPTIONS --lossy-unification #-}
+-- Predecessor presentation of ▷: when the strict downset ↡x is
+-- represented by a predecessor p, ▷Psh P at x is P at p; at a minimal
+-- object ▷Psh P is trivial.
+module Cubical.Categories.Direct.Predecessor where
+
+open import Cubical.Foundations.Prelude
+open import Cubical.Foundations.Equiv
+open import Cubical.Foundations.HLevels
+open import Cubical.Foundations.Isomorphism
+open import Cubical.Foundations.Structure
+open import Cubical.Data.Sigma
+open import Cubical.Data.Unit using (Unit* ; tt*)
+open import Cubical.Data.Empty as ⊥ using ()
+open import Cubical.Relation.Nullary using (¬_)
+
+open import Cubical.Categories.Category
+open import Cubical.Categories.Functor
+open import Cubical.Categories.Presheaf.Base
+open import Cubical.Categories.Presheaf.More
+open import Cubical.Categories.Presheaf.StrictHom.Base
+open import Cubical.Categories.Direct.Base
+open import Cubical.Categories.Direct.StrictDownset
+  using ( ↡Psh ; ▷Psh ; next
+        ; ▷Fam ; nextFam ; löbFam ; löbFam-unfold ; löbFam-uniq-unfold )
+import Cubical.Categories.Presheaf.Family.Base as FamBase
+
+private
+  variable
+    ℓ ℓ' ℓD ℓP : Level
+
+module _ {C : Category ℓ ℓ'} {Wo : WFOrder ℓD ℓ'}
+         (dir : DirectStr C Wo) where
+  open Category C
+  open Functor
+  open PshHomStrict
+  open DirectNotation dir
+
+  -- p is a predecessor of x when it represents the strict downset ↡x
+  record isPredOf (x p : ob) : Type (ℓ-max ℓ ℓ') where
+    field
+      ρ   : C [ p , x ]
+      p≺x : p ≺ x
+
+    ↡fun : ∀ y → C [ y , p ] → ⟨ ↡Psh dir x .F-ob y ⟩
+    ↡fun y f = (f ⋆ ρ) , ≺-precomp f p≺x
+
+    field
+      univ : ∀ y → isEquiv (↡fun y)
+
+    ↡eq : ∀ y → C [ y , p ] ≃ ⟨ ↡Psh dir x .F-ob y ⟩
+    ↡eq y = ↡fun y , univ y
+
+  module _ {ℓP} (P : Presheaf C ℓP) where
+    private
+      module P = PresheafNotation P
+
+    -- ▷ at a minimal object is trivial
+    module _ {x : ob} (min : ∀ y → ¬ (y ≺ x)) where
+      ▷min : isContr ⟨ ▷Psh dir P .F-ob x ⟩
+      ▷min .fst = pshhom
+        (λ y (g , q) → ⊥.rec (min y q))
+        (λ y' y h (g , q) w hyp → ⊥.rec (min y q))
+      ▷min .snd α = makePshHomStrictPath
+        (funExt λ y → funExt λ (g , q) → ⊥.rec (min y q))
+
+    -- ▷ at x computes as P at the predecessor
+    module _ {x p : ob} (pred : isPredOf x p) where
+      open isPredOf pred
+
+      ▷pred : Iso ⟨ ▷Psh dir P .F-ob x ⟩ ⟨ P .F-ob p ⟩
+      ▷pred .Iso.fun α = α .N-ob p (ρ , p≺x)
+      ▷pred .Iso.inv v = pshhom
+        (λ y w → invEq (↡eq y) w P.⋆ v)
+        (λ y' y h w' w hyp →
+          sym (P.⋆Assoc h (invEq (↡eq y) w') v)
+          ∙ cong (P._⋆ v)
+              (sym (retEq (↡eq y') (h ⋆ invEq (↡eq y) w'))
+               ∙ cong (invEq (↡eq y'))
+                   (Σ≡Prop (λ _ → isProp≺ _ _)
+                      (⋆Assoc h (invEq (↡eq y) w') ρ
+                       ∙ cong (h ⋆_) (cong fst (secEq (↡eq y) w')))
+                    ∙ hyp)))
+      ▷pred .Iso.sec v =
+        cong (P._⋆ v)
+          (cong (invEq (↡eq p)) (Σ≡Prop (λ _ → isProp≺ _ _) (sym (⋆IdL ρ)))
+           ∙ retEq (↡eq p) id)
+        ∙ P.⋆IdL v
+      ▷pred .Iso.ret α = makePshHomStrictPath (funExt λ y → funExt λ w →
+        α .N-hom y p (invEq (↡eq y) w) (ρ , p≺x) _ refl
+        ∙ cong (α .N-ob y) (secEq (↡eq y) w))
+
+      -- under ▷pred, next is restriction along ρ
+      ▷pred-next : (u : ⟨ P .F-ob x ⟩)
+        → ▷pred .Iso.fun (next dir P .N-ob x u) ≡ ρ P.⋆ u
+      ▷pred-next u = refl
+
+  -- the family ▷ in predecessor form
+  module _ {ℓF} (A : ob → hSet (ℓ-max ℓF (ℓ-max ℓ ℓ'))) where
+    private
+      GA = FamBase.Cofree {ℓ = ℓF} C .F-ob A
+
+    ▷FamPred : {x p : ob} → isPredOf x p
+      → Iso ⟨ ▷Fam dir {ℓF = ℓF} A x ⟩ ((z : ob) → C [ z , p ] → ⟨ A z ⟩)
+    ▷FamPred = ▷pred GA
+
+    ▷FamMin : {x : ob} → (∀ y → ¬ (y ≺ x))
+      → isContr ⟨ ▷Fam dir {ℓF = ℓF} A x ⟩
+    ▷FamMin = ▷min GA
+
+    -- under ▷FamPred, nextFam is the constant closure, so
+    -- löbFam-unfold computes in predecessor form
+    ▷FamPred-next : {x p : ob} (pr : isPredOf x p) (t : ∀ z → ⟨ A z ⟩)
+      → ▷FamPred pr .Iso.fun (nextFam dir {ℓF = ℓF} A t x)
+        ≡ (λ z _ → t z)
+    ▷FamPred-next pr t = refl
+
+  -- every object is minimal or has a predecessor
+  data ▷View (x : ob) : Type (ℓ-max ℓ ℓ') where
+    minimal : (∀ y → ¬ (y ≺ x)) → ▷View x
+    hasPred : (p : ob) → isPredOf x p → ▷View x
+
+  Predecessors : Type (ℓ-max ℓ ℓ')
+  Predecessors = ∀ x → ▷View x
+
+  -- Löb induction through the predecessor presentation of ▷Fam
+  module _ (pv : Predecessors) {ℓF}
+           (A : ob → hSet (ℓ-max ℓF (ℓ-max ℓ ℓ'))) where
+
+    LaterPredAt : {x : ob} → ▷View x → Type (ℓ-max ℓF (ℓ-max ℓ ℓ'))
+    LaterPredAt (minimal _)   = Unit*
+    LaterPredAt (hasPred p _) = (z : ob) → C [ z , p ] → ⟨ A z ⟩
+
+    LaterPred : ob → Type (ℓ-max ℓF (ℓ-max ℓ ℓ'))
+    LaterPred x = LaterPredAt (pv x)
+
+    LaterPredIsoAt : {x : ob} (v : ▷View x)
+      → Iso ⟨ ▷Fam dir {ℓF = ℓF} A x ⟩ (LaterPredAt v)
+    LaterPredIsoAt (minimal m) .Iso.fun _ = tt*
+    LaterPredIsoAt (minimal m) .Iso.inv _ = ▷FamMin A m .fst
+    LaterPredIsoAt (minimal m) .Iso.sec _ = refl
+    LaterPredIsoAt (minimal m) .Iso.ret β = ▷FamMin A m .snd β
+    LaterPredIsoAt (hasPred p pr) = ▷FamPred A pr
+
+    LaterPredIso : ∀ x → Iso ⟨ ▷Fam dir {ℓF = ℓF} A x ⟩ (LaterPred x)
+    LaterPredIso x = LaterPredIsoAt (pv x)
+
+    module LöbPred (φ : ∀ x → LaterPred x → ⟨ A x ⟩) where
+      private
+        φ▷ : ∀ x → ⟨ ▷Fam dir {ℓF = ℓF} A x ⟩ → ⟨ A x ⟩
+        φ▷ x β = φ x (LaterPredIso x .Iso.fun β)
+
+      nextPred : (∀ z → ⟨ A z ⟩) → ∀ x → LaterPred x
+      nextPred t x = LaterPredIso x .Iso.fun (nextFam dir {ℓF = ℓF} A t x)
+
+      fix : ∀ x → ⟨ A x ⟩
+      fix = löbFam dir {ℓF = ℓF} A φ▷
+
+      unfold : ∀ x → fix x ≡ φ x (nextPred fix x)
+      unfold = löbFam-unfold dir {ℓF = ℓF} A φ▷
+
+      uniq : (t : ∀ x → ⟨ A x ⟩)
+        → (∀ x → t x ≡ φ x (nextPred t x))
+        → t ≡ fix
+      uniq = löbFam-uniq-unfold dir {ℓF = ℓF} A φ▷

--- a/Cubical/Categories/Direct/Product.agda
+++ b/Cubical/Categories/Direct/Product.agda
@@ -1,0 +1,178 @@
+-- The product of two direct categories is direct.
+module Cubical.Categories.Direct.Product where
+
+open import Cubical.Foundations.Prelude
+open import Cubical.Foundations.HLevels
+open import Cubical.Data.Sigma
+open import Cubical.Data.Sum
+open import Cubical.Data.Empty as ⊥
+open import Cubical.Relation.Nullary using (¬_ ; isProp¬)
+import Cubical.Data.Equality as Eq
+
+open import Cubical.Induction.WellFounded
+
+open import Cubical.Categories.Category
+open import Cubical.Categories.Instances.BinProduct
+open import Cubical.Categories.Direct.Base
+
+private
+  variable
+    ℓc ℓc' ℓe ℓe' ℓD ℓD' ℓ< ℓ<' : Level
+
+  ≤-antisym : (W : WFOrder ℓD ℓ<) {a b : WFOrder.D W}
+            → WFOrder._≤_ W a b → WFOrder._≤_ W b a → a Eq.≡ b
+  ≤-antisym W (inr a≡b) _         = a≡b
+  ≤-antisym W (inl a<b) (inr b≡a) = Eq.sym b≡a
+  ≤-antisym W (inl a<b) (inl b<a) =
+    ⊥.rec (WFOrder.¬<refl W (WFOrder.trans< W a<b b<a))
+
+-- The lexicographic and product well-founded orders
+module _ (Wo : WFOrder ℓD ℓ<) (Wo' : WFOrder ℓD' ℓ<') where
+  private
+    module W  = WFOrder Wo
+    module W' = WFOrder Wo'
+
+    isPropEq : ∀ {a a' : W.D} → isProp (a Eq.≡ a')
+    isPropEq {a} {a'} = isOfHLevelRetract 1
+      Eq.eqToPath Eq.pathToEq Eq.pathToEq-eqToPath (W.isSetD a a')
+
+  -- Lexicographic order
+  _<Lex_ : (W.D × W'.D) → (W.D × W'.D) → Type (ℓ-max ℓ< (ℓ-max ℓD ℓ<'))
+  (a , b) <Lex (a' , b') = (a W.< a') ⊎ ((a Eq.≡ a') × (b W'.< b'))
+
+  private
+    isProp<Lex : ∀ p q → isProp (p <Lex q)
+    isProp<Lex (a , b) (a' , b') =
+      isProp⊎ (W.isProp< a a') (isProp× isPropEq (W'.isProp< b b')) disjoint
+      where
+        disjoint : (a W.< a') → ((a Eq.≡ a') × (b W'.< b')) → ⊥
+        disjoint a<a' (a≡a' , _) = W.¬<refl (Eq.transport (a W.<_) (Eq.sym a≡a') a<a')
+
+    trans<Lex : ∀ {p q r} → p <Lex q → q <Lex r → p <Lex r
+    trans<Lex (inl a<a')          (inl a'<a'')          = inl (W.trans< a<a' a'<a'')
+    trans<Lex {p = a , _} (inl a<a') (inr (a'≡a'' , _)) =
+      inl (Eq.transport (a W.<_) a'≡a'' a<a')
+    trans<Lex {r = a'' , _} (inr (a≡a' , _)) (inl a'<a'') =
+      inl (Eq.transport (W._< a'') (Eq.sym a≡a') a'<a'')
+    trans<Lex (inr (a≡a' , b<b')) (inr (a'≡a'' , b'<b'')) =
+      inr (a≡a' Eq.∙ a'≡a'' , W'.trans< b<b' b'<b'')
+
+    wf<Lex : WellFounded _<Lex_
+    wf<Lex (a , b) = go a (W.wf< a) b (W'.wf< b)
+      where
+        go : ∀ a → Acc W._<_ a → ∀ b → Acc W'._<_ b → Acc _<Lex_ (a , b)
+        go a aA@(acc rsA) b (acc rsB) = acc λ where
+          (a' , b') (inl a'<a)             → go a' (rsA a' a'<a) b' (W'.wf< b')
+          (a' , b') (inr (Eq.refl , b'<b)) → go a  aA            b' (rsB b' b'<b)
+
+  LexWFOrder : WFOrder (ℓ-max ℓD ℓD') (ℓ-max ℓ< (ℓ-max ℓD ℓ<'))
+  LexWFOrder = record
+    { D       = W.D × W'.D
+    ; isSetD  = isSet× W.isSetD W'.isSetD
+    ; _<_     = _<Lex_
+    ; isProp< = isProp<Lex
+    ; trans<  = trans<Lex
+    ; wf<     = wf<Lex
+    }
+
+  -- Product order
+  _<Prod_ : (W.D × W'.D) → (W.D × W'.D)
+       → Type (ℓ-max (ℓ-max ℓD ℓD') (ℓ-max ℓ< ℓ<'))
+  (a , b) <Prod (a' , b') =
+    (a W.≤ a') × (b W'.≤ b') × (¬ ((a Eq.≡ a') × (b Eq.≡ b')))
+
+  private
+    isProp<Prod : ∀ p q → isProp (p <Prod q)
+    isProp<Prod (a , b) (a' , b') =
+      isProp× W.isProp≤ (isProp× W'.isProp≤ (isProp¬ _))
+
+    trans<Prod : ∀ {p q r} → p <Prod q → q <Prod r → p <Prod r
+    trans<Prod {a , b} {a' , b'} {a'' , b''}
+            (a≤a' , b≤b' , ne) (a'≤a'' , b'≤b'' , _) =
+      W.≤-trans a≤a' a'≤a'' , W'.≤-trans b≤b' b'≤b'' , ne''
+      where
+        -- If `(a,b) = (a'',b'')` then, sandwiched by the ≤'s, also
+        -- `(a,b) = (a',b')`, contradicting the first strictness witness.
+        ne'' : ¬ ((a Eq.≡ a'') × (b Eq.≡ b''))
+        ne'' (a≡a'' , b≡b'') = ne
+          ( ≤-antisym Wo  a≤a' (Eq.transport (a' W.≤_)  (Eq.sym a≡a'') a'≤a'')
+          , ≤-antisym Wo' b≤b' (Eq.transport (b' W'.≤_) (Eq.sym b≡b'') b'≤b'') )
+
+    -- `_<Prod_ ⊆ _<Lex_`, so accessibility for lex transfers to product order.
+    <Prod→<Lex : ∀ {p q} → p <Prod q → p <Lex q
+    <Prod→<Lex (inl a<a' , _        , _)  = inl a<a'
+    <Prod→<Lex (inr a≡a' , inl b<b' , _)  = inr (a≡a' , b<b')
+    <Prod→<Lex (inr a≡a' , inr b≡b' , ne) = ⊥.rec (ne (a≡a' , b≡b'))
+
+    wf<Prod : WellFounded _<Prod_
+    wf<Prod p = go p (wf<Lex p)
+      where
+        go : ∀ p → Acc _<Lex_ p → Acc _<Prod_ p
+        go p (acc r) = acc λ q q<p → go q (r q (<Prod→<Lex q<p))
+
+  ProdWFOrder : WFOrder (ℓ-max ℓD ℓD') (ℓ-max (ℓ-max ℓD ℓD') (ℓ-max ℓ< ℓ<'))
+  ProdWFOrder = record
+    { D       = W.D × W'.D
+    ; isSetD  = isSet× W.isSetD W'.isSetD
+    ; _<_     = _<Prod_
+    ; isProp< = isProp<Prod
+    ; trans<  = trans<Prod
+    ; wf<     = wf<Prod
+    }
+
+-- The product of two direct categories, over either order.
+module _ {C : Category ℓc ℓc'} {D : Category ℓe ℓe'}
+         {Wo : WFOrder ℓD ℓ<} {Wo' : WFOrder ℓD' ℓ<'} where
+  private
+    module W  = WFOrder Wo
+    module W' = WFOrder Wo'
+
+  -- Directness over the lexicographic order
+  LexDirect : DirectStr C Wo → DirectStr D Wo'
+              → DirectStr (C ×C D) (LexWFOrder Wo Wo')
+  LexDirect dirC dirD =
+    mkDirectStr (C ×C D) (LexWFOrder Wo Wo') deg× non-dec×
+    where
+      open DirectNotation dirC using () renaming (deg to degC ; non-dec to non-decC)
+      open DirectNotation dirD using () renaming (deg to degD ; non-dec to non-decD)
+
+      deg× : Category.ob (C ×C D) → W.D × W'.D
+      deg× (c , d) = degC c , degD d
+
+      -- component-wise `≤` (from the two non-decreasing degrees) is a lex `≤`.
+      lex≤ : ∀ {a a' b b'} → a W.≤ a' → b W'.≤ b'
+           → WFOrder._≤_ (LexWFOrder Wo Wo') (a , b) (a' , b')
+      lex≤ (inl a<a')     _              = inl (inl a<a')
+      lex≤ (inr Eq.refl) (inl b<b')      = inl (inr (Eq.refl , b<b'))
+      lex≤ (inr Eq.refl) (inr Eq.refl)   = inr Eq.refl
+
+      non-dec× : ∀ {x y} → (C ×C D) [ x , y ]
+               → WFOrder._≤_ (LexWFOrder Wo Wo') (deg× x) (deg× y)
+      non-dec× (f , g) = lex≤ (non-decC f) (non-decD g)
+
+  -- Directness over the product order.
+  ProdDirect : DirectStr C Wo → DirectStr D Wo'
+               → DirectStr (C ×C D) (ProdWFOrder Wo Wo')
+  ProdDirect dirC dirD =
+    mkDirectStr (C ×C D) (ProdWFOrder Wo Wo') deg× non-dec×
+    where
+      open DirectNotation dirC using () renaming (deg to degC ; non-dec to non-decC)
+      open DirectNotation dirD using () renaming (deg to degD ; non-dec to non-decD)
+
+      deg× : Category.ob (C ×C D) → W.D × W'.D
+      deg× (c , d) = degC c , degD d
+
+      -- component-wise `≤` IS the product `≤` (equal pairs go to `inr`).
+      prod≤ : ∀ {a a' b b'} → a W.≤ a' → b W'.≤ b'
+            → WFOrder._≤_ (ProdWFOrder Wo Wo') (a , b) (a' , b')
+      prod≤ {a} (inl a<a') b≤b' =
+        inl (inl a<a' , b≤b'
+            , λ (a≡a' , _) → W.¬<refl (Eq.transport (a W.<_) (Eq.sym a≡a') a<a'))
+      prod≤ {b = b} (inr a≡a') (inl b<b') =
+        inl (inr a≡a' , inl b<b'
+            , λ (_ , b≡b') → W'.¬<refl (Eq.transport (b W'.<_) (Eq.sym b≡b') b<b'))
+      prod≤ (inr Eq.refl) (inr Eq.refl) = inr Eq.refl
+
+      non-dec× : ∀ {x y} → (C ×C D) [ x , y ]
+               → WFOrder._≤_ (ProdWFOrder Wo Wo') (deg× x) (deg× y)
+      non-dec× (f , g) = prod≤ (non-decC f) (non-decD g)

--- a/Cubical/Categories/Direct/StrictDownset.agda
+++ b/Cubical/Categories/Direct/StrictDownset.agda
@@ -1,0 +1,260 @@
+-- The strict-downset sieve ↡c of a direct category.
+module Cubical.Categories.Direct.StrictDownset where
+
+open import Cubical.Foundations.Prelude
+open import Cubical.Foundations.HLevels
+open import Cubical.Foundations.Structure
+open import Cubical.Data.Sigma
+open import Cubical.Data.Sum
+import Cubical.Data.Sum as Sum
+open import Cubical.Data.Empty as ⊥
+open import Cubical.Data.Unit
+
+open import Cubical.Induction.WellFounded
+
+open import Cubical.Categories.Category
+open import Cubical.Categories.Functor
+open import Cubical.Categories.Morphism
+open import Cubical.Categories.Presheaf.Base
+open import Cubical.Categories.Presheaf.StrictHom.Base
+open import Cubical.Categories.Presheaf.Constructions.Unit
+open import Cubical.Categories.Yoneda
+open import Cubical.Categories.Subobject.Base
+open import Cubical.Categories.Presheaf.Sieve
+open import Cubical.Categories.Direct.Base
+import Cubical.Categories.Presheaf.Family.Base as FamBase
+import Cubical.Categories.Adjoint as Adjoint
+import Cubical.Categories.NaturalTransformation as NT
+import Cubical.Data.Equality as Eq
+
+private
+  variable
+    ℓ ℓ' ℓD : Level
+
+module _ {C : Category ℓ ℓ'} {Wo : WFOrder ℓD ℓ'} (dir : DirectStr C Wo) where
+  open Category C
+  open Functor
+  open PshHomStrict
+  open DirectNotation dir
+
+  -- the strict-downset sub-presheaf of よc
+  ↡Psh : (c : ob) → Presheaf C ℓ'
+  ↡Psh c .F-ob y =
+    (Σ[ f ∈ C [ y , c ] ] (y ≺ c))
+    , isSetΣ isSetHom (λ _ → isProp→isSet (isProp≺ y c))
+  ↡Psh c .F-hom g (f , p) = (g ⋆ f) , ≺-precomp g p
+  ↡Psh c .F-id     = funExt λ (f , p) → Σ≡Prop (λ _ → isProp≺ _ _) (⋆IdL f)
+  ↡Psh c .F-seq g h = funExt λ (f , p) → Σ≡Prop (λ _ → isProp≺ _ _) (⋆Assoc h g f)
+
+  ↡incl : (c : ob) → PshHomStrict (↡Psh c) (yo c)
+  ↡incl c .N-ob y (f , p) = f
+  ↡incl c .N-hom y' y g (f' , p') (f , p) e = cong fst e
+
+  ↡monic : (c : ob) → isMonic (PRESHEAF C ℓ') (↡incl c)
+  ↡monic c {a = g} {a' = g'} eq =
+    makePshHomStrictPath (funExt λ y → funExt λ t →
+      Σ≡Prop (λ _ → isProp≺ _ _) (λ i → (eq i) .N-ob y t))
+
+  -- the strict downset, as a sieve on c
+  ↡ : (c : ob) → Sieve C c
+  ↡ c = ↡Psh c , ↡incl c , ↡monic c
+
+  ↡F : Functor C (PRESHEAF C ℓ')
+  ↡F .F-ob = ↡Psh
+  ↡F .F-hom a .N-ob y (f , p) = (f ⋆ a) , ≺-postcomp p a
+  ↡F .F-hom a .N-hom y' y g (f' , p') (f , p) e =
+    Σ≡Prop (λ _ → isProp≺ _ _) (sym (⋆Assoc g f' a) ∙ cong (_⋆ a) (cong fst e))
+  ↡F .F-id =
+    makePshHomStrictPath (funExt λ y → funExt λ (f , p) →
+      Σ≡Prop (λ _ → isProp≺ _ _) (⋆IdR f))
+  ↡F .F-seq a b =
+    makePshHomStrictPath (funExt λ y → funExt λ (f , p) →
+      Σ≡Prop (λ _ → isProp≺ _ _) (sym (⋆Assoc f a b)))
+
+  private module Wo = WFOrder Wo
+
+  -- ↡c contains exactly the strict maps into c
+  ↡∋→≺ : ∀ {c y} (f : C [ y , c ]) → (↡ c) ∋ f → y ≺ c
+  ↡∋→≺ f ((_ , p) , _) = p
+
+  ≺→↡∋ : ∀ {c y} (f : C [ y , c ]) → y ≺ c → (↡ c) ∋ f
+  ≺→↡∋ f p = (f , p) , refl
+
+  -- ↡c omits the identity so its a proper sieve
+  ↡-proper : ∀ {c} → isProperSieve (↡ c)
+  ↡-proper {c} idIn = Wo.¬<refl (↡∋→≺ id idIn)
+
+  -- A direct structure is reflecting when equal-degree maps are split epis.
+  -- In such a category non-identities
+  -- strictly raise degree, so ↡ is the maximal proper sieve
+  Reflecting : Type (ℓ-max (ℓ-max ℓ ℓ') ℓD)
+  Reflecting = ∀ {x y} (f : C [ x , y ])
+    → deg x ≡ deg y → Σ[ s ∈ C [ y , x ] ] (s ⋆ f ≡ id)
+
+  -- every proper sieve refines into ↡c
+  ↡-maximal : Reflecting → ∀ {c} (S : Sieve C c) → isProperSieve S → S ⊆ ↡ c
+  ↡-maximal refl-dir {c} S proper f Sf =
+    Sum.elim {C = λ _ → (↡ c) ∋ f}
+      (λ y≺c → ≺→↡∋ f y≺c)
+      (λ y≡c → let sec = refl-dir f (Eq.eqToPath y≡c)
+               in ⊥.rec (proper (subst (S ∋_) (sec .snd)
+                                        (sieve-precomp S (sec .fst) Sf))))
+      (non-dec f)
+
+  module _ {ℓP} (P : Presheaf C ℓP) where
+    ▷Psh : Presheaf C (ℓ-max (ℓ-max (ℓ-max ℓ ℓ') ℓ') ℓP)
+    ▷Psh .F-ob x = PshHomStrict (↡Psh x) P , isSetPshHomStrict _ _
+    ▷Psh .F-hom a α = ↡F .F-hom a ⋆PshHomStrict α
+    ▷Psh .F-id     = funExt λ α → cong (_⋆PshHomStrict α) (↡F .F-id)
+    ▷Psh .F-seq a b = funExt λ α → cong (_⋆PshHomStrict α) (↡F .F-seq b a)
+
+    next : PshHomStrict P ▷Psh
+    next .N-ob x p = pshhom (λ y (g , q) → P .F-hom g p)
+      (λ c c' h (g' , q') (g , q) e →
+        sym (funExt⁻ (P .F-seq g' h) p) ∙ cong (λ k → P .F-hom k p) (cong fst e))
+    next .N-hom c c' f p' p e =
+      makePshHomStrictPath (funExt λ y → funExt λ (g , q) →
+        funExt⁻ (P .F-seq f g) p' ∙ cong (P .F-hom g) e)
+
+    module _ (fhom : PshHomStrict ▷Psh P) where
+      private
+        f₀ : ∀ c → PshHomStrict (↡Psh c) P → ⟨ P .F-ob c ⟩
+        f₀ = fhom .N-ob
+
+      down : ∀ c → Acc _≺_ c → PshHomStrict (↡Psh c) P
+      downIrr : ∀ c (A A' : Acc _≺_ c) → down c A ≡ down c A'
+      downNat : ∀ {y' y} (A' : Acc _≺_ y') (A : Acc _≺_ y) (h : C [ y' , y ])
+              → ↡F .F-hom h ⋆PshHomStrict down y A ≡ down y' A'
+
+      down c (acc r) .N-ob y (g , q) = f₀ y (down y (r y q))
+      down c (acc r) .N-hom y' y h (g' , q') (g , q) e =
+        fhom .N-hom y' y h (down y (r y q')) _ refl
+        ∙ cong (f₀ y') (downNat (r y' q) (r y q') h)
+      downIrr c (acc r) (acc r') =
+        makePshHomStrictPath (funExt λ y → funExt λ (g , q) →
+          cong (f₀ y) (downIrr y (r y q) (r' y q)))
+      downNat (acc rA') (acc rA) h =
+        makePshHomStrictPath (funExt λ z → funExt λ (m , s) →
+          cong (f₀ z) (downIrr z (rA z (≺-postcomp s h)) (rA' z s)))
+
+      löb : PshHomStrict UnitPsh P
+      löb .N-ob c _ = f₀ c (down c (wf≺ c))
+      löb .N-hom c c' h _ _ _ =
+        fhom .N-hom c c' h (down c' (wf≺ c')) _ refl
+        ∙ cong (f₀ c) (downNat (wf≺ c) (wf≺ c') h)
+
+      downValue : ∀ c (Ac : Acc _≺_ c) {y} (g : C [ y , c ]) (q : y ≺ c)
+                → down c Ac .N-ob y (g , q) ≡ f₀ y (down y (wf≺ y))
+      downValue c (acc r) {y} g q = cong (f₀ y) (downIrr y (r y q) (wf≺ y))
+
+      -- the guarded fixed-point equation:  löb = (löb ⋆ next) ⋆ f
+      löb-fix : löb ≡ (löb ⋆PshHomStrict next) ⋆PshHomStrict fhom
+      löb-fix = makePshHomStrictPath (funExt λ c → funExt λ _ →
+        cong (f₀ c) (makePshHomStrictPath (funExt λ y → funExt λ (g , q) →
+          downValue c (wf≺ c) g q ∙ sym (löb .N-hom y c g _ _ refl))))
+
+      -- and it is the unique fixed point
+      löb-uniq : (s : PshHomStrict UnitPsh P)
+               → s ≡ (s ⋆PshHomStrict next) ⋆PshHomStrict fhom
+               → s ≡ löb
+      löb-uniq s s-fix =
+        makePshHomStrictPath (funExt λ c → funExt λ _ → WFI.induction wf≺ step c)
+        where
+          step : ∀ c → (∀ y → y ≺ c → s .N-ob y tt ≡ löb .N-ob y tt)
+               → s .N-ob c tt ≡ löb .N-ob c tt
+          step c IH =
+            funExt⁻ (funExt⁻ (cong N-ob s-fix) c) tt
+            ∙ cong (f₀ c) (makePshHomStrictPath (funExt λ y → funExt λ (g , q) →
+                s .N-hom y c g _ _ refl ∙ IH y q ∙ sym (downValue c (wf≺ c) g q)))
+
+  module _ {ℓF} (A : ob → hSet (ℓ-max ℓF (ℓ-max ℓ ℓ'))) where
+    private
+      U = FamBase.PSH→Fam {ℓ = ℓF} C
+      G = FamBase.Cofree {ℓ = ℓF} C
+      module Adj = Adjoint.UnitCounit._⊣_ (FamBase.CofreeFamAdj {ℓ = ℓF} C)
+      ηP = NT.NatTrans.N-ob Adj.η
+      εA = NT.NatTrans.N-ob Adj.ε
+
+    ▷Fam : ob → hSet _
+    ▷Fam = U .F-ob (▷Psh (G .F-ob A))
+
+    toFam : PshHomStrict UnitPsh (G .F-ob A) → (∀ x → ⟨ A x ⟩)
+    toFam s x = εA A x (s .N-ob x _)
+
+    fromFam : (∀ x → ⟨ A x ⟩) → PshHomStrict UnitPsh (G .F-ob A)
+    fromFam t = pshhom (λ c _ y h → t y) (λ c c' f p' p e → refl)
+
+    toFam-fromFam : (t : ∀ x → ⟨ A x ⟩) → toFam (fromFam t) ≡ t
+    toFam-fromFam t = refl
+
+    fromFam-toFam : (s : PshHomStrict UnitPsh (G .F-ob A)) → fromFam (toFam s) ≡ s
+    fromFam-toFam s = makePshHomStrictPath (funExt λ c → funExt λ _ →
+      funExt λ y → funExt λ h →
+        sym (funExt⁻ (funExt⁻ (s .N-hom y c h _ _ refl) y) id)
+        ∙ cong (s .N-ob c _ y) (⋆IdL h))
+
+    nextFam : (∀ x → ⟨ A x ⟩) → ∀ x → ⟨ ▷Fam x ⟩
+    nextFam t x =
+      (fromFam t ⋆PshHomStrict next (G .F-ob A)) .N-ob x tt
+
+    -- apply a later element at a strict bound
+    ▷FamApp : {x y : ob} → ⟨ ▷Fam x ⟩ → C [ y , x ] → y ≺ x → ⟨ A y ⟩
+    ▷FamApp β g q = β .N-ob _ (g , q) _ id
+
+    module _ (φ : ∀ x → ⟨ ▷Fam x ⟩ → ⟨ A x ⟩) where
+      φ↑ : PshHomStrict (▷Psh (G .F-ob A)) (G .F-ob A)
+      φ↑ = ηP (▷Psh (G .F-ob A)) ⋆PshHomStrict G .F-hom φ
+
+      löbFam : ∀ x → ⟨ A x ⟩
+      löbFam = toFam (löb (G .F-ob A) φ↑)
+
+      stepFam : (∀ x → ⟨ A x ⟩) → (∀ x → ⟨ A x ⟩)
+      stepFam t =
+        toFam ((fromFam t ⋆PshHomStrict next (G .F-ob A)) ⋆PshHomStrict φ↑)
+
+      löbFam-fix : löbFam ≡ stepFam löbFam
+      löbFam-fix =
+        cong toFam (löb-fix (G .F-ob A) φ↑)
+        ∙ sym (cong (λ s →
+                 toFam ((s ⋆PshHomStrict next (G .F-ob A)) ⋆PshHomStrict φ↑))
+                 (fromFam-toFam (löb (G .F-ob A) φ↑)))
+
+      löbFam-uniq : (t : ∀ x → ⟨ A x ⟩) → t ≡ stepFam t → t ≡ löbFam
+      löbFam-uniq t t-fix =
+        sym (toFam-fromFam t)
+        ∙ cong toFam
+            (löb-uniq (G .F-ob A) φ↑ (fromFam t)
+              (cong fromFam t-fix
+               ∙ fromFam-toFam
+                   ((fromFam t ⋆PshHomStrict next (G .F-ob A)) ⋆PshHomStrict φ↑)))
+
+      löbFam-unfold : ∀ x → löbFam x ≡ φ x (nextFam löbFam x)
+      löbFam-unfold x =
+        funExt⁻ löbFam-fix x
+        ∙ cong (φ x)
+            (funExt⁻ (▷Psh (G .F-ob A) .F-id) (nextFam löbFam x))
+
+      löbFam-uniq-unfold : (t : ∀ x → ⟨ A x ⟩)
+        → (∀ x → t x ≡ φ x (nextFam t x)) → t ≡ löbFam
+      löbFam-uniq-unfold t teq = löbFam-uniq t (funExt λ x →
+        teq x
+        ∙ cong (φ x)
+            (sym (funExt⁻ (▷Psh (G .F-ob A) .F-id) (nextFam t x))))
+
+  private
+    ℓ▷ : Level
+    ℓ▷ = ℓ-max ℓ ℓ'
+
+  ▷ : Functor (PRESHEAF C ℓ▷) (PRESHEAF C ℓ▷)
+  ▷ .F-ob P = ▷Psh P
+  ▷ .F-hom φ .N-ob x β = β ⋆PshHomStrict φ
+  ▷ .F-hom φ .N-hom c c' f β' β e = cong (_⋆PshHomStrict φ) e
+  ▷ .F-id      = makePshHomStrictPath refl
+  ▷ .F-seq φ ψ = makePshHomStrictPath refl
+
+  nextNT : NT.NatTrans Id ▷
+  nextNT = NT.natTrans (λ P → next P)
+    (λ {P} {Q} φ →
+      makePshHomStrictPath (funExt λ x → funExt λ p →
+        makePshHomStrictPath (funExt λ y → funExt λ (g , q) →
+          φ .N-hom y x g p (P .F-hom g p) refl)))

--- a/Cubical/Categories/Direct/StrictUpset.agda
+++ b/Cubical/Categories/Direct/StrictUpset.agda
@@ -1,0 +1,122 @@
+{-# OPTIONS --lossy-unification #-}
+-- The strict-upset coend ◁ of a direct category — the Earlier modality,
+-- dual to the Later modality ▷ of Cubical.Categories.Direct.StrictDownset.
+module Cubical.Categories.Direct.StrictUpset where
+
+open import Cubical.Foundations.Prelude
+open import Cubical.Foundations.Function
+open import Cubical.Foundations.HLevels
+open import Cubical.Foundations.Isomorphism
+open import Cubical.Foundations.Structure
+open import Cubical.Data.Sigma
+
+open import Cubical.Categories.Category
+open import Cubical.Categories.Functor
+open import Cubical.Categories.NaturalTransformation
+open import Cubical.Categories.Instances.Sets
+open import Cubical.Categories.Presheaf.Base
+open import Cubical.Categories.Presheaf.More
+open import Cubical.Categories.Presheaf.StrictHom.Base
+open import Cubical.Categories.Presheaf.Constructions.Tensor
+open import Cubical.Categories.Direct.Base
+open import Cubical.Categories.Direct.StrictDownset using (▷Psh ; next)
+
+private
+  variable
+    ℓ ℓ' ℓD : Level
+
+module _ {C : Category ℓ ℓ'} {Wo : WFOrder ℓD ℓ'} (dir : DirectStr C Wo) where
+  open Category C
+  open Functor
+  open NatTrans
+  open PshHomStrict
+  open DirectNotation dir
+
+  ↟Fun : (x : ob) → Functor C (SET ℓ')
+  ↟Fun x .F-ob y =
+    (Σ[ f ∈ C [ x , y ] ] (x ≺ y))
+    , isSetΣ isSetHom (λ _ → isProp→isSet (isProp≺ x y))
+  ↟Fun x .F-hom g (f , p) = (f ⋆ g) , ≺-postcomp p g
+  ↟Fun x .F-id     = funExt λ (f , p) → Σ≡Prop (λ _ → isProp≺ _ _) (⋆IdR f)
+  ↟Fun x .F-seq g h = funExt λ (f , p) → Σ≡Prop (λ _ → isProp≺ _ _) (sym (⋆Assoc f g h))
+
+  ↟reindex : ∀ {x x'} (a : C [ x , x' ]) → NatTrans (↟Fun x') (↟Fun x)
+  ↟reindex a .N-ob y (f , p) = (a ⋆ f) , ≺-precomp a p
+  ↟reindex a .N-hom {y} {y'} g = funExt λ (f , p) →
+    Σ≡Prop (λ _ → isProp≺ _ _) (sym (⋆Assoc a f g))
+
+  module _ {ℓP} (P : Presheaf C ℓP) where
+    private
+      module P = PresheafNotation P
+      module ⊗x {x} = Tensor (↟Fun x) P
+
+    ◁Psh : Presheaf C (ℓ-max (ℓ-max (ℓ-max ℓ ℓ') ℓ') ℓP)
+    ◁Psh .F-ob x = (↟Fun x ⊗ P) , isSet⊗
+    ◁Psh .F-hom a = ↟reindex a ⊗NT idTrans P
+    ◁Psh .F-id {x} = funExt (⊗x.ind (λ _ → isSet⊗ _ _)
+      λ (f , p) q → cong (⊗x._,⊗ q) (Σ≡Prop (λ _ → isProp≺ _ _) (⋆IdL f)))
+    ◁Psh .F-seq a b = funExt (⊗x.ind (λ _ → isSet⊗ _ _)
+      λ (f , p) q → cong (⊗x._,⊗ q) (Σ≡Prop (λ _ → isProp≺ _ _) (⋆Assoc b a f)))
+
+    prev : PshHomStrict ◁Psh P
+    prev .N-ob x = ⊗x.rec P.isSetPsh
+      (λ (f , p) q → f P.⋆ q)
+      (λ (f , p) g q → sym (P.⋆Assoc f g q))
+    prev .N-hom x x' a t' t e =
+      prevNat t' ∙ cong (prev .N-ob x) e
+      where
+        prevNat : (u : ↟Fun x' ⊗ P)
+          → a P.⋆ prev .N-ob x' u ≡ prev .N-ob x (◁Psh .F-hom a u)
+        prevNat = ⊗x.ind (λ _ → P.isSetPsh _ _)
+          (λ (f , p) q → sym (P.⋆Assoc a f q))
+
+  -- ◁ ⊣ ▷
+  module _ {ℓP ℓQ} (P : Presheaf C ℓP) (Q : Presheaf C ℓQ) where
+    private
+      module P = PresheafNotation P
+      module Q = PresheafNotation Q
+      module ⊗P {x} = Tensor (↟Fun x) P
+
+      ◁transpose : (β : PshHomStrict P (▷Psh dir Q)) (z : ob)
+                  → (↟Fun z ⊗ P) → ⟨ Q .F-ob z ⟩
+      ◁transpose β z = ⊗P.rec Q.isSetPsh
+        (λ (g , q₀) u → β .N-ob _ u .N-ob z (g , q₀))
+        (λ (g , q₀) f u →
+          sym (λ i → β .N-hom _ _ f u _ refl i .N-ob z (g , q₀)))
+
+      ◁transposeNat : ∀ β z' z (h : C [ z' , z ]) (t' : ↟Fun z ⊗ P)
+        → h Q.⋆ ◁transpose β z t'
+          ≡ ◁transpose β z' (◁Psh P .F-hom h t')
+      ◁transposeNat β z' z h = ⊗P.ind (λ _ → Q.isSetPsh _ _)
+        λ (g , q₀) u → β .N-ob _ u .N-hom z' z h (g , q₀) _ refl
+
+    ◁UMP : Iso (PshHomStrict (◁Psh P) Q) (PshHomStrict P (▷Psh dir Q))
+    ◁UMP .Iso.fun α .N-ob y u = pshhom
+      (λ z (g , q) → α .N-ob z ((g , q) ⊗P.,⊗ u))
+      (λ z' z h (g , q) w hyp →
+        α .N-hom z' z h ((g , q) ⊗P.,⊗ u) _ refl
+        ∙ cong (λ v → α .N-ob z' (v ⊗P.,⊗ u)) hyp)
+    ◁UMP .Iso.fun α .N-hom y' y k u' u hyp =
+      makePshHomStrictPath (funExt λ z → funExt λ (g , q) →
+        cong (α .N-ob z)
+          (sym (⊗P.swap (g , q) k u') ∙ cong ((g , q) ⊗P.,⊗_) hyp))
+    ◁UMP .Iso.inv β .N-ob = ◁transpose β
+    ◁UMP .Iso.inv β .N-hom z' z h t' t hyp =
+      ◁transposeNat β z' z h t' ∙ cong (◁transpose β z') hyp
+    ◁UMP .Iso.sec β =
+      makePshHomStrictPath (funExt λ y → funExt λ u →
+        makePshHomStrictPath refl)
+    ◁UMP .Iso.ret α =
+      makePshHomStrictPath (funExt λ z →
+        funExt (⊗P.ind (λ _ → Q.isSetPsh _ _) λ (g , q₀) u → refl))
+
+  -- prev is the transpose of next
+  module _ {ℓP} (P : Presheaf C ℓP) where
+    private
+      module P = PresheafNotation P
+      module ⊗P {x} = Tensor (↟Fun x) P
+
+    transposeNext≡prev : ◁UMP P P .Iso.inv (next dir P) ≡ prev P
+    transposeNext≡prev =
+      makePshHomStrictPath (funExt λ z →
+        funExt (⊗P.ind (λ _ → P.isSetPsh _ _) λ (g , q₀) u → refl))

--- a/Cubical/Categories/Displayed/Instances/FunctorAlgebras/Recursive.agda
+++ b/Cubical/Categories/Displayed/Instances/FunctorAlgebras/Recursive.agda
@@ -1,0 +1,200 @@
+-- Recursive coalgebras and corecursive algebras of an endofunctor:
+-- coalgebra-to-algebra morphisms
+-- initial/final coincidence
+module Cubical.Categories.Displayed.Instances.FunctorAlgebras.Recursive where
+
+open import Cubical.Foundations.Prelude
+open import Cubical.Foundations.HLevels
+open import Cubical.Foundations.Equiv
+open import Cubical.Foundations.Equiv.Properties
+open import Cubical.Foundations.Isomorphism
+open import Cubical.Data.Sigma
+open import Cubical.Data.Unit
+
+open import Cubical.Categories.Category
+open import Cubical.Categories.Functor
+open import Cubical.Categories.Bifunctor
+open import Cubical.Categories.Profunctor.Relator
+open import Cubical.Categories.NaturalTransformation
+open import Cubical.Categories.Functors.Constant
+open import Cubical.Categories.Instances.Sets
+open import Cubical.Categories.Limits.Terminal.More
+open import Cubical.Categories.Displayed.Instances.FunctorAlgebras
+open import Cubical.Categories.Displayed.Instances.FunctorCoalgebras
+
+private
+  variable ℓC ℓC' : Level
+
+module _ {C : Category ℓC ℓC'} (F : Functor C C) where
+  private
+    module C = Category C
+  open Functor
+  open Bifunctor
+
+  Hylo : Coalgebra F → Algebra F → Type ℓC'
+  Hylo (X , c) (B , a) =
+    Σ[ h ∈ C [ X , B ] ] (h ≡ c C.⋆ (F .F-hom h C.⋆ a))
+
+  isSetHylo : ∀ Xc Ba → isSet (Hylo Xc Ba)
+  isSetHylo Xc Ba =
+    isSetΣ C.isSetHom (λ _ → isProp→isSet (C.isSetHom _ _))
+
+  HYLO : (COALG F) o-[ ℓC' ]-* (ALG F)
+  HYLO = mkBifunctorSep Sep
+    where
+    open BifunctorSep
+    Sep : BifunctorSep ((COALG F) ^op) (ALG F) (SET ℓC')
+    Sep .Bif-ob Xc Ba = Hylo Xc Ba , isSetHylo Xc Ba
+    Sep .Bif-homL {c = X , cX} {c' = X' , cX'} (m , msq) (B , a) (h , hsq) =
+      (m C.⋆ h)
+      , (cong (m C.⋆_) hsq
+         ∙ sym (C.⋆Assoc _ _ _)
+         ∙ cong (C._⋆ (F .F-hom h C.⋆ a)) msq
+         ∙ C.⋆Assoc _ _ _
+         ∙ cong (cX' C.⋆_)
+             (sym (C.⋆Assoc _ _ _)
+              ∙ cong (C._⋆ a) (sym (F .F-seq m h))))
+    Sep .Bif-L-id = funExt λ (h , _) →
+      Σ≡Prop (λ _ → C.isSetHom _ _) (C.⋆IdL h)
+    Sep .Bif-L-seq (m , _) (m' , _) = funExt λ (h , _) →
+      Σ≡Prop (λ _ → C.isSetHom _ _) (C.⋆Assoc m' m h)
+    Sep .Bif-homR {d = B , a} {d' = B' , a'} (X , cX) (n , nsq) (h , hsq) =
+      (h C.⋆ n)
+      , (cong (C._⋆ n) hsq
+         ∙ C.⋆Assoc _ _ _
+         ∙ cong (cX C.⋆_)
+             (C.⋆Assoc _ _ _
+              ∙ cong (F .F-hom h C.⋆_) nsq
+              ∙ sym (C.⋆Assoc _ _ _)
+              ∙ cong (C._⋆ a') (sym (F .F-seq h n))))
+    Sep .Bif-R-id = funExt λ (h , _) →
+      Σ≡Prop (λ _ → C.isSetHom _ _) (C.⋆IdR h)
+    Sep .Bif-R-seq (n , _) (n' , _) = funExt λ (h , _) →
+      Σ≡Prop (λ _ → C.isSetHom _ _) (sym (C.⋆Assoc h n n'))
+    Sep .SepBif-RL-commute (m , _) (n , _) = funExt λ (h , _) →
+      Σ≡Prop (λ _ → C.isSetHom _ _) (sym (C.⋆Assoc m h n))
+
+  isRecursiveCoalgebra : Coalgebra F → Type (ℓ-max ℓC ℓC')
+  isRecursiveCoalgebra Xc = (Ba : Algebra F) → isContr (Hylo Xc Ba)
+
+  isCorecursiveAlgebra : Algebra F → Type (ℓ-max ℓC ℓC')
+  isCorecursiveAlgebra Ba = (Xc : Coalgebra F) → isContr (Hylo Xc Ba)
+
+  HYLOTrivial : Type (ℓ-max ℓC ℓC')
+  HYLOTrivial = (Xc : Coalgebra F) (Ba : Algebra F) → isContr (Hylo Xc Ba)
+
+  HYLOTrivial→recursive : HYLOTrivial → ∀ Xc → isRecursiveCoalgebra Xc
+  HYLOTrivial→recursive t Xc Ba = t Xc Ba
+
+  HYLOTrivial→corecursive : HYLOTrivial → ∀ Ba → isCorecursiveAlgebra Ba
+  HYLOTrivial→corecursive t Ba Xc = t Xc Ba
+
+  private
+    Unit*SET : hSet ℓC'
+    Unit*SET = Unit* , isSetUnit*
+
+  module _ (Xc : Coalgebra F) where
+    open NatTrans
+
+    recursive→trivial : isRecursiveCoalgebra Xc
+      → NatIso (appL HYLO Xc) (Constant (ALG F) (SET ℓC') Unit*SET)
+    recursive→trivial rec .NatIso.trans .N-ob Ba _ = tt*
+    recursive→trivial rec .NatIso.trans .N-hom n = refl
+    recursive→trivial rec .NatIso.nIso Ba = isiso
+      (λ _ → rec Ba .fst)
+      (funExt λ _ → refl)
+      (funExt λ h → rec Ba .snd h)
+
+    trivial→recursive :
+        NatIso (appL HYLO Xc) (Constant (ALG F) (SET ℓC') Unit*SET)
+      → isRecursiveCoalgebra Xc
+    trivial→recursive ni Ba = isOfHLevelRespectEquiv 0
+      (invEquiv (isoToEquiv (iso
+        (ni .NatIso.trans .N-ob Ba)
+        (ni .NatIso.nIso Ba .isIso.inv)
+        (λ b → funExt⁻ (ni .NatIso.nIso Ba .isIso.sec) b)
+        (λ h → funExt⁻ (ni .NatIso.nIso Ba .isIso.ret) h))))
+      isContrUnit*
+
+  module _ (Ba : Algebra F) where
+    open NatTrans
+
+    corecursive→trivial : isCorecursiveAlgebra Ba
+      → NatIso (appR HYLO Ba)
+               (Constant ((COALG F) ^op) (SET ℓC') Unit*SET)
+    corecursive→trivial corec .NatIso.trans .N-ob Xc _ = tt*
+    corecursive→trivial corec .NatIso.trans .N-hom m = refl
+    corecursive→trivial corec .NatIso.nIso Xc = isiso
+      (λ _ → corec Xc .fst)
+      (funExt λ _ → refl)
+      (funExt λ h → corec Xc .snd h)
+
+    trivial→corecursive :
+        NatIso (appR HYLO Ba)
+               (Constant ((COALG F) ^op) (SET ℓC') Unit*SET)
+      → isCorecursiveAlgebra Ba
+    trivial→corecursive ni Xc = isOfHLevelRespectEquiv 0
+      (invEquiv (isoToEquiv (iso
+        (ni .NatIso.trans .N-ob Xc)
+        (ni .NatIso.nIso Xc .isIso.inv)
+        (λ b → funExt⁻ (ni .NatIso.nIso Xc .isIso.sec) b)
+        (λ h → funExt⁻ (ni .NatIso.nIso Xc .isIso.ret) h))))
+      isContrUnit*
+
+  module FixpointRecursion
+    (Fix : C.ob)
+    (fixIso : CatIso C (F .F-ob Fix) Fix)
+    (triv : HYLOTrivial)
+    where
+
+    private
+      α    = fixIso .fst
+      α⁻¹  = fixIso .snd .isIso.inv
+      αsec = fixIso .snd .isIso.sec
+      αret = fixIso .snd .isIso.ret
+
+    terminalCoalgebra : TerminalCoalgebra F
+    terminalCoalgebra = terminalToUniversalElement
+      ( (Fix , α⁻¹)
+      , λ (X , c) → isOfHLevelRespectEquiv 0
+          (Σ-cong-equiv-snd (eqv X c)) (triv (X , c) (Fix , α)) )
+      where
+        eqv : ∀ X c (m : C [ X , Fix ])
+            → (m ≡ c C.⋆ (F .F-hom m C.⋆ α))
+              ≃ (m C.⋆ α⁻¹ ≡ c C.⋆ F .F-hom m)
+        eqv X c m = propBiimpl→Equiv
+          (C.isSetHom _ _) (C.isSetHom _ _)
+          (λ p →
+            cong (C._⋆ α⁻¹) p
+            ∙ C.⋆Assoc _ _ _
+            ∙ cong (c C.⋆_) (C.⋆Assoc _ _ _
+                             ∙ cong (F .F-hom m C.⋆_) αret
+                             ∙ C.⋆IdR _))
+          (λ q →
+            sym (C.⋆IdR m)
+            ∙ cong (m C.⋆_) (sym αsec)
+            ∙ sym (C.⋆Assoc _ _ _)
+            ∙ cong (C._⋆ α) q
+            ∙ C.⋆Assoc _ _ _)
+
+    initialAlgebra : InitialAlgebra F
+    initialAlgebra = terminalToUniversalElement
+      ( (Fix , α)
+      , λ (B , a) → isOfHLevelRespectEquiv 0
+          (Σ-cong-equiv-snd (eqv B a)) (triv (Fix , α⁻¹) (B , a)) )
+      where
+        eqv : ∀ B a (m : C [ Fix , B ])
+            → (m ≡ α⁻¹ C.⋆ (F .F-hom m C.⋆ a))
+              ≃ (α C.⋆ m ≡ F .F-hom m C.⋆ a)
+        eqv B a m = propBiimpl→Equiv
+          (C.isSetHom _ _) (C.isSetHom _ _)
+          (λ p →
+            cong (α C.⋆_) p
+            ∙ sym (C.⋆Assoc _ _ _)
+            ∙ cong (C._⋆ (F .F-hom m C.⋆ a)) αret
+            ∙ C.⋆IdL _)
+          (λ q →
+            sym (C.⋆IdL m)
+            ∙ cong (C._⋆ m) (sym αsec)
+            ∙ C.⋆Assoc _ _ _
+            ∙ cong (α⁻¹ C.⋆_) q)

--- a/Cubical/Categories/Presheaf/Sieve.agda
+++ b/Cubical/Categories/Presheaf/Sieve.agda
@@ -1,0 +1,66 @@
+-- A sieve on `c` is a subobject of the representable presheaf `よc`.
+--
+-- This instantiates the general displayed-category notion of subobject
+-- (`Cubical.Categories.Subobject.Base`) at `(PRESHEAF C , よc)`, where
+-- PRESHEAF has *strict* presheaf morphisms (`PshHomStrict`) as homs — the
+-- same category used for the presheaf/family monadicity.  A sieve is thus a
+-- sub-presheaf `S` of `よc` together with the proof that the inclusion
+-- `S ↪ よc` is monic.
+module Cubical.Categories.Presheaf.Sieve where
+
+open import Cubical.Foundations.Prelude
+open import Cubical.Foundations.Structure
+open import Cubical.Data.Sigma
+open import Cubical.Relation.Nullary
+
+open import Cubical.Categories.Category
+open import Cubical.Categories.Functor
+open import Cubical.Categories.Presheaf.Base
+open import Cubical.Categories.Presheaf.StrictHom.Base
+open import Cubical.Categories.Yoneda
+open import Cubical.Categories.Subobject.Base
+
+private
+  variable
+    ℓ ℓ' : Level
+
+module _ (C : Category ℓ ℓ') where
+  open Category C
+
+  -- a sieve on c = a subobject of the representable よc in PRESHEAF
+  Sieve : ob → Type (ℓ-max ℓ (ℓ-suc ℓ'))
+  Sieve c = Subobject (PRESHEAF C ℓ') (yo c)
+
+module _ {C : Category ℓ ℓ'} where
+  open Category C
+  open Functor
+  open PshHomStrict
+
+  module _ {c : ob} where
+    -- the underlying sub-presheaf
+    sievePsh : Sieve C c → Presheaf C ℓ'
+    sievePsh = sub-dom (PRESHEAF C ℓ') (yo c)
+
+    -- the inclusion S ↪ よc (a strict presheaf morphism)
+    sieveIncl : (S : Sieve C c) → PshHomStrict (sievePsh S) (yo c)
+    sieveIncl = sub-incl (PRESHEAF C ℓ') (yo c)
+
+    -- "S contains f": f : y → c lies in the image of the inclusion
+    _∋_ : (S : Sieve C c) {y : ob} (f : C [ y , c ]) → Type ℓ'
+    _∋_ S {y} f = Σ[ t ∈ ⟨ sievePsh S .F-ob y ⟩ ] (sieveIncl S .N-ob y t ≡ f)
+
+    -- sieves are closed under precomposition
+    sieve-precomp : (S : Sieve C c) {y z : ob} {f : C [ y , c ]} (g : C [ z , y ])
+      → S ∋ f → S ∋ (g ⋆ f)
+    sieve-precomp S {y} {z} {f} g (t , eq) =
+      sievePsh S .F-hom g t ,
+      sym (sieveIncl S .N-hom z y g t (sievePsh S .F-hom g t) refl)
+      ∙ cong (yo {C = C} c .F-hom g) eq
+
+    -- proper: does not contain the identity
+    isProperSieve : Sieve C c → Type ℓ'
+    isProperSieve S = ¬ (S ∋ id)
+
+    -- refinement order on sieves
+    _⊆_ : Sieve C c → Sieve C c → Type (ℓ-max ℓ ℓ')
+    S ⊆ T = ∀ {y} (f : C [ y , c ]) → S ∋ f → T ∋ f

--- a/Cubical/Categories/Presheaf/StrictHom/CartesianClosed.agda
+++ b/Cubical/Categories/Presheaf/StrictHom/CartesianClosed.agda
@@ -82,6 +82,11 @@ Unit*Psh-introStrict : ∀ {ℓA} {ℓ1} {C : Category ℓ ℓ'}{P : Presheaf C 
 Unit*Psh-introStrict .N-ob = λ x _ → tt*
 Unit*Psh-introStrict .N-hom c c' f p' p x = refl
 
+UnitPsh-introStrict : ∀ {ℓA} {C : Category ℓ ℓ'}{P : Presheaf C ℓA}
+  → PshHomStrict P UnitPsh
+UnitPsh-introStrict .N-ob = λ x _ → tt
+UnitPsh-introStrict .N-hom c c' f p' p x = refl
+
 module _
   {C : Category ℓc ℓc'}
   where
@@ -215,6 +220,28 @@ module _ {C : Category ℓC ℓC'} (P : Presheaf C ℓP) (Q : Presheaf C ℓQ) w
         (funExt₂ λ d (f , p) →
           sym (cong (λ x → α .N-ob c r .N-ob d (x , p)) (sym (C.⋆IdL f))
           ∙ funExt⁻ (funExt⁻ (cong N-ob (α .N-hom d c f r (f R.⋆ r) refl)) d) (C.id , p))))
+
+module _ {C : Category ℓC ℓC'} {P : Presheaf C ℓP} {Q : Presheaf C ℓQ} where
+
+  -- the external hom underlying a global element of the internal hom
+  eltPshHomStrict : PshHomStrict UnitPsh (P ⇒PshLargeStrict Q)
+                  → PshHomStrict P Q
+  eltPshHomStrict s =
+    ×PshIntroStrict (UnitPsh-introStrict ⋆PshHomStrict s) idPshHomStrict
+      ⋆PshHomStrict appPshHomStrict P Q
+
+  -- β at a pairing: applying the transpose of γ to a pair (u , v)
+  module _ {R : Presheaf C ℓR} {W : Presheaf C ℓS}
+    (u : PshHomStrict W R) (v : PshHomStrict W P)
+    (γ : PshHomStrict (R ×Psh P) Q) where
+
+    applyλ :
+      ×PshIntroStrict (u ⋆PshHomStrict λPshHomStrict P Q γ) v
+        ⋆PshHomStrict appPshHomStrict P Q
+      ≡ ×PshIntroStrict u v ⋆PshHomStrict γ
+    applyλ = makePshHomStrictPath (funExt λ c → funExt λ x →
+      cong (λ z → γ .N-ob c (z , v .N-ob c x))
+        (funExt⁻ (R .F-id) (u .N-ob c x)))
 
 module _ (C : Category ℓC ℓC') (ℓP : Level) where
   Exp-PRESHEAF :

--- a/Cubical/Categories/Subobject/Base.agda
+++ b/Cubical/Categories/Subobject/Base.agda
@@ -1,0 +1,56 @@
+-- A subobject of `c` in a category `D` is a monomorphism into `c`.
+--
+-- We build the category of subobjects of `c` compositionally as a displayed
+-- category over `D`: it is the `StructureOver` whose structure on an object
+-- `a` is a mono `a → c`, and whose (propositional) hom-constraint on a map
+-- `f : a → a'` is that the triangle commutes.  `SubobjectCat` is its total
+-- category.  Sieves instantiate this at `(PSh C , よc)`.
+module Cubical.Categories.Subobject.Base where
+
+open import Cubical.Foundations.Prelude
+open import Cubical.Data.Sigma
+
+open import Cubical.Categories.Category
+open import Cubical.Categories.Morphism
+open import Cubical.Categories.Displayed.Base
+open import Cubical.Categories.Displayed.Instances.StructureOver.Base
+open import Cubical.Categories.Instances.TotalCategory
+
+open Category
+
+private
+  variable
+    ℓ ℓ' : Level
+
+module _ (D : Category ℓ ℓ') (c : D .ob) where
+  private module D = Category D
+
+  -- structure on `a`: a mono into c ;  constraint on `f`: the triangle commutes
+  SubobjectStr : StructureOver D (ℓ-max ℓ ℓ') ℓ'
+  SubobjectStr .StructureOver.ob[_] a = Σ[ m ∈ D [ a , c ] ] isMonic D m
+  SubobjectStr .StructureOver.Hom[_][_,_] f m m' = (f D.⋆ m' .fst) ≡ m .fst
+  SubobjectStr .StructureOver.idᴰ {p = m} = D.⋆IdL (m .fst)
+  SubobjectStr .StructureOver._⋆ᴰ_ {f = f} {g = g} {zᴰ = m''} p q =
+    D.⋆Assoc f g (m'' .fst) ∙ cong (f D.⋆_) q ∙ p
+  SubobjectStr .StructureOver.isPropHomᴰ = D.isSetHom _ _
+
+  Subobjectᴰ : Categoryᴰ D (ℓ-max ℓ ℓ') ℓ'
+  Subobjectᴰ = StructureOver→Catᴰ SubobjectStr
+
+  -- subobjects of c, with refinement morphisms (commuting triangles)
+  SubobjectCat : Category (ℓ-max ℓ ℓ') ℓ'
+  SubobjectCat = ∫C Subobjectᴰ
+
+  -- a subobject of c = a mono into c
+  Subobject : Type (ℓ-max ℓ ℓ')
+  Subobject = SubobjectCat .ob
+
+  module _ (S : Subobject) where
+    sub-dom : D .ob
+    sub-dom = S .fst
+
+    sub-incl : D [ sub-dom , c ]
+    sub-incl = S .snd .fst
+
+    sub-isMonic : isMonic D sub-incl
+    sub-isMonic = S .snd .snd

--- a/Cubical/Induction/WellFounded/More.agda
+++ b/Cubical/Induction/WellFounded/More.agda
@@ -1,0 +1,22 @@
+-- Extensions to Cubical.Induction.WellFounded
+module Cubical.Induction.WellFounded.More where
+
+open import Cubical.Foundations.Prelude
+
+open import Cubical.Induction.WellFounded
+
+private
+  variable
+    ℓA ℓW ℓ< : Level
+
+-- Pull a well-founded relation back along a function.
+module _ {A : Type ℓA} {W : Type ℓW} (deg : A → W)
+         (_<_ : W → W → Type ℓ<) where
+  pullback< : A → A → Type ℓ<
+  pullback< a a' = deg a < deg a'
+
+  accPullback : ∀ a → Acc _<_ (deg a) → Acc pullback< a
+  accPullback a (acc r) = acc (λ a' p → accPullback a' (r (deg a') p))
+
+  wfPullback : WellFounded _<_ → WellFounded pullback<
+  wfPullback wf a = accPullback a (wf (deg a))


### PR DESCRIPTION
Notes can be found again [here](https://um-catlab.github.io/foreign/stevenschaefer.net/sss-00GC/index.xml). In summary, this PR has
- a definition of direct categories
- a definition of later/earlier/Lob induction for presheaves and families
- a characterization of locally contractive functors
- proof that locally contractive functors have unique fixed points
- a proof that all coalgebras of locally contractive functors are recursive. Dually, all algebras are corecursive

This is dependent on PR #259 