### PR TITLE
Application of guarded recursion

### DIFF
--- a/Cubical/Algebra/OrderedSemiring.agda
+++ b/Cubical/Algebra/OrderedSemiring.agda
@@ -1,0 +1,58 @@
+module Cubical.Algebra.OrderedSemiring where
+
+open import Cubical.Foundations.Prelude
+open import Cubical.Foundations.HLevels
+
+record OrderedSemiring (ℓ : Level) : Type (ℓ-suc ℓ) where
+  infixr 6 _⊕_
+  infixr 7 _⊗_
+  field
+    R          : Type ℓ
+    isSetR     : isSet R
+    𝟘 𝟙        : R
+    _⊕_ _⊗_    : R → R → R
+    ⊕-assoc    : ∀ x y z → (x ⊕ y) ⊕ z ≡ x ⊕ (y ⊕ z)
+    ⊕-comm     : ∀ x y → x ⊕ y ≡ y ⊕ x
+    ⊕-idem     : ∀ x → x ⊕ x ≡ x
+    ⊕-unit     : ∀ x → 𝟘 ⊕ x ≡ x
+    ⊗-assoc    : ∀ x y z → (x ⊗ y) ⊗ z ≡ x ⊗ (y ⊗ z)
+    ⊗-unitˡ    : ∀ x → 𝟙 ⊗ x ≡ x
+    ⊗-unitʳ    : ∀ x → x ⊗ 𝟙 ≡ x
+    ⊗-annihilˡ : ∀ x → 𝟘 ⊗ x ≡ 𝟘
+    ⊗-distribˡ : ∀ x y z → (x ⊕ y) ⊗ z ≡ (x ⊗ z) ⊕ (y ⊗ z)
+
+  -- the induced order:  x ⊑ y  ("x is below y") iff  x ⊕ y ≡ x.
+  _⊑_ : R → R → Type ℓ
+  x ⊑ y = x ⊕ y ≡ x
+
+  isProp⊑ : ∀ {x y} → isProp (x ⊑ y)
+  isProp⊑ = isSetR _ _
+
+  ⊑-refl : ∀ {x} → x ⊑ x
+  ⊑-refl {x} = ⊕-idem x
+
+  ⊑-trans : ∀ {x y z} → x ⊑ y → y ⊑ z → x ⊑ z
+  ⊑-trans {x} {y} {z} p q =
+    cong (_⊕ z) (sym p) ∙ ⊕-assoc x y z ∙ cong (x ⊕_) q ∙ p
+
+  ⊑-antisym : ∀ {x y} → x ⊑ y → y ⊑ x → x ≡ y
+  ⊑-antisym {x} {y} p q = sym p ∙ ⊕-comm x y ∙ q
+
+  -- ⊕ is the meet: it is a lower bound of both arguments …
+  ⊕-lb₁ : ∀ x y → (x ⊕ y) ⊑ x
+  ⊕-lb₁ x y = ⊕-assoc x y x ∙ cong (x ⊕_) (⊕-comm y x)
+            ∙ sym (⊕-assoc x x y) ∙ cong (_⊕ y) (⊕-idem x)
+
+  ⊕-lb₂ : ∀ x y → (x ⊕ y) ⊑ y
+  ⊕-lb₂ x y = ⊕-assoc x y y ∙ cong (x ⊕_) (⊕-idem y)
+
+  ⊕-skip : ∀ x {y z} → y ⊑ z → (x ⊕ y) ⊑ z
+  ⊕-skip x p = ⊑-trans (⊕-lb₂ x _) p
+
+  -- 𝟘 is the top element.
+  ⊑𝟘 : ∀ x → x ⊑ 𝟘
+  ⊑𝟘 x = ⊕-comm x 𝟘 ∙ ⊕-unit x
+
+  -- ⊗ is monotone in its left argument (from left-distributivity).
+  ⊗-monoˡ : ∀ {x x'} y → x ⊑ x' → (x ⊗ y) ⊑ (x' ⊗ y)
+  ⊗-monoˡ {x} {x'} y p = sym (⊗-distribˡ x x' y) ∙ cong (_⊗ y) p

--- a/Cubical/Algebra/OrderedSemiring/Bool.agda
+++ b/Cubical/Algebra/OrderedSemiring/Bool.agda
@@ -1,0 +1,58 @@
+-- The Boolean ordered semiring
+module Cubical.Algebra.OrderedSemiring.Bool where
+
+open import Cubical.Foundations.Prelude
+open import Cubical.Data.Bool
+open import Cubical.Algebra.OrderedSemiring
+
+private
+  ∨-assoc : ∀ x y z → (x or y) or z ≡ x or (y or z)
+  ∨-assoc false y z = refl
+  ∨-assoc true  y z = refl
+
+  ∨-comm : ∀ x y → x or y ≡ y or x
+  ∨-comm false false = refl
+  ∨-comm false true  = refl
+  ∨-comm true  false = refl
+  ∨-comm true  true  = refl
+
+  ∨-idem : ∀ x → x or x ≡ x
+  ∨-idem false = refl
+  ∨-idem true  = refl
+
+  ∧-assoc : ∀ x y z → (x and y) and z ≡ x and (y and z)
+  ∧-assoc false y z = refl
+  ∧-assoc true  y z = refl
+
+  ∧-idr : ∀ x → x and true ≡ x
+  ∧-idr false = refl
+  ∧-idr true  = refl
+
+  ∧-distribˡ : ∀ x y z → (x or y) and z ≡ (x and z) or (y and z)
+  ∧-distribˡ false y     z     = refl
+  ∧-distribˡ true  y     true  = refl
+  ∧-distribˡ true  false false = refl
+  ∧-distribˡ true  true  false = refl
+
+Boolean : OrderedSemiring ℓ-zero
+Boolean = record
+  { R          = Bool     ; isSetR = isSetBool
+  ; 𝟘          = false    ; 𝟙 = true
+  ; _⊕_        = _or_     ; _⊗_ = _and_
+  ; ⊕-assoc    = ∨-assoc  ; ⊕-comm = ∨-comm ; ⊕-idem = ∨-idem
+  ; ⊕-unit     = λ _ → refl
+  ; ⊗-assoc    = ∧-assoc  ; ⊗-unitˡ = λ _ → refl ; ⊗-unitʳ = ∧-idr
+  ; ⊗-annihilˡ = λ _ → refl
+  ; ⊗-distribˡ = ∧-distribˡ
+  }
+
+open import Cubical.Algebra.OrderedSemiring.Selective
+open import Cubical.Data.Sum using (_⊎_ ; inl ; inr)
+
+private
+  ∨-select : ∀ x y → (x or y ≡ x) ⊎ (x or y ≡ y)
+  ∨-select false y = inr refl
+  ∨-select true  y = inl refl
+
+BooleanSel : SelectiveSemiring ℓ-zero
+BooleanSel = record { semiring = Boolean ; ⊕-select = ∨-select }

--- a/Cubical/Algebra/OrderedSemiring/MinPlus.agda
+++ b/Cubical/Algebra/OrderedSemiring/MinPlus.agda
@@ -1,0 +1,25 @@
+-- The min-plus (tropical) ordered semiring
+module Cubical.Algebra.OrderedSemiring.MinPlus where
+
+open import Cubical.Foundations.Prelude
+open import Cubical.Data.Nat using (zero)
+open import Cubical.Data.Maybe using (just)
+open import Cubical.Data.Nat.More
+open import Cubical.Algebra.OrderedSemiring
+
+MinPlus : OrderedSemiring ℓ-zero
+MinPlus = record
+  { R          = Cost      ; isSetR = isSetCost
+  ; 𝟘          = ∞         ; 𝟙 = just zero
+  ; _⊕_        = _⊕_       ; _⊗_ = _⊗_
+  ; ⊕-assoc    = ⊕-assoc   ; ⊕-comm = ⊕-comm ; ⊕-idem = ⊕-idem
+  ; ⊕-unit     = λ _ → refl
+  ; ⊗-assoc    = ⊗-assoc   ; ⊗-unitˡ = ⊗-unitˡ ; ⊗-unitʳ = ⊗-unitʳ
+  ; ⊗-annihilˡ = λ _ → refl
+  ; ⊗-distribˡ = ⊗-distribˡ
+  }
+
+open import Cubical.Algebra.OrderedSemiring.Selective
+
+MinPlusSel : SelectiveSemiring ℓ-zero
+MinPlusSel = record { semiring = MinPlus ; ⊕-select = ⊕-select }

--- a/Cubical/Algebra/OrderedSemiring/Selective.agda
+++ b/Cubical/Algebra/OrderedSemiring/Selective.agda
@@ -1,0 +1,12 @@
+module Cubical.Algebra.OrderedSemiring.Selective where
+
+open import Cubical.Foundations.Prelude
+open import Cubical.Data.Sum using (_⊎_)
+open import Cubical.Algebra.OrderedSemiring
+
+record SelectiveSemiring (ℓ : Level) : Type (ℓ-suc ℓ) where
+  field
+    semiring : OrderedSemiring ℓ
+  open OrderedSemiring semiring public
+  field
+    ⊕-select : ∀ x y → (x ⊕ y ≡ x) ⊎ (x ⊕ y ≡ y)

--- a/Cubical/Categories/Direct/Base.agda
+++ b/Cubical/Categories/Direct/Base.agda
@@ -1,0 +1,149 @@
+-- Direct categories.
+module Cubical.Categories.Direct.Base where
+
+open import Cubical.Foundations.Prelude
+open import Cubical.Foundations.HLevels
+open import Cubical.Data.Sum
+open import Cubical.Data.Empty as ⊥
+open import Cubical.Relation.Nullary
+import Cubical.Data.Equality as Eq
+
+open import Cubical.Induction.WellFounded
+
+open import Cubical.Categories.Category
+open import Cubical.Categories.Functor
+
+private
+  variable
+    ℓC ℓC' ℓD ℓ< : Level
+
+-- Pull a well-founded relation back along a function.
+-- TODO put this somewhere else
+module _ {A : Type ℓC} {W : Type ℓD} (deg : A → W)
+         (_<_ : W → W → Type ℓ<) where
+  pullback< : A → A → Type ℓ<
+  pullback< a a' = deg a < deg a'
+
+  accPullback : ∀ a → Acc _<_ (deg a) → Acc pullback< a
+  accPullback a (acc r) = acc (λ a' p → accPullback a' (r (deg a') p))
+
+  wfPullback : WellFounded _<_ → WellFounded pullback<
+  wfPullback wf a = accPullback a (wf (deg a))
+
+record WFOrder (ℓD ℓ< : Level) : Type (ℓ-suc (ℓ-max ℓD ℓ<)) where
+  field
+    D       : Type ℓD
+    isSetD  : isSet D
+    _<_     : D → D → Type ℓ<
+    isProp< : ∀ a b → isProp (a < b)
+    trans<  : ∀ {a b c} → a < b → b < c → a < c
+    wf<     : WellFounded _<_
+
+  ¬<refl : ∀ {a} → ¬ (a < a)
+  ¬<refl = wf→x≮x wf<
+
+  -- less-than-or-equal-to is less-than or equal-to
+  _≤_ : D → D → Type (ℓ-max ℓD ℓ<)
+  a ≤ b = (a < b) ⊎ (a Eq.≡ b)
+
+  isProp≤ : ∀ {a b} → isProp (a ≤ b)
+  isProp≤ {a} {b} = isProp⊎ (isProp< a b) isPropEq
+    (λ a<b a≡b → ¬<refl (Eq.transport (a <_) (Eq.sym a≡b) a<b))
+    where
+      isPropEq : isProp (a Eq.≡ b)
+      isPropEq = isOfHLevelRetract 1
+        Eq.eqToPath Eq.pathToEq Eq.pathToEq-eqToPath (isSetD a b)
+
+  ≤-refl : ∀ {a} → a ≤ a
+  ≤-refl = inr Eq.refl
+
+  ≤-trans : ∀ {a b c} → a ≤ b → b ≤ c → a ≤ c
+  ≤-trans         (inl a<b) (inl b<c) = inl (trans< a<b b<c)
+  ≤-trans {a = a} (inl a<b) (inr b≡c) = inl (Eq.transport (a <_) b≡c a<b)
+  ≤-trans {c = c} (inr a≡b) (inl b<c) = inl (Eq.transport (_< c) (Eq.sym a≡b) b<c)
+  ≤-trans         (inr a≡b) (inr b≡c) = inr (a≡b Eq.∙ b≡c)
+
+  ≤-<-trans : ∀ {a b c} → a ≤ b → b < c → a < c
+  ≤-<-trans         (inl a<b) b<c = trans< a<b b<c
+  ≤-<-trans {c = c} (inr a≡b) b<c = Eq.transport (λ z → z < c) (Eq.sym a≡b) b<c
+
+  <-≤-trans : ∀ {a b c} → a < b → b ≤ c → a < c
+  <-≤-trans         a<b (inl b<c) = trans< a<b b<c
+  <-≤-trans {a = a} a<b (inr b≡c) = Eq.transport (λ z → a < z) b≡c a<b
+
+-- Pull a whole well-founded order back along a measure `A → D`.
+module _ {ℓA : Level} (Wo : WFOrder ℓD ℓ<)
+         {A : Type ℓA} (isSetA : isSet A) (meas : A → WFOrder.D Wo) where
+  private module Wo = WFOrder Wo
+  pullbackWFOrder : WFOrder ℓA ℓ<
+  pullbackWFOrder = record
+    { D       = A
+    ; isSetD  = isSetA
+    ; _<_     = λ a b → meas a Wo.< meas b
+    ; isProp< = λ a b → Wo.isProp< (meas a) (meas b)
+    ; trans<  = λ {a} {b} {c} → Wo.trans< {meas a} {meas b} {meas c}
+    ; wf<     = wfPullback meas Wo._<_ Wo.wf<
+    }
+
+-- The thin category on the reflexive closure of a well-founded order
+module _ (Wo : WFOrder ℓD ℓ<) where
+  private module Wo = WFOrder Wo
+  open Category
+
+  WFOrder→Cat : Category ℓD (ℓ-max ℓD ℓ<)
+  WFOrder→Cat .ob           = Wo.D
+  WFOrder→Cat .Hom[_,_]     = Wo._≤_
+  WFOrder→Cat .id           = Wo.≤-refl
+  WFOrder→Cat ._⋆_          = Wo.≤-trans
+  WFOrder→Cat .⋆IdL _       = Wo.isProp≤ _ _
+  WFOrder→Cat .⋆IdR _       = Wo.isProp≤ _ _
+  WFOrder→Cat .⋆Assoc _ _ _ = Wo.isProp≤ _ _
+  WFOrder→Cat .isSetHom     = isProp→isSet Wo.isProp≤
+
+module _ {C : Category ℓC ℓC'} (Wo : WFOrder ℓD ℓ<) where
+  private
+    module C  = Category C
+    module Wo = WFOrder Wo
+
+  -- A direct structure on a category is a degree functor into a
+  -- well-founded order: morphisms flow in the same order as the
+  -- ordering on objects
+  DirectStr : Type _
+  DirectStr = Functor C (WFOrder→Cat Wo)
+
+  mkDirectStr :
+      (deg : C.ob → Wo.D)
+    → (non-dec : ∀ {x y} → C [ x , y ] → deg x Wo.≤ deg y)
+    → DirectStr
+  mkDirectStr deg non-dec .Functor.F-ob      = deg
+  mkDirectStr deg non-dec .Functor.F-hom     = non-dec
+  mkDirectStr deg non-dec .Functor.F-id      = Wo.isProp≤ _ _
+  mkDirectStr deg non-dec .Functor.F-seq _ _ = Wo.isProp≤ _ _
+
+module DirectNotation
+  {ℓC ℓC' ℓD ℓ< : Level} {C : Category ℓC ℓC'} {Wo : WFOrder ℓD ℓ<}
+  (dir : DirectStr {C = C} Wo) where
+  private
+    module C  = Category C
+    module Wo = WFOrder Wo
+
+  deg : C.ob → Wo.D
+  deg = dir .Functor.F-ob
+
+  non-dec : ∀ {x y} → C [ x , y ] → deg x Wo.≤ deg y
+  non-dec = dir .Functor.F-hom
+
+  _≺_ : C.ob → C.ob → Type ℓ<
+  x ≺ y = deg x Wo.< deg y
+
+  isProp≺ : ∀ x y → isProp (x ≺ y)
+  isProp≺ x y = Wo.isProp< _ _
+
+  wf≺ : WellFounded _≺_
+  wf≺ = wfPullback deg Wo._<_ Wo.wf<
+
+  ≺-precomp : ∀ {z y x} → C [ z , y ] → y ≺ x → z ≺ x
+  ≺-precomp f y≺x = Wo.≤-<-trans (non-dec f) y≺x
+
+  ≺-postcomp : ∀ {y x x'} → y ≺ x → C [ x , x' ] → y ≺ x'
+  ≺-postcomp y≺x f = Wo.<-≤-trans y≺x (non-dec f)

--- a/Cubical/Categories/Direct/Examples/Ackermann.agda
+++ b/Cubical/Categories/Direct/Examples/Ackermann.agda
@@ -1,0 +1,63 @@
+{-# OPTIONS --lossy-unification #-}
+-- The Ackermann function by Löb induction over the lexicographic order on ℕ × ℕ
+module Cubical.Categories.Direct.Examples.Ackermann where
+
+open import Cubical.Foundations.Prelude
+open import Cubical.Foundations.HLevels using (hSet)
+open import Cubical.Foundations.Structure using (⟨_⟩)
+
+open import Cubical.Data.Sigma using (_×_ ; _,_)
+open import Cubical.Data.Sum using (inl ; inr)
+open import Cubical.Data.Nat using (ℕ ; zero ; suc ; isSetℕ)
+open import Cubical.Data.Nat.Order.Recursive using (≤-refl)
+import Cubical.Data.Equality as Eq
+
+open import Cubical.Categories.Direct.Base
+open import Cubical.Categories.Direct.Product using (LexWFOrder)
+open import Cubical.Categories.Direct.Instances.Nat using (ℕWFOrder)
+open import Cubical.Categories.Direct.Instances.Poset using (PosetDirect)
+open import Cubical.Categories.Direct.StrictDownset
+  using (▷Fam ; ▷FamApp ; löbFam ; löbFam-unfold)
+
+private
+  dir = PosetDirect (LexWFOrder ℕWFOrder ℕWFOrder)
+
+open DirectNotation dir using (_≺_)
+
+lex-fst : ∀ {m n n'} → (m , n) ≺ (suc m , n')
+lex-fst {m} = inl (≤-refl m)
+
+lex-snd : ∀ {m n} → (m , n) ≺ (m , suc n)
+lex-snd {_} {n} = inr (Eq.refl , ≤-refl n)
+
+A : ℕ × ℕ → hSet ℓ-zero
+A _ = ℕ , isSetℕ
+
+call : ∀ {x} → ⟨ ▷Fam dir {ℓF = ℓ-zero} A x ⟩ → ∀ y → y ≺ x → ℕ
+call β y q = ▷FamApp dir {ℓF = ℓ-zero} A β (inl q) q
+
+step : ∀ x → ⟨ ▷Fam dir {ℓF = ℓ-zero} A x ⟩ → ⟨ A x ⟩
+step (zero  , n)     β = suc n
+step (suc m , zero)  β = call β (m , 1) lex-fst
+step (suc m , suc n) β = call β (m , call β (suc m , n) lex-snd) lex-fst
+
+ack : ℕ → ℕ → ℕ
+ack m n = löbFam dir {ℓF = ℓ-zero} A step (m , n)
+
+ack-0 : ∀ n → ack 0 n ≡ suc n
+ack-0 n = löbFam-unfold dir {ℓF = ℓ-zero} A step (0 , n)
+
+ack-s0 : ∀ m → ack (suc m) 0 ≡ ack m 1
+ack-s0 m = löbFam-unfold dir {ℓF = ℓ-zero} A step (suc m , 0)
+
+ack-ss : ∀ m n → ack (suc m) (suc n) ≡ ack m (ack (suc m) n)
+ack-ss m n = löbFam-unfold dir {ℓF = ℓ-zero} A step (suc m , suc n)
+
+_ : ack 4 0 ≡ 13
+_ = refl
+
+_ : ack 2 4 ≡ 11
+_ = refl
+
+_ : ack 3 3 ≡ 61
+_ = refl

--- a/Cubical/Categories/Direct/Examples/BinarySearch.agda
+++ b/Cubical/Categories/Direct/Examples/BinarySearch.agda
@@ -1,0 +1,204 @@
+{-# OPTIONS --lossy-unification #-}
+-- Intrinsically correct binary search returning the index, as a hylomorphism.
+module Cubical.Categories.Direct.Examples.BinarySearch where
+
+open import Cubical.Foundations.Prelude
+open import Cubical.Foundations.HLevels
+open import Cubical.Foundations.Structure using (⟨_⟩)
+
+open import Cubical.Data.Sigma
+open import Cubical.Data.Sum using (_⊎_ ; inl ; inr ; isSet⊎)
+open import Cubical.Data.Unit using (tt)
+open import Cubical.Data.Empty as ⊥ using ()
+open import Cubical.Data.Maybe using (Maybe ; just ; nothing ; map-Maybe)
+open import Cubical.Data.Nat using (ℕ ; zero ; suc ; isSetℕ)
+open import Cubical.Data.Nat.Order.Recursive
+  using (_≤_ ; _<_ ; isProp≤ ; ≤-trans ; <-weaken ; ¬m<m ; <→≢
+        ; Trichotomy ; lt ; eq ; gt ; _≟_)
+open import Cubical.Data.List
+  using (List ; [] ; _∷_ ; _++_ ; length ; take ; drop)
+open import Cubical.Data.List.Properties using (isOfHLevelList)
+open import Cubical.Data.List.More
+open import Cubical.Data.Fin using (Fin ; toℕ)
+
+open import Cubical.Relation.Nullary using (¬_ ; Dec ; yes ; no ; isProp¬)
+open import Cubical.Relation.Nullary.More using (isSetDec)
+
+open import Cubical.Categories.Category
+open import Cubical.Categories.Functor using (Functor)
+open import Cubical.Categories.Direct.Base
+open import Cubical.Categories.Direct.Instances.ListByLength using (ListDirect)
+import Cubical.Categories.Direct.LocallyContractive as LC
+
+open Functor
+
+private
+  dir = ListDirect ℕ isSetℕ
+
+open DirectNotation dir using (_≺_ ; isProp≺)
+
+Fam : Category _ _
+Fam = LC.Fam dir
+
+open Ordered _≤_ isProp≤ ≤-trans
+
+≤<-trans : ∀ {a b c} → a ≤ b → b < c → a < c
+≤<-trans {a} {b} {c} a≤b b<c = ≤-trans {suc a} {suc b} {c} a≤b b<c
+
+half : ℕ → ℕ
+half zero          = zero
+half (suc zero)    = zero
+half (suc (suc n)) = suc (half n)
+
+half< : ∀ m → half (suc m) < suc m
+half< zero          = tt
+half< (suc zero)    = tt
+half< (suc (suc m)) = <-weaken (half< m)
+
+module _ (q : ℕ) where
+
+  Member : List ℕ → Type
+  Member xs = q ∈ xs
+
+  MemIff : List ℕ → List ℕ → Type
+  MemIff xs ys = (Member xs → Member ys) × (Member ys → Member xs)
+
+  isSetMemIff : ∀ xs ys → isSet (MemIff xs ys)
+  isSetMemIff xs ys =
+    isSet× (isSetΠ λ _ → isSet∈ isSetℕ ys) (isSetΠ λ _ → isSet∈ isSetℕ xs)
+
+  Hob : Category.ob Fam → Category.ob Fam
+  Hob A xs =
+      ( (¬ Member xs)
+      ⊎ ( Member xs
+        ⊎ (Σ[ ys ∈ List ℕ ] ((ys ≺ xs) × MemIff xs ys × ⟨ A ys ⟩)) ) )
+    , isSet⊎ (isProp→isSet (isProp¬ (Member xs)))
+        (isSet⊎ (isSet∈ isSetℕ xs)
+          (isSetΣ (isOfHLevelList 0 isSetℕ) λ ys →
+            isSet× (isProp→isSet (isProp≺ ys xs))
+            (isSet× (isSetMemIff xs ys) (A ys .snd))))
+
+  Hmap : {A B : Category.ob Fam} (xs : List ℕ)
+       → (∀ {ys} → ys ≺ xs → ⟨ A ys ⟩ → ⟨ B ys ⟩)
+       → ⟨ Hob A xs ⟩ → ⟨ Hob B xs ⟩
+  Hmap xs f (inl ¬m)      = inl ¬m
+  Hmap xs f (inr (inl m)) = inr (inl m)
+  Hmap xs f (inr (inr (ys , ys≺ , iff , a))) =
+    inr (inr (ys , ys≺ , iff , f ys≺ a))
+
+  Hhom : {A B : Category.ob Fam} → Fam [ A , B ] → Fam [ Hob A , Hob B ]
+  Hhom {A} {B} h xs = Hmap {A} {B} xs (λ {ys} _ → h ys)
+
+  H : Functor Fam Fam
+  H .F-ob A          = Hob A
+  H .F-hom {A} {B} h = Hhom {A} {B} h
+  H .F-id            = funExt λ _ → funExt
+    λ { (inl _) → refl ; (inr (inl _)) → refl ; (inr (inr _)) → refl }
+  H .F-seq _ _       = funExt λ _ → funExt
+    λ { (inl _) → refl ; (inr (inl _)) → refl ; (inr (inr _)) → refl }
+
+  Hδ : LC.▷HomActionFam dir H
+  Hδ {A} {B} xs β = Hmap {A} {B} xs (λ q' → LC.▷app dir β (inl q') q')
+
+  Hlc : LC.LocallyContractiveFam dir
+  Hlc = H , Hδ , λ h xs → funExt
+    λ { (inl _) → refl ; (inr (inl _)) → refl ; (inr (inr _)) → refl }
+
+  Inp Out : Category.ob Fam
+  Inp xs = Sorted xs , isProp→isSet (isPropSorted xs)
+  Out xs = Dec (Member xs) , isSetDec (isSet∈ isSetℕ xs)
+
+  alg : Fam [ H .F-ob Out , Out ]
+  alg xs (inl ¬m)                               = no ¬m
+  alg xs (inr (inl m))                          = yes m
+  alg xs (inr (inr (ys , _ , (to , from) , d))) = decMap d
+    where
+      decMap : Dec (Member ys) → Dec (Member xs)
+      decMap (yes b) = yes (from b)
+      decMap (no ¬b) = no (λ a → ¬b (to a))
+
+  coalg : Fam [ Inp , H .F-ob Inp ]
+  coalg []        s = inl (λ ())
+  coalg (x ∷ xs') s = go (q ≟ mid)
+    where
+      full = x ∷ xs'
+      k    = half (length full)
+      lo   = take k full
+      mid  = lookupD 0 full k
+      hi   = drop (suc k) full
+
+      k<len : k < length full
+      k<len = half< (length xs')
+
+      recomb : full ≡ lo ++ mid ∷ hi
+      recomb = sym (take-lookup-drop 0 k full k<len)
+
+      split : All (_≤ mid) lo × Sorted lo × All (mid ≤_) hi × Sorted hi
+      split = Sorted-split lo (subst Sorted recomb s)
+
+      loB = split .fst
+      slo = split .snd .fst
+      hiB = split .snd .snd .fst
+      shi = split .snd .snd .snd
+
+      lo≺ : lo ≺ full
+      lo≺ = ≤-trans (length-take-≤ k full) (half< (length xs'))
+      hi≺ : hi ≺ full
+      hi≺ = length-drop-≤ k xs'
+
+      fromLo : Member lo → Member full
+      fromLo q∈lo = subst (q ∈_) (sym recomb) (∈-++ˡ q∈lo)
+      fromHi : Member hi → Member full
+      fromHi q∈hi = subst (q ∈_) (sym recomb) (∈-++ʳ lo (inr q∈hi))
+
+      go : Trichotomy q mid → ⟨ Hob Inp full ⟩
+      go (eq q≡mid) =
+        inr (inl (subst (q ∈_) (sym recomb) (∈-++ʳ lo (inl q≡mid))))
+      go (lt q<mid) = inr (inr (lo , lo≺ , (toLo , fromLo) , slo))
+        where
+          ¬q∈hi : ¬ (q ∈ hi)
+          ¬q∈hi q∈hi = ¬m<m (≤<-trans (All-∈ hiB q∈hi) q<mid)
+          toLo : Member full → Member lo
+          toLo m with ∈-++⁻ lo (subst (q ∈_) recomb m)
+          ... | inl q∈lo        = q∈lo
+          ... | inr (inl q≡mid) = ⊥.rec (<→≢ q<mid q≡mid)
+          ... | inr (inr q∈hi)  = ⊥.rec (¬q∈hi q∈hi)
+      go (gt mid<q) = inr (inr (hi , hi≺ , (toHi , fromHi) , shi))
+        where
+          ¬q∈lo : ¬ (q ∈ lo)
+          ¬q∈lo q∈lo = ¬m<m (≤<-trans (All-∈ loB q∈lo) mid<q)
+          toHi : Member full → Member hi
+          toHi m with ∈-++⁻ lo (subst (q ∈_) recomb m)
+          ... | inl q∈lo        = ⊥.rec (¬q∈lo q∈lo)
+          ... | inr (inl q≡mid) = ⊥.rec (<→≢ mid<q (sym q≡mid))
+          ... | inr (inr q∈hi)  = q∈hi
+
+  private
+    module HF = LC.HyloFam dir Hlc Inp Out coalg alg
+
+  member? : ∀ xs → Sorted xs → Dec (Member xs)
+  member? = HF.hylo .fst
+
+  search : ∀ xs → Sorted xs → Maybe (Fin (length xs))
+  search xs s with member? xs s
+  ... | yes m = just (∈→Fin m)
+  ... | no  _ = nothing
+
+private
+  s123 : Sorted (1 ∷ 2 ∷ 3 ∷ [])
+  s123 = (tt , tt , tt) , (tt , tt) , (tt , tt)
+
+  _ : map-Maybe toℕ (search 1 (1 ∷ 2 ∷ 3 ∷ []) s123) ≡ just 0
+  _ = refl
+
+  _ : map-Maybe toℕ (search 2 (1 ∷ 2 ∷ 3 ∷ []) s123) ≡ just 1
+  _ = refl
+
+  _ : map-Maybe toℕ (search 3 (1 ∷ 2 ∷ 3 ∷ []) s123) ≡ just 2
+  _ = refl
+
+  _ : search 5 (1 ∷ 2 ∷ 3 ∷ []) s123 ≡ nothing
+  _ = refl
+
+  _ : search 0 (1 ∷ 2 ∷ 3 ∷ []) s123 ≡ nothing
+  _ = refl

--- a/Cubical/Categories/Direct/Examples/Cospan.agda
+++ b/Cubical/Categories/Direct/Examples/Cospan.agda
@@ -1,0 +1,75 @@
+{-# OPTIONS --lossy-unification #-}
+-- Guarded recursion over the walking cospan
+module Cubical.Categories.Direct.Examples.Cospan where
+
+open import Cubical.Foundations.Prelude
+open import Cubical.Foundations.Isomorphism using (Iso)
+open import Cubical.Foundations.HLevels
+open import Cubical.Foundations.Structure using (⟨_⟩)
+
+open import Cubical.Data.Sigma
+open import Cubical.Data.Unit using (tt)
+open import Cubical.Data.Empty as ⊥ using ()
+open import Cubical.Data.Nat using (ℕ ; _+_ ; _·_ ; isSetℕ)
+
+open import Cubical.Categories.Category
+open import Cubical.Categories.Functor using (Functor)
+open import Cubical.Categories.Presheaf.Base using (Presheaf)
+open import Cubical.Categories.Presheaf.StrictHom.Base
+  using (PshHomStrict ; pshhom ; PshHomStrictN-homTy ; makePshHomStrictPath)
+open import Cubical.Categories.Direct.Base
+open import Cubical.Categories.Direct.Instances.Cospan
+import Cubical.Categories.Direct.StrictDownset as SD
+
+open Functor
+open Iso
+open PshHomStrict
+
+private
+  dir = CospanDirect
+
+module _ {ℓP} (P : Presheaf CospanCat ℓP) where
+  private
+    legs : ⟨ P .F-ob L ⟩ × ⟨ P .F-ob R ⟩
+         → ∀ y → ⟨ SD.↡Psh dir M .F-ob y ⟩ → ⟨ P .F-ob y ⟩
+    legs (x , y) L _       = x
+    legs (x , y) R _       = y
+    legs (x , y) M (_ , q) = ⊥.rec q
+
+    legs-hom : ∀ xy → PshHomStrictN-homTy (SD.↡Psh dir M) P (legs xy)
+    legs-hom (x , y) L L g p' p e = funExt⁻ (P .F-id) x
+    legs-hom (x , y) R R g p' p e = funExt⁻ (P .F-id) y
+    legs-hom (x , y) L R g p' p e = ⊥.rec g
+    legs-hom (x , y) R L g p' p e = ⊥.rec g
+    legs-hom (x , y) M L g p' p e = ⊥.rec g
+    legs-hom (x , y) M R g p' p e = ⊥.rec g
+    legs-hom (x , y) c M g (f' , q') p e = ⊥.rec q'
+
+  ▷M-Iso : Iso ⟨ SD.▷Psh dir P .F-ob M ⟩ (⟨ P .F-ob L ⟩ × ⟨ P .F-ob R ⟩)
+  ▷M-Iso .fun β = β .N-ob L (tt , tt) , β .N-ob R (tt , tt)
+  ▷M-Iso .inv xy = pshhom (legs xy) (legs-hom xy)
+  ▷M-Iso .sec xy = refl
+  ▷M-Iso .ret β = makePshHomStrictPath (funExt λ where
+    L → funExt λ _ → refl
+    R → funExt λ _ → refl
+    M → funExt λ { (_ , q) → ⊥.rec q })
+
+module Join (a b : ℕ) where
+  A : Ob → hSet ℓ-zero
+  A _ = ℕ , isSetℕ
+
+  step : ∀ x → ⟨ SD.▷Fam dir {ℓF = ℓ-zero} A x ⟩ → ⟨ A x ⟩
+  step L β = a + a
+  step R β = b · b
+  step M β = SD.▷FamApp dir {ℓF = ℓ-zero} A {y = L} β tt tt
+           + SD.▷FamApp dir {ℓF = ℓ-zero} A {y = R} β tt tt
+
+  join : ℕ
+  join = SD.löbFam dir {ℓF = ℓ-zero} A step M
+
+  join-eq : join ≡ (a + a) + b · b
+  join-eq = SD.löbFam-unfold dir {ℓF = ℓ-zero} A step M
+
+private
+  _ : Join.join 2 3 ≡ 13
+  _ = refl

--- a/Cubical/Categories/Direct/Examples/GCD.agda
+++ b/Cubical/Categories/Direct/Examples/GCD.agda
@@ -1,0 +1,109 @@
+{-# OPTIONS --lossy-unification #-}
+-- Intrinsically verified Euclidean algorithm as a hylomorphism
+-- Adapted from Alexandru, Urbat, Wißmann
+-- https://git8.cs.fau.de/software/intrinsically-recursive
+module Cubical.Categories.Direct.Examples.GCD where
+
+open import Cubical.Foundations.Prelude
+open import Cubical.Foundations.HLevels
+open import Cubical.Foundations.Structure using (⟨_⟩)
+
+open import Cubical.Data.Sigma
+open import Cubical.Data.Sum using (_⊎_ ; inl ; inr ; isSet⊎)
+open import Cubical.Data.Unit using (Unit ; tt ; isSetUnit)
+open import Cubical.Data.Nat using (ℕ ; zero ; suc ; isSetℕ)
+open import Cubical.Data.Nat.Mod using (_mod_ ; mod<)
+open import Cubical.Data.Nat.GCD
+  using (isGCD ; GCD ; isPropGCD ; zeroGCD ; stepGCD)
+
+open import Cubical.Categories.Category
+open import Cubical.Categories.Functor using (Functor)
+open import Cubical.Categories.Direct.Base
+open import Cubical.Categories.Direct.Instances.Nat using (ℕWFOrder ; <→Wo<)
+open import Cubical.Categories.Direct.Instances.Poset using (PosetDirect)
+import Cubical.Categories.Direct.LocallyContractive as LC
+
+open Functor
+
+private
+  dir = PosetDirect (pullbackWFOrder ℕWFOrder (isSet× isSetℕ isSetℕ) snd)
+
+open DirectNotation dir using (_≺_)
+
+Fam : Category _ _
+Fam = LC.Fam dir
+
+Hob : Category.ob Fam → Category.ob Fam
+Hob A (m , n) =
+    ( ( n ≡ 0 )
+    ⊎ ( Σ[ n₀ ∈ ℕ ] (n ≡ suc n₀) × ⟨ A (suc n₀ , m mod suc n₀) ⟩ ) )
+  , isSet⊎ (isProp→isSet (isSetℕ n 0))
+           (isSetΣ isSetℕ λ n₀ →
+             isSet× (isProp→isSet (isSetℕ n (suc n₀)))
+                    (A (suc n₀ , m mod suc n₀) .snd))
+
+mod≺ : ∀ {m n} n₀ → n ≡ suc n₀ → (suc n₀ , m mod suc n₀) ≺ (m , n)
+mod≺ {m} n₀ e =
+  subst (λ z → (suc n₀ , m mod suc n₀) ≺ (m , z)) (sym e) (<→Wo< (mod< n₀ m))
+
+Hmap : {A B : Category.ob Fam} (x : ℕ × ℕ)
+     → (∀ {y} → y ≺ x → ⟨ A y ⟩ → ⟨ B y ⟩)
+     → ⟨ Hob A x ⟩ → ⟨ Hob B x ⟩
+Hmap (m , n) f (inl e)            = inl e
+Hmap (m , n) f (inr (n₀ , e , a)) = inr (n₀ , e , f (mod≺ n₀ e) a)
+
+Hhom : {A B : Category.ob Fam} → Fam [ A , B ] → Fam [ Hob A , Hob B ]
+Hhom {A} {B} h x = Hmap {A} {B} x (λ {y} _ → h y)
+
+H : Functor Fam Fam
+H .F-ob A          = Hob A
+H .F-hom {A} {B} h = Hhom {A} {B} h
+H .F-id            = funExt λ _ → funExt λ { (inl _) → refl ; (inr _) → refl }
+H .F-seq _ _       = funExt λ _ → funExt λ { (inl _) → refl ; (inr _) → refl }
+
+Hδ : LC.▷HomActionFam dir H
+Hδ {A} {B} x β = Hmap {A} {B} x (λ q → LC.▷app dir β (inl q) q)
+
+Hlc : LC.LocallyContractiveFam dir
+Hlc = H , Hδ , λ h x → funExt λ { (inl _) → refl ; (inr _) → refl }
+
+Inp Out : Category.ob Fam
+Inp _       = Unit , isSetUnit
+Out (m , n) = GCD m n , isProp→isSet isPropGCD
+
+coalg : Fam [ Inp , H .F-ob Inp ]
+coalg (m , zero)   tt = inl refl
+coalg (m , suc n₀) tt = inr (n₀ , refl , tt)
+
+alg : Fam [ H .F-ob Out , Out ]
+alg (m , n) (inl e) =
+  m , subst (λ z → isGCD m z m) (sym e) (zeroGCD m)
+alg (m , n) (inr (n₀ , e , (d , dGCD))) =
+  d , subst (λ z → isGCD m z d) (sym e) (stepGCD dGCD)
+
+private
+  module HF = LC.HyloFam dir Hlc Inp Out coalg alg
+
+gcdGCD : ∀ m n → GCD m n
+gcdGCD m n = HF.hylo .fst (m , n) tt
+
+gcd : ℕ → ℕ → ℕ
+gcd m n = gcdGCD m n .fst
+
+gcdIsGCD : ∀ m n → isGCD m n (gcd m n)
+gcdIsGCD m n = gcdGCD m n .snd
+
+gcd-0 : ∀ m → gcd m 0 ≡ m
+gcd-0 m = cong fst (HF.hylo-unfold (m , 0) tt)
+
+gcd-suc : ∀ m n₀ → gcd m (suc n₀) ≡ gcd (suc n₀) (m mod suc n₀)
+gcd-suc m n₀ = cong fst (HF.hylo-unfold (m , suc n₀) tt)
+
+_ : gcd 12 8 ≡ 4
+_ = refl
+
+_ : gcd 48 36 ≡ 12
+_ = refl
+
+_ : gcd 96 15 ≡ 3
+_ = refl

--- a/Cubical/Categories/Direct/Examples/Hanoi.agda
+++ b/Cubical/Categories/Direct/Examples/Hanoi.agda
@@ -1,0 +1,127 @@
+{-# OPTIONS --lossy-unification #-}
+-- The tower of Hanoi as a hylomorphism
+module Cubical.Categories.Direct.Examples.Hanoi where
+
+open import Cubical.Foundations.Prelude
+open import Cubical.Foundations.HLevels
+open import Cubical.Foundations.Structure using (⟨_⟩)
+
+open import Cubical.Data.Sigma
+open import Cubical.Data.Sum using (_⊎_ ; inl ; inr ; isSet⊎)
+open import Cubical.Data.Unit using (Unit ; tt ; isSetUnit)
+open import Cubical.Data.Nat using (ℕ ; zero ; suc ; _+_ ; isSetℕ ; +-suc)
+open import Cubical.Data.Nat.Order.Recursive using (≤-refl)
+open import Cubical.Data.Fin using (Fin ; isSetFin)
+open import Cubical.Data.List using (List ; [] ; _∷_ ; _++_ ; length)
+open import Cubical.Data.List.Properties using (isOfHLevelList ; length++)
+
+open import Cubical.Categories.Category
+open import Cubical.Categories.Functor using (Functor)
+open import Cubical.Categories.Direct.Base
+open import Cubical.Categories.Direct.Instances.Nat using (ℕWFOrder)
+open import Cubical.Categories.Direct.Instances.Poset using (PosetDirect)
+import Cubical.Categories.Direct.LocallyContractive as LC
+
+open Functor
+
+private
+  dir = PosetDirect ℕWFOrder
+
+open DirectNotation dir using (_≺_ ; isProp≺)
+
+Fam : Category _ _
+Fam = LC.Fam dir
+
+Peg : Type ℓ-zero
+Peg = Fin 3
+
+isSetPeg : isSet Peg
+isSetPeg = isSetFin
+
+Move : Type ℓ-zero
+Move = Peg × Peg
+
+isSetMove : isSet Move
+isSetMove = isSet× isSetPeg isSetPeg
+
+Hob : Category.ob Fam → Category.ob Fam
+Hob A n = (Unit ⊎ (Σ[ m ∈ ℕ ] (m ≺ n) × Peg × Peg × ⟨ A m ⟩ × ⟨ A m ⟩))
+        , isSet⊎ isSetUnit
+            (isSetΣ isSetℕ λ m →
+              isSet× (isProp→isSet (isProp≺ m n))
+                (isSet× isSetPeg
+                  (isSet× isSetPeg
+                    (isSet× (A m .snd) (A m .snd)))))
+
+Hmap : {A B : Category.ob Fam} (n : ℕ)
+     → (∀ {m} → m ≺ n → ⟨ A m ⟩ → ⟨ B m ⟩)
+     → ⟨ Hob A n ⟩ → ⟨ Hob B n ⟩
+Hmap n f (inl tt) = inl tt
+Hmap n f (inr (m , lt , from , to , d₁ , d₂)) =
+  inr (m , lt , from , to , f lt d₁ , f lt d₂)
+
+Hhom : {A B : Category.ob Fam} → Fam [ A , B ] → Fam [ Hob A , Hob B ]
+Hhom {A} {B} h n = Hmap {A} {B} n (λ {m} _ → h m)
+
+H : Functor Fam Fam
+H .F-ob A          = Hob A
+H .F-hom {A} {B} h = Hhom {A} {B} h
+H .F-id            = funExt λ _ → funExt λ { (inl _) → refl ; (inr _) → refl }
+H .F-seq _ _       = funExt λ _ → funExt λ { (inl _) → refl ; (inr _) → refl }
+
+Hδ : LC.▷HomActionFam dir H
+Hδ {A} {B} n β = Hmap {A} {B} n (λ q → LC.▷app dir β (inl q) q)
+
+Hlc : LC.LocallyContractiveFam dir
+Hlc = H , Hδ , λ h n → funExt λ { (inl _) → refl ; (inr _) → refl }
+
+Inp Out : Category.ob Fam
+Inp _ = (Peg × Peg × Peg) , isSet× isSetPeg (isSet× isSetPeg isSetPeg)
+Out _ = List Move , isOfHLevelList 0 isSetMove
+
+coalg : Fam [ Inp , H .F-ob Inp ]
+coalg zero     _                = inl tt
+coalg (suc n₀) (from , to , aux) =
+  inr (n₀ , ≤-refl n₀ , from , to , (from , aux , to) , (aux , to , from))
+
+alg : Fam [ H .F-ob Out , Out ]
+alg n (inl tt)                            = []
+alg n (inr (m , _ , from , to , d₁ , d₂)) = d₁ ++ ((from , to) ∷ d₂)
+
+private
+  module HF = LC.HyloFam dir Hlc Inp Out coalg alg
+
+hanoi : ℕ → Peg → Peg → Peg → List Move
+hanoi n from to aux = HF.hylo .fst n (from , to , aux)
+
+hanoi-0 : ∀ from to aux → hanoi 0 from to aux ≡ []
+hanoi-0 from to aux = HF.hylo-unfold 0 (from , to , aux)
+
+hanoi-suc : ∀ n₀ from to aux
+          → hanoi (suc n₀) from to aux
+          ≡ hanoi n₀ from aux to ++ ((from , to) ∷ hanoi n₀ aux to from)
+hanoi-suc n₀ from to aux = HF.hylo-unfold (suc n₀) (from , to , aux)
+
+-- 2^n - 1
+hanoiLen : ℕ → ℕ
+hanoiLen zero    = 0
+hanoiLen (suc n) = suc (hanoiLen n + hanoiLen n)
+
+length-hanoi : ∀ n from to aux
+  → length (hanoi n from to aux) ≡ hanoiLen n
+length-hanoi zero    from to aux = cong length (hanoi-0 from to aux)
+length-hanoi (suc n) from to aux =
+  cong length (hanoi-suc n from to aux)
+  ∙ length++ (hanoi n from aux to) ((from , to) ∷ hanoi n aux to from)
+  ∙ cong₂ (λ a b → a + suc b)
+      (length-hanoi n from aux to) (length-hanoi n aux to from)
+  ∙ +-suc (hanoiLen n) (hanoiLen n)
+
+p0 p1 p2 : Peg
+p0 = 0 , tt
+p1 = 1 , tt
+p2 = 2 , tt
+
+_ : hanoi 2 p0 p2 p1
+  ≡ ((p0 , p1) ∷ (p0 , p2) ∷ (p1 , p2) ∷ [])
+_ = refl

--- a/Cubical/Categories/Direct/Examples/Karatsuba.agda
+++ b/Cubical/Categories/Direct/Examples/Karatsuba.agda
@@ -1,0 +1,197 @@
+{-# OPTIONS --lossy-unification #-}
+-- Intrinsically verified Karatsuba multiplication as a hylomorphism
+module Cubical.Categories.Direct.Examples.Karatsuba where
+
+open import Cubical.Foundations.Prelude
+open import Cubical.Foundations.HLevels
+open import Cubical.Foundations.Structure using (⟨_⟩)
+
+open import Cubical.Data.Sigma
+open import Cubical.Data.Sum using (_⊎_ ; inl ; inr ; isSet⊎)
+open import Cubical.Data.Unit using (Unit ; tt ; isSetUnit)
+open import Cubical.Data.Nat
+  using (ℕ ; zero ; suc ; isSetℕ ; _+_ ; _·_ ; _∸_)
+open import Cubical.Data.Nat.Properties using (+-assoc ; ∸+)
+open import Cubical.Data.Nat.Mod
+  using (≡remainder+quotient ; remainder_/_ ; quotient_/_)
+open import Cubical.Tactics.NatSolver using (solveℕ!)
+
+import Cubical.Data.Nat.Order as Ord
+
+open import Cubical.Categories.Category
+open import Cubical.Categories.Functor using (Functor)
+open import Cubical.Categories.Direct.Base
+open import Cubical.Categories.Direct.Instances.Nat using (ℕWFOrder ; <→Wo<)
+open import Cubical.Categories.Direct.Instances.Poset using (PosetDirect)
+import Cubical.Categories.Direct.LocallyContractive as LC
+
+open Functor
+
+private
+  dir = PosetDirect
+    (pullbackWFOrder ℕWFOrder (isSet× (isSet× isSetℕ isSetℕ) isSetℕ) snd)
+
+open DirectNotation dir using (_≺_ ; isProp≺)
+
+Fam : Category _ _
+Fam = LC.Fam dir
+
+B : ℕ
+B = 2
+
+_^B : ℕ → ℕ
+zero  ^B = 1
+suc h ^B = B · (h ^B)
+
+⌊_/2⌋ : ℕ → ℕ
+⌊ zero /2⌋        = zero
+⌊ suc zero /2⌋    = zero
+⌊ suc (suc n) /2⌋ = suc ⌊ n /2⌋
+
+half≤ : ∀ n → ⌊ n /2⌋ Ord.≤ n
+half≤ zero          = Ord.≤-refl
+half≤ (suc zero)    = Ord.≤-suc Ord.≤-refl
+half≤ (suc (suc n)) = Ord.suc-≤-suc (Ord.≤-suc (half≤ n))
+
+half< : ∀ n → ⌊ suc (suc n) /2⌋ Ord.< suc (suc n)
+half< n = Ord.suc-≤-suc (Ord.suc-≤-suc (half≤ n))
+
+private
+  ∸∸-cancel : ∀ a b c → (a + b + c) ∸ a ∸ b ≡ c
+  ∸∸-cancel a b c =
+    cong (_∸ b) (cong (_∸ a) (sym (+-assoc a b c)) ∙ ∸+ (b + c) a) ∙ ∸+ c b
+
+  karatsuba-identity : ∀ xlo xhi ylo yhi Bh →
+      xhi · yhi · (Bh · Bh)
+        + (((xhi + xlo) · (yhi + ylo) ∸ xhi · yhi ∸ xlo · ylo) · Bh + xlo · ylo)
+    ≡ (xlo + Bh · xhi) · (ylo + Bh · yhi)
+  karatsuba-identity xlo xhi ylo yhi Bh =
+      cong (λ w → xhi · yhi · (Bh · Bh) + (w · Bh + xlo · ylo)) subeq ∙ final
+    where
+      crosseq : (xhi + xlo) · (yhi + ylo)
+              ≡ xhi · yhi + xlo · ylo + (xhi · ylo + xlo · yhi)
+      crosseq = solveℕ!
+
+      subeq : (xhi + xlo) · (yhi + ylo) ∸ xhi · yhi ∸ xlo · ylo
+            ≡ xhi · ylo + xlo · yhi
+      subeq = cong (λ w → w ∸ xhi · yhi ∸ xlo · ylo) crosseq
+            ∙ ∸∸-cancel (xhi · yhi) (xlo · ylo) (xhi · ylo + xlo · yhi)
+
+      final : xhi · yhi · (Bh · Bh) + ((xhi · ylo + xlo · yhi) · Bh + xlo · ylo)
+            ≡ (xlo + Bh · xhi) · (ylo + Bh · yhi)
+      final = solveℕ!
+
+Hob : Category.ob Fam → Category.ob Fam
+Hob A ((x , y) , k) =
+    ( Unit
+    ⊎ ( Σ[ xlo ∈ ℕ ] Σ[ xhi ∈ ℕ ] Σ[ ylo ∈ ℕ ] Σ[ yhi ∈ ℕ ]
+        Σ[ Bh ∈ ℕ ] Σ[ k' ∈ ℕ ]
+          (((xlo , ylo) , k') ≺ ((x , y) , k))
+          × (x ≡ xlo + Bh · xhi) × (y ≡ ylo + Bh · yhi)
+          × ⟨ A ((xlo , ylo) , k') ⟩
+          × ⟨ A ((xhi + xlo , yhi + ylo) , k') ⟩
+          × ⟨ A ((xhi , yhi) , k') ⟩ ) )
+  , isSet⊎ isSetUnit
+      (isSetΣ isSetℕ λ xlo → isSetΣ isSetℕ λ xhi → isSetΣ isSetℕ λ ylo →
+       isSetΣ isSetℕ λ yhi → isSetΣ isSetℕ λ Bh → isSetΣ isSetℕ λ k' →
+         isSet× (isProp→isSet (isProp≺ _ _))
+         (isSet× (isProp→isSet (isSetℕ _ _))
+         (isSet× (isProp→isSet (isSetℕ _ _))
+         (isSet× (A ((xlo , ylo) , k') .snd)
+         (isSet× (A ((xhi + xlo , yhi + ylo) , k') .snd)
+                 (A ((xhi , yhi) , k') .snd))))))
+
+Hmap : {A B : Category.ob Fam} (idx : (ℕ × ℕ) × ℕ)
+     → (∀ {y} → y ≺ idx → ⟨ A y ⟩ → ⟨ B y ⟩)
+     → ⟨ Hob A idx ⟩ → ⟨ Hob B idx ⟩
+Hmap idx f (inl tt) = inl tt
+Hmap idx f
+  (inr (xlo , xhi , ylo , yhi , Bh , k' , lt , px , py , a0 , a1 , a2)) =
+  inr ( xlo , xhi , ylo , yhi , Bh , k' , lt , px , py
+      , f lt a0 , f lt a1 , f lt a2 )
+
+Hhom : {A B : Category.ob Fam} → Fam [ A , B ] → Fam [ Hob A , Hob B ]
+Hhom {A} {B} h idx = Hmap {A} {B} idx (λ {y} _ → h y)
+
+H : Functor Fam Fam
+H .F-ob A          = Hob A
+H .F-hom {A} {B} h = Hhom {A} {B} h
+H .F-id            = funExt λ _ → funExt λ { (inl _) → refl ; (inr _) → refl }
+H .F-seq _ _       = funExt λ _ → funExt λ { (inl _) → refl ; (inr _) → refl }
+
+Hδ : LC.▷HomActionFam dir H
+Hδ {A} {B} idx β = Hmap {A} {B} idx (λ q → LC.▷app dir β (inl q) q)
+
+Hlc : LC.LocallyContractiveFam dir
+Hlc = H , Hδ , λ h idx → funExt λ { (inl _) → refl ; (inr _) → refl }
+
+Inp : Category.ob Fam
+Inp _ = Unit , isSetUnit
+
+Out : Category.ob Fam
+Out ((x , y) , k) = (Σ[ p ∈ ℕ ] (p ≡ x · y))
+                  , isSetΣ isSetℕ λ p → isProp→isSet (isSetℕ p (x · y))
+
+coalg : Fam [ Inp , H .F-ob Inp ]
+coalg ((x , y) , zero)         tt = inl tt
+coalg ((x , y) , suc zero)     tt = inl tt
+coalg ((x , y) , suc (suc k₀)) tt =
+  inr ( remainder x / Bh , quotient x / Bh , remainder y / Bh , quotient y / Bh
+      , Bh , ⌊ suc (suc k₀) /2⌋
+      , <→Wo< (half< k₀)
+      , sym (≡remainder+quotient Bh x)
+      , sym (≡remainder+quotient Bh y)
+      , tt , tt , tt )
+  where
+    Bh : ℕ
+    Bh = ⌊ suc (suc k₀) /2⌋ ^B
+
+alg : Fam [ H .F-ob Out , Out ]
+alg ((x , y) , k) (inl tt) = x · y , refl
+alg ((x , y) , k)
+  (inr (xlo , xhi , ylo , yhi , Bh , k' , _ , px , py
+       , (p0 , e0) , (p1 , e1) , (p2 , e2))) =
+  p2 · (Bh · Bh) + ((p1 ∸ p2 ∸ p0) · Bh + p0) , proof
+  where
+    valeq : p2 · (Bh · Bh) + ((p1 ∸ p2 ∸ p0) · Bh + p0)
+          ≡ xhi · yhi · (Bh · Bh)
+              + (((xhi + xlo) · (yhi + ylo) ∸ xhi · yhi ∸ xlo · ylo) · Bh
+                 + xlo · ylo)
+    valeq i = (e2 i) · (Bh · Bh) + (((e1 i) ∸ (e2 i) ∸ (e0 i)) · Bh + (e0 i))
+
+    proof : p2 · (Bh · Bh) + ((p1 ∸ p2 ∸ p0) · Bh + p0) ≡ x · y
+    proof = valeq
+          ∙ karatsuba-identity xlo xhi ylo yhi Bh
+          ∙ cong₂ _·_ (sym px) (sym py)
+
+private
+  module HF = LC.HyloFam dir Hlc Inp Out coalg alg
+
+limbsFuel : ℕ → ℕ → ℕ
+limbsFuel zero      _       = zero
+limbsFuel (suc _)   zero    = zero
+limbsFuel (suc fu)  (suc n) = suc (limbsFuel fu ⌊ suc n /2⌋)
+
+limbsOf : ℕ → ℕ
+limbsOf n = limbsFuel n n
+
+kmulΣ : (x y : ℕ) → Σ[ p ∈ ℕ ] (p ≡ x · y)
+kmulΣ x y = HF.hylo .fst ((x , y) , limbsOf (x + y)) tt
+
+kmul : ℕ → ℕ → ℕ
+kmul x y = kmulΣ x y .fst
+
+kmul-correct : ∀ x y → kmul x y ≡ x · y
+kmul-correct x y = kmulΣ x y .snd
+
+_ : kmul 0 0 ≡ 0
+_ = refl
+
+_ : kmul 1 1 ≡ 1
+_ = refl
+
+_ : kmul 3 5 ≡ 15
+_ = refl
+
+_ : kmul 12 12 ≡ 144
+_ = refl

--- a/Cubical/Categories/Direct/Examples/ParallelPair.agda
+++ b/Cubical/Categories/Direct/Examples/ParallelPair.agda
@@ -1,0 +1,207 @@
+{-# OPTIONS --lossy-unification #-}
+-- Guarded recursion over the walking parallel pair V ⇉ E
+module Cubical.Categories.Direct.Examples.ParallelPair where
+
+open import Cubical.Foundations.Prelude
+open import Cubical.Foundations.Isomorphism using (Iso)
+open import Cubical.Foundations.HLevels
+open import Cubical.Foundations.Structure using (⟨_⟩)
+
+open import Cubical.Data.Sigma
+open import Cubical.Data.Bool using (true ; false)
+open import Cubical.Data.Unit using (tt)
+open import Cubical.Data.Empty as ⊥ using ()
+open import Cubical.Data.Int using (ℤ ; _-_ ; isSetℤ)
+
+open import Cubical.Categories.Category
+open import Cubical.Categories.Functor using (Functor)
+open import Cubical.Categories.Presheaf.Base using (Presheaf)
+open import Cubical.Categories.Presheaf.Constructions.Unit using (UnitPsh)
+open import Cubical.Categories.Presheaf.StrictHom.Base
+  using (PshHomStrict ; pshhom ; PshHomStrictN-homTy ; makePshHomStrictPath)
+open import Cubical.Categories.Direct.Base
+open import Cubical.Categories.Direct.Instances.ParallelPair
+import Cubical.Categories.Direct.StrictDownset as SD
+
+open Functor
+open Iso
+open PshHomStrict
+
+private
+  dir = ParallelPairDirect
+
+module _ {ℓP} (P : Presheaf ParallelPair ℓP) where
+  -- ▷ P at V is trivial
+  ▷V-contr : isContr ⟨ SD.▷Psh dir P .F-ob V ⟩
+  ▷V-contr .fst =
+    pshhom (λ y (f , q) → ⊥.rec q) (λ c c' g (f' , q') p e → ⊥.rec q')
+  ▷V-contr .snd β =
+    makePshHomStrictPath (funExt λ y → funExt λ (f , q) → ⊥.rec q)
+
+  private
+    ends : ⟨ P .F-ob V ⟩ × ⟨ P .F-ob V ⟩
+         → ∀ y → ⟨ SD.↡Psh dir E .F-ob y ⟩ → ⟨ P .F-ob y ⟩
+    ends (x , y) V (false , _) = x
+    ends (x , y) V (true  , _) = y
+    ends (x , y) E (_     , q) = ⊥.rec q
+
+    ends-hom : ∀ xy → PshHomStrictN-homTy (SD.↡Psh dir E) P (ends xy)
+    ends-hom xy V V g (f' , q') p e = funExt⁻ (P .F-id) _ ∙ cong (ends xy V) e
+    ends-hom xy E V g p'        p e = ⊥.rec g
+    ends-hom xy V E g (f' , q') p e = ⊥.rec q'
+    ends-hom xy E E g (f' , q') p e = ⊥.rec q'
+
+  -- ▷ P at E is a pair of vertices
+  ▷E-Iso : Iso ⟨ SD.▷Psh dir P .F-ob E ⟩ (⟨ P .F-ob V ⟩ × ⟨ P .F-ob V ⟩)
+  ▷E-Iso .fun β = β .N-ob V (s , tt) , β .N-ob V (t , tt)
+  ▷E-Iso .inv xy = pshhom (ends xy) (ends-hom xy)
+  ▷E-Iso .sec xy = refl
+  ▷E-Iso .ret β = makePshHomStrictPath (funExt λ where
+    V → funExt λ { (false , _) → refl ; (true , _) → refl }
+    E → funExt λ { (_ , q) → ⊥.rec q })
+
+  -- next is the boundary of an edge
+  next-boundary : ∀ (e : ⟨ P .F-ob E ⟩)
+    → ▷E-Iso .fun (SD.next dir P .N-ob E e) ≡ (P .F-hom s e , P .F-hom t e)
+  next-boundary e = refl
+
+module Coboundary
+  (Vt Et : hSet ℓ-zero)
+  (src tgt : ⟨ Et ⟩ → ⟨ Vt ⟩)
+  (pot : ⟨ Vt ⟩ → ℤ)
+  where
+
+  A : Ob → hSet ℓ-zero
+  A V = (⟨ Vt ⟩ → ℤ) , isSet→ isSetℤ
+  A E = (⟨ Et ⟩ → ℤ) , isSet→ isSetℤ
+
+  view : ⟨ SD.▷Fam dir {ℓF = ℓ-zero} A E ⟩
+       → ParallelPair [ V , E ] → ⟨ Vt ⟩ → ℤ
+  view β g = SD.▷FamApp dir {ℓF = ℓ-zero} A β g tt
+
+  step : ∀ x → ⟨ SD.▷Fam dir {ℓF = ℓ-zero} A x ⟩ → ⟨ A x ⟩
+  step V β = pot
+  step E β e = view β t (tgt e) - view β s (src e)
+
+  potential : ⟨ Vt ⟩ → ℤ
+  potential = SD.löbFam dir {ℓF = ℓ-zero} A step V
+
+  δ : ⟨ Et ⟩ → ℤ
+  δ = SD.löbFam dir {ℓF = ℓ-zero} A step E
+
+  potential≡pot : potential ≡ pot
+  potential≡pot = SD.löbFam-unfold dir {ℓF = ℓ-zero} A step V
+
+  δ-eq : ∀ e → δ e ≡ pot (tgt e) - pot (src e)
+  δ-eq e =
+    funExt⁻ (SD.löbFam-unfold dir {ℓF = ℓ-zero} A step E) e
+    ∙ (λ i → potential≡pot i (tgt e) - potential≡pot i (src e))
+
+  δ-uniq : (f : ⟨ Vt ⟩ → ℤ) (g : ⟨ Et ⟩ → ℤ)
+         → f ≡ pot
+         → (∀ e → g e ≡ f (tgt e) - f (src e))
+         → g ≡ δ
+  δ-uniq f g hf hg =
+    funExt⁻ (SD.löbFam-uniq-unfold dir {ℓF = ℓ-zero} A step fam fix) E
+    where
+      fam : ∀ x → ⟨ A x ⟩
+      fam V = f
+      fam E = g
+      fix : ∀ x → fam x ≡ step x (SD.nextFam dir {ℓF = ℓ-zero} A fam x)
+      fix V = hf
+      fix E = funExt hg
+
+module Example where
+  open import Cubical.Data.Bool
+    using (Bool ; true ; false ; not ; _and_ ; _⊕_ ; if_then_else_
+          ; isSetBool ; Bool→Type ; isProp-Bool→Type)
+
+  Vtx : Type
+  Vtx = Bool × Bool
+
+  v₀ v₁ v₂ v₃ : Vtx
+  v₀ = false , false
+  v₁ = false , true
+  v₂ = true  , false
+  v₃ = true  , true
+
+  eqV : Vtx → Vtx → Bool
+  eqV (a , b) (c , d) = not (a ⊕ c) and not (b ⊕ d)
+
+  hasEdge : Vtx → Vtx → Bool
+  hasEdge i j = not (eqV i j and fst i)
+
+  Edg : Type
+  Edg = Σ[ p ∈ Vtx × Vtx ] Bool→Type (hasEdge (p .fst) (p .snd))
+
+  src tgt : Edg → Vtx
+  src e = e .fst .fst
+  tgt e = e .fst .snd
+
+  loop₀ loop₁ : Edg
+  loop₀ = (v₀ , v₀) , tt
+  loop₁ = (v₁ , v₁) , tt
+
+  isSetVtx : isSet Vtx
+  isSetVtx = isSet× isSetBool isSetBool
+
+  -- Complete graph on 4 vertices + 2 self loops
+  G : Presheaf ParallelPair ℓ-zero
+  G .F-ob V = Vtx , isSetVtx
+  G .F-ob E = Edg , isSetΣ (isSet× isSetVtx isSetVtx)
+    (λ p → isProp→isSet (isProp-Bool→Type (hasEdge (p .fst) (p .snd))))
+  G .F-hom {V} {V} _ i = i
+  G .F-hom {E} {E} _ e = e
+  G .F-hom {E} {V} f ((i , j) , _) = if f then j else i
+  G .F-hom {V} {E} f = ⊥.rec f
+  G .F-id {V} = refl
+  G .F-id {E} = refl
+  G .F-seq {V} {V} {V} f g = refl
+  G .F-seq {E} {E} {E} f g = refl
+  G .F-seq {E} {E} {V} f g = refl
+  G .F-seq {E} {V} {V} f g = refl
+  G .F-seq {V} {E}     f g = ⊥.rec f
+  G .F-seq {V} {V} {E} f g = ⊥.rec g
+  G .F-seq {E} {V} {E} f g = ⊥.rec g
+
+  loopStep : (e : Edg) → tgt e ≡ src e → PshHomStrict (SD.▷Psh dir G) G
+  loopStep e q .N-ob V _ = src e
+  loopStep e q .N-ob E _ = e
+  loopStep e q .N-hom V V f     p' p _ = refl
+  loopStep e q .N-hom V E false p' p _ = refl
+  loopStep e q .N-hom V E true  p' p _ = q
+  loopStep e q .N-hom E E f     p' p _ = refl
+  loopStep e q .N-hom E V f     p' p _ = ⊥.rec f
+
+  -- Global elements of a directed graph choose of self loop,
+  -- which isn't terribly interesting
+  sect₀ sect₁ : PshHomStrict UnitPsh G
+  sect₀ = SD.löb dir G (loopStep loop₀ refl)
+  sect₁ = SD.löb dir G (loopStep loop₁ refl)
+
+  _ : sect₀ .N-ob V tt ≡ v₀
+  _ = refl
+
+  _ : sect₀ .N-ob E tt ≡ loop₀
+  _ = refl
+
+  _ : sect₁ .N-ob V tt ≡ v₁
+  _ = refl
+
+  _ : sect₁ .N-ob E tt ≡ loop₁
+  _ = refl
+
+  private
+    c₀ : ⟨ SD.▷Psh dir G .F-ob V ⟩
+    c₀ = ▷V-contr G .fst
+    β₀ : ⟨ SD.▷Psh dir G .F-ob E ⟩
+    β₀ = ▷E-Iso G .inv (v₀ , v₀)
+
+  step-self-loop : (φ : PshHomStrict (SD.▷Psh dir G) G)
+    → (src (φ .N-ob E β₀) ≡ φ .N-ob V c₀)
+    × (tgt (φ .N-ob E β₀) ≡ φ .N-ob V c₀)
+  step-self-loop φ =
+      φ .N-hom V E s β₀ _ refl
+        ∙ cong (φ .N-ob V) (sym (▷V-contr G .snd _))
+    , φ .N-hom V E t β₀ _ refl
+        ∙ cong (φ .N-ob V) (sym (▷V-contr G .snd _))

--- a/Cubical/Categories/Direct/Examples/Quicksort.agda
+++ b/Cubical/Categories/Direct/Examples/Quicksort.agda
@@ -1,0 +1,197 @@
+{-# OPTIONS --lossy-unification #-}
+-- Intrinsically correct quicksort as a hylomorphism
+--
+-- Adapted from Alexandru, Urbat, Wißmann
+-- https://git8.cs.fau.de/software/intrinsically-recursive
+module Cubical.Categories.Direct.Examples.Quicksort where
+
+open import Cubical.Foundations.Prelude
+open import Cubical.Foundations.HLevels
+open import Cubical.Foundations.Structure using (⟨_⟩)
+
+open import Cubical.Data.Sigma
+open import Cubical.Data.Sum using (_⊎_ ; inl ; inr ; isSet⊎)
+open import Cubical.Data.Unit using (tt)
+open import Cubical.Data.Bool
+  using (Bool ; true ; false ; not ; false≢true ; true≢false)
+open import Cubical.Data.Nat using (ℕ ; zero ; suc ; isSetℕ)
+open import Cubical.Data.Nat.Order.Recursive using (_≤_)
+import Cubical.Data.Nat.Order.Recursive as Ord
+open import Cubical.Data.List using (List ; [] ; _∷_ ; _++_ ; length)
+open import Cubical.Data.List.Properties using (isOfHLevelList)
+open import Cubical.Data.List.More
+  using (All ; module Ordered ; filterL ; filter-length ; All-filter-sound)
+open import Cubical.Data.Empty as ⊥ using (⊥)
+import Cubical.HITs.FiniteMultiset as FMS
+
+open import Cubical.Categories.Category
+open import Cubical.Categories.Functor using (Functor)
+open import Cubical.Categories.Direct.Base
+open import Cubical.Categories.Direct.Instances.Bag
+  using (Bag ; BagDirect ; lengthFM ; fromList ; fromList-++
+        ; lengthFM-fromList ; bagShuffle ; partitionBag
+        ; AllFM ; All→AllFM ; AllFM→All)
+import Cubical.Categories.Direct.LocallyContractive as LC
+
+open Functor
+
+private
+  dir = BagDirect ℕ
+
+open DirectNotation dir using (_≺_ ; isProp≺)
+
+Fam : Category _ _
+Fam = LC.Fam dir
+
+leq : ℕ → ℕ → Bool
+leq zero    _       = true
+leq (suc m) zero    = false
+leq (suc m) (suc n) = leq m n
+
+leq-true : ∀ y x → leq y x ≡ true → y ≤ x
+leq-true zero    x       _ = tt
+leq-true (suc y) zero    e = ⊥.rec (false≢true e)
+leq-true (suc y) (suc x) e = leq-true y x e
+
+leq-false : ∀ y x → leq y x ≡ false → x ≤ y
+leq-false zero    x       e = ⊥.rec (true≢false e)
+leq-false (suc y) zero    e = tt
+leq-false (suc y) (suc x) e = leq-false y x e
+
+not-true : ∀ b → not b ≡ true → b ≡ false
+not-true false _ = refl
+not-true true  e = ⊥.rec (false≢true e)
+
+lows highs : ℕ → List ℕ → List ℕ
+lows  piv xs = filterL (λ y → leq y piv) xs
+highs piv xs = filterL (λ y → not (leq y piv)) xs
+
+open Ordered _≤_ Ord.isProp≤ Ord.≤-trans
+
+Q≤ Q≥ : ℕ → ℕ → hProp ℓ-zero
+Q≤ piv z = (z ≤ piv) , Ord.isProp≤ {z} {piv}
+Q≥ piv z = (piv ≤ z) , Ord.isProp≤ {piv} {z}
+
+Hob : Category.ob Fam → Category.ob Fam
+Hob A b =
+  ( (b ≡ FMS.[])
+  ⊎ ( Σ[ piv ∈ ℕ ] Σ[ lo ∈ Bag ℕ ] Σ[ hi ∈ Bag ℕ ]
+        (lo ≺ b) × (hi ≺ b)
+        × (b ≡ lo FMS.++ (piv FMS.∷ hi))
+        × ⟨ AllFM (Q≤ piv) lo ⟩ × ⟨ AllFM (Q≥ piv) hi ⟩
+        × ⟨ A lo ⟩ × ⟨ A hi ⟩ ) )
+  , isSet⊎ (isProp→isSet (FMS.trunc _ _))
+      (isSetΣ isSetℕ λ piv → isSetΣ FMS.trunc λ lo → isSetΣ FMS.trunc λ hi →
+        isSet× (isProp→isSet (isProp≺ lo b))
+        (isSet× (isProp→isSet (isProp≺ hi b))
+        (isSet× (isProp→isSet (FMS.trunc _ _))
+        (isSet× (isProp→isSet (AllFM (Q≤ piv) lo .snd))
+        (isSet× (isProp→isSet (AllFM (Q≥ piv) hi .snd))
+        (isSet× (A lo .snd) (A hi .snd)))))))
+
+Hmap : {A B : Category.ob Fam} (b : Bag ℕ)
+     → (∀ {c} → c ≺ b → ⟨ A c ⟩ → ⟨ B c ⟩)
+     → ⟨ Hob A b ⟩ → ⟨ Hob B b ⟩
+Hmap b f (inl e) = inl e
+Hmap b f
+  (inr (piv , lo , hi , loLt , hiLt , recomb , loBd , hiBd , aLo , aHi)) =
+  inr ( piv , lo , hi , loLt , hiLt , recomb , loBd , hiBd
+      , f loLt aLo , f hiLt aHi )
+
+Hhom : {A B : Category.ob Fam} → Fam [ A , B ] → Fam [ Hob A , Hob B ]
+Hhom {A} {B} h b = Hmap {A} {B} b (λ {c} _ → h c)
+
+H : Functor Fam Fam
+H .F-ob A          = Hob A
+H .F-hom {A} {B} h = Hhom {A} {B} h
+H .F-id            = funExt λ _ → funExt λ { (inl _) → refl ; (inr _) → refl }
+H .F-seq _ _       = funExt λ _ → funExt λ { (inl _) → refl ; (inr _) → refl }
+
+Hδ : LC.▷HomActionFam dir H
+Hδ {A} {B} b β = Hmap {A} {B} b (λ q → LC.▷app dir β (inl q) q)
+
+Hlc : LC.LocallyContractiveFam dir
+Hlc = H , Hδ , λ h b → funExt λ { (inl _) → refl ; (inr _) → refl }
+
+Inp Out : Category.ob Fam
+Inp b = (Σ[ xs ∈ List ℕ ] (fromList xs ≡ b))
+      , isSetΣ (isOfHLevelList 0 isSetℕ)
+               (λ _ → isProp→isSet (FMS.trunc _ _))
+Out b = (Σ[ ys ∈ List ℕ ] (Sorted ys × (fromList ys ≡ b)))
+      , isSetΣ (isOfHLevelList 0 isSetℕ)
+               (λ ys → isProp→isSet
+                 (isProp× (isPropSorted ys) (FMS.trunc _ _)))
+
+coalg : Fam [ Inp , H .F-ob Inp ]
+coalg b ([] , e)     = inl (sym e)
+coalg b (x ∷ xs , e) =
+  inr ( x , fromList (lows x xs) , fromList (highs x xs)
+      , cert (λ y → leq y x) , cert (λ y → not (leq y x)) , recomb
+      , All→AllFM (Q≤ x) (lows x xs)
+          (All-filter-sound (λ y → leq y x) (_≤ x)
+            (λ y e' → leq-true y x e') xs)
+      , All→AllFM (Q≥ x) (highs x xs)
+          (All-filter-sound (λ y → not (leq y x)) (x ≤_)
+            (λ y e' → leq-false y x (not-true (leq y x) e')) xs)
+      , (lows x xs , refl)
+      , (highs x xs , refl) )
+  where
+    lenb : lengthFM b ≡ suc (length xs)
+    lenb = cong lengthFM (sym e) ∙ cong suc (lengthFM-fromList xs)
+    cert : ∀ p → fromList (filterL p xs) ≺ b
+    cert p = subst2 (λ m k → suc m ≤ k)
+               (sym (lengthFM-fromList (filterL p xs))) (sym lenb)
+               (filter-length p xs)
+    recomb : b ≡ fromList (lows x xs) FMS.++ (x FMS.∷ fromList (highs x xs))
+    recomb = sym e
+           ∙ cong (x FMS.∷_) (partitionBag (λ y → leq y x) xs)
+           ∙ bagShuffle x (fromList (lows x xs)) (fromList (highs x xs))
+
+alg : Fam [ H .F-ob Out , Out ]
+alg b (inl e) = [] , tt , sym e
+alg b (inr (piv , lo , hi , _ , _ , recomb , loBd , hiBd
+           , (ysL , sL , cL) , (ysR , sR , cR))) =
+    ysL ++ piv ∷ ysR
+  , sorted-++ ysL sL sR
+      (AllFM→All (Q≤ piv) ysL
+        (subst (λ c → ⟨ AllFM (Q≤ piv) c ⟩) (sym cL) loBd))
+      (AllFM→All (Q≥ piv) ysR
+        (subst (λ c → ⟨ AllFM (Q≥ piv) c ⟩) (sym cR) hiBd))
+  , fromList-++ ysL (piv ∷ ysR)
+    ∙ cong₂ FMS._++_ cL (cong (piv FMS.∷_) cR)
+    ∙ sym recomb
+
+private
+  module HF = LC.HyloFam dir Hlc Inp Out coalg alg
+
+qsort : (xs : List ℕ) → ⟨ Out (fromList xs) ⟩
+qsort xs = HF.hylo .fst (fromList xs) (xs , refl)
+
+sortList : List ℕ → List ℕ
+sortList xs = qsort xs .fst
+
+qsort-sorted : ∀ xs → Sorted (sortList xs)
+qsort-sorted xs = qsort xs .snd .fst
+
+qsort-contents : ∀ xs → fromList (sortList xs) ≡ fromList xs
+qsort-contents xs = qsort xs .snd .snd
+
+qsort-unfold : ∀ x xs
+  → sortList (x ∷ xs) ≡ sortList (lows x xs) ++ x ∷ sortList (highs x xs)
+qsort-unfold x xs =
+  cong fst (HF.hylo-unfold (fromList (x ∷ xs)) (x ∷ xs , refl))
+
+qsort-unique : (h : Fam [ Inp , Out ])
+  → (∀ b ξ → h b ξ ≡ alg b (Hhom {Inp} {Out} h b (coalg b ξ)))
+  → ∀ b ξ → h b ξ ≡ HF.hylo .fst b ξ
+qsort-unique = HF.hylo-uniq-unfold
+
+private
+  _ : sortList (3 ∷ 1 ∷ 2 ∷ []) ≡ 1 ∷ 2 ∷ 3 ∷ []
+  _ = refl
+
+  _ : sortList (5 ∷ 3 ∷ 8 ∷ 1 ∷ 2 ∷ []) ≡ 1 ∷ 2 ∷ 3 ∷ 5 ∷ 8 ∷ []
+  _ = refl
+
+  _ : sortList (2 ∷ 2 ∷ 1 ∷ []) ≡ 1 ∷ 2 ∷ 2 ∷ []
+  _ = refl

--- a/Cubical/Categories/Direct/Examples/ShortestPath.agda
+++ b/Cubical/Categories/Direct/Examples/ShortestPath.agda
@@ -1,0 +1,357 @@
+{-# OPTIONS --lossy-unification #-}
+-- Intrinsically verified shortest paths as a guarded fixpoint
+--
+-- It is generic over a selective ordered semiring for the graph weights.
+-- "Selective" means x ⊕ y always returns either x or y
+module Cubical.Categories.Direct.Examples.ShortestPath where
+
+open import Cubical.Foundations.Prelude
+open import Cubical.Foundations.HLevels
+open import Cubical.Foundations.Structure
+
+open import Cubical.Data.Nat using (ℕ ; zero ; suc ; isSetℕ)
+open import Cubical.Data.Nat.Order.Recursive using (_≤_)
+import Cubical.Data.Nat.Order.Recursive as Ord
+open import Cubical.Data.FinData
+  using (Fin ; zero ; suc ; discreteFin ; toℕ ; isSetFin)
+open import Cubical.Data.Vec.Base using (Vec)
+open import Cubical.Data.Vec.Properties
+  using (FinVec→Vec ; Vec→FinVec ; FinVec→Vec→FinVec ; FinVec≃Vec)
+open import Cubical.Data.Sigma
+open import Cubical.Data.Sum using (_⊎_ ; inl ; inr ; isSet⊎)
+open import Cubical.Data.Unit using (tt)
+open import Cubical.Data.Empty as ⊥ using (⊥)
+open import Cubical.Data.Bool using (Bool ; true ; false)
+open import Cubical.Relation.Nullary using (Dec ; yes ; no)
+import Cubical.Data.Equality as Eq
+
+open import Cubical.Categories.Category
+open import Cubical.Categories.Instances.BinProduct using (_×C_)
+open import Cubical.Categories.Presheaf.StrictHom.Base
+open import Cubical.Categories.Instances.DirectedGraph
+  using (GraphPsh ; module Graph ; isFiniteGraph ; Disc ; finDisc)
+open import Cubical.Categories.Direct.Base
+open import Cubical.Categories.Direct.Product using (LexWFOrder ; LexDirect)
+open import Cubical.Categories.Direct.StrictDownset
+  using (▷Fam ; ▷FamApp ; löbFam)
+open import Cubical.Categories.Direct.Instances.Nat
+  using (ℕWFOrder ; ℕCat ; ℕDirect)
+import Cubical.Categories.Direct.Instances.ParallelPair as PP
+open import Cubical.Algebra.OrderedSemiring.Selective
+open import Cubical.Algebra.OrderedSemiring.MinPlus using (MinPlusSel)
+open import Cubical.Algebra.OrderedSemiring.Bool using (BooleanSel)
+open import Cubical.Data.Maybe using (just ; nothing)
+open import Cubical.Data.Nat.More using (Cost)
+
+open PshHomStrict
+
+Listing : GraphPsh ℓ-zero → Type
+Listing Q = Σ[ n ∈ ℕ ] Σ[ vtx ∈ (Fin n → Graph.Vertex Q) ]
+              (∀ v → Σ[ i ∈ Fin n ] vtx i ≡ v)
+
+module _ (SR : SelectiveSemiring ℓ-zero) where
+  open SelectiveSemiring SR
+
+  ⨁Fin : ∀ {n} → (Fin n → R) → R
+  ⨁Fin {zero}  f = 𝟘
+  ⨁Fin {suc n} f = f zero ⊕ ⨁Fin (λ i → f (suc i))
+
+  ⨁Fin-lb : ∀ {n} (f : Fin n → R) (i : Fin n) → ⨁Fin f ⊑ f i
+  ⨁Fin-lb f zero    = ⊕-lb₁ (f zero) _
+  ⨁Fin-lb f (suc i) = ⊕-skip (f zero) (⨁Fin-lb (λ j → f (suc j)) i)
+
+  ≤suc : ∀ {j n} → j ≤ n → j ≤ suc n
+  ≤suc {j} {n} jn =
+    Ord.≤-trans {j} {n} {suc n} jn
+      (Ord.<-weaken {n} {suc n} (Ord.≤-refl (suc n)))
+
+  ShapeCat : Category ℓ-zero ℓ-zero
+  ShapeCat = ℕCat ×C PP.ParallelPair
+
+  ShapeWF : WFOrder ℓ-zero ℓ-zero
+  ShapeWF = LexWFOrder ℕWFOrder ℕWFOrder
+
+  ShapeDir : DirectStr {C = ShapeCat} ShapeWF
+  ShapeDir = LexDirect ℕDirect PP.ParallelPairDirect
+
+  open DirectNotation ShapeDir using (_≺_)
+
+  ℕid : ∀ {n} → ℕCat [ n , n ]
+  ℕid = inr Eq.refl
+  ℕup : ∀ {n} → ℕCat [ n , suc n ]
+  ℕup {n} = inl (Ord.≤-refl (suc n))
+  ↓time : ∀ {n} → (n , PP.E) ≺ (suc n , PP.E)
+  ↓time {n} = inl (Ord.≤-refl (suc n))
+  ↓layer : ∀ {n} → (n , PP.V) ≺ (n , PP.E)
+  ↓layer = inr (Eq.refl , _)
+
+  module Search (Q : GraphPsh ℓ-zero) (fin : Listing Q)
+                (weight : Graph.Vertex Q → Graph.Vertex Q → R)
+                (source : Graph.Vertex Q) where
+    open Graph Q
+    N : ℕ
+    N = fin .fst
+    vtx : Fin N → Vertex
+    vtx = fin .snd .fst
+    coverV : ∀ v → Σ[ i ∈ Fin N ] vtx i ≡ v
+    coverV = fin .snd .snd
+    w : Fin N → Fin N → R
+    w i j = weight (vtx i) (vtx j)
+    src₀ : Fin N
+    src₀ = coverV source .fst
+
+    data Walk : ℕ → Fin N → Type where
+      nil  : Walk 0 src₀
+      snoc : ∀ {k u} → Walk k u → (v : Fin N) → Walk (suc k) v
+
+    pcost : ∀ {k v} → Walk k v → R
+    pcost nil                = 𝟙
+    pcost (snoc {u = u} p v) = pcost p ⊗ w u v
+
+    WalkRep : ℕ → Fin N → Type
+    WalkRep zero    v = src₀ Eq.≡ v
+    WalkRep (suc k) v = Σ[ u ∈ Fin N ] WalkRep k u
+    isSetWalkRep : ∀ k v → isSet (WalkRep k v)
+    isSetWalkRep zero    v = isProp→isSet (isOfHLevelRetract 1
+      Eq.eqToPath Eq.pathToEq Eq.pathToEq-eqToPath (isSetFin src₀ v))
+    isSetWalkRep (suc k) v = isSetΣ isSetFin (λ u → isSetWalkRep k u)
+    toRep : ∀ {k v} → Walk k v → WalkRep k v
+    toRep nil                = Eq.refl
+    toRep (snoc {u = u} p v) = u , toRep p
+    fromRep : ∀ {k v} → WalkRep k v → Walk k v
+    fromRep {k = zero}      Eq.refl = nil
+    fromRep {k = suc k} {v} (u , r) = snoc (fromRep r) v
+    fromRep-toRep : ∀ {k v} (p : Walk k v) → fromRep (toRep p) ≡ p
+    fromRep-toRep nil        = refl
+    fromRep-toRep (snoc p v) = cong (λ q → snoc q v) (fromRep-toRep p)
+    isSetWalk : ∀ {k v} → isSet (Walk k v)
+    isSetWalk {k} {v} =
+      isOfHLevelRetract 2 toRep fromRep fromRep-toRep (isSetWalkRep k v)
+
+    relaxF : (Fin N → Fin N → R) → (Fin N → R) → Fin N → R
+    relaxF ec d v = d v ⊕ ⨁Fin (λ i → d i ⊗ ec i v)
+    relax : (Fin N → Fin N → R) → Vec R N → Vec R N
+    relax ec dv = FinVec→Vec (relaxF ec (Vec→FinVec dv))
+
+    relax-β : ∀ ec dv → Vec→FinVec (relax ec dv) ≡ relaxF ec (Vec→FinVec dv)
+    relax-β ec dv = FinVec→Vec→FinVec (relaxF ec (Vec→FinVec dv))
+
+    relax-keeps : ∀ ec d v → relaxF ec d v ⊑ d v
+    relax-keeps ec d v = ⊕-lb₁ (d v) _
+    relax-lb : ∀ ec d u v → relaxF ec d v ⊑ (d u ⊗ ec u v)
+    relax-lb ec d u v = ⊕-skip (d v) (⨁Fin-lb (λ i → d i ⊗ ec i v) u)
+
+    LowerBound : ℕ → (Fin N → R) → Type
+    LowerBound m d = ∀ {j v} (p : Walk j v) → j ≤ m → d v ⊑ pcost p
+    isPropLowerBound : ∀ m d → isProp (LowerBound m d)
+    isPropLowerBound m d = isPropImplicitΠ λ _ → isPropImplicitΠ λ _ →
+      isPropΠ λ _ → isPropΠ λ _ → isProp⊑
+
+    AchAt : ℕ → R → Fin N → Type
+    AchAt m c v =
+      (c ≡ 𝟘) ⊎ (Σ[ j ∈ ℕ ] Σ[ p ∈ Walk j v ] (j ≤ m) × (pcost p ≡ c))
+    isSetAchAt : ∀ m c v → isSet (AchAt m c v)
+    isSetAchAt m c v = isSet⊎ (isProp→isSet (isSetR c 𝟘))
+      (isSetΣ isSetℕ λ j → isSetΣ isSetWalk λ p →
+        isSet× (isProp→isSet (Ord.isProp≤ {j} {m})) (isProp→isSet (isSetR _ _)))
+    Attained : ℕ → (Fin N → R) → Type
+    Attained m d = ∀ v → AchAt m (d v) v
+    isSetAttained : ∀ m d → isSet (Attained m d)
+    isSetAttained m d = isSetΠ λ v → isSetAchAt m (d v) v
+
+    weakenA : ∀ {m c v} → AchAt m c v → AchAt (suc m) c v
+    weakenA (inl e)                 = inl e
+    weakenA (inr (j , p , le , eq)) = inr (j , p , ≤suc {j} le , eq)
+    extendA : ∀ {m c u} v → AchAt m c u → AchAt (suc m) (c ⊗ w u v) v
+    extendA {u = u} v (inl e) =
+      inl (cong (_⊗ w u v) e ∙ ⊗-annihilˡ (w u v))
+    extendA {u = u} v (inr (j , p , le , eq)) =
+      inr (suc j , snoc p v , le , cong (_⊗ w u v) eq)
+    combineA : ∀ {m c₁ c₂ v} → AchAt m c₁ v → AchAt m c₂ v → AchAt m (c₁ ⊕ c₂) v
+    combineA {m} {c₁} {c₂} {v} a₁ a₂ with ⊕-select c₁ c₂
+    ... | inl e = subst (λ c → AchAt m c v) (sym e) a₁
+    ... | inr e = subst (λ c → AchAt m c v) (sym e) a₂
+
+    base? : ∀ (v : Fin N) → Dec (src₀ ≡ v) → R
+    base? _ (yes _) = 𝟙
+    base? _ (no  _) = 𝟘
+    base : Fin N → R
+    base v = base? v (discreteFin src₀ v)
+    walk0 : ∀ {v} → src₀ ≡ v → Walk 0 v
+    walk0 e = subst (Walk 0) e nil
+    pcost-walk0 : ∀ {v} (e : src₀ ≡ v) → pcost (walk0 e) ≡ 𝟙
+    pcost-walk0 = J (λ _ e → pcost (walk0 e) ≡ 𝟙)
+      (cong pcost (substRefl {B = Walk 0} nil))
+    base?-lb : (dec : Dec (src₀ ≡ src₀)) → base? src₀ dec ⊑ 𝟙
+    base?-lb (yes _) = ⊑-refl
+    base?-lb (no ¬e) = ⊥.rec (¬e refl)
+    base?-att : ∀ v (dec : Dec (src₀ ≡ v)) → AchAt 0 (base? v dec) v
+    base?-att v (yes e) = inr (0 , walk0 e , tt , pcost-walk0 e)
+    base?-att v (no  _) = inl refl
+
+    isSetVecR : isSet (Vec R N)
+    isSetVecR = isOfHLevelRespectEquiv 2 (FinVec≃Vec N) (isSetΠ λ _ → isSetR)
+
+    Carrier : Category.ob ShapeCat → hSet ℓ-zero
+    Carrier (n , PP.V) =
+        (Σ[ ec ∈ (Fin N → Fin N → R) ] (∀ i j → ec i j ≡ w i j))
+      , isSetΣ (isSetΠ λ _ → isSetΠ λ _ → isSetR)
+               (λ _ → isProp→isSet (isPropΠ λ _ → isPropΠ λ _ → isSetR _ _))
+    Carrier (n , PP.E) =
+        ( Σ[ dv ∈ Vec R N ]
+          (LowerBound n (Vec→FinVec dv) × Attained n (Vec→FinVec dv)) )
+      , isSetΣ isSetVecR
+               (λ dv →
+                 isSet× (isProp→isSet (isPropLowerBound n (Vec→FinVec dv)))
+                              (isSetAttained n (Vec→FinVec dv)))
+
+    step : ∀ x → ⟨ ▷Fam ShapeDir {ℓF = ℓ-zero} Carrier x ⟩ → ⟨ Carrier x ⟩
+    step (n     , PP.V) β = w , λ _ _ → refl
+    step (zero  , PP.E) β = FinVec→Vec base , lb0 , att0
+      where
+        memo0 : Vec→FinVec (FinVec→Vec base) ≡ base
+        memo0 = FinVec→Vec→FinVec base
+        lb0 : LowerBound 0 (Vec→FinVec (FinVec→Vec base))
+        lb0 = subst (LowerBound 0) (sym memo0) lb0'
+          where lb0' : LowerBound 0 base
+                lb0' nil        _  = base?-lb (discreteFin src₀ src₀)
+                lb0' (snoc _ _) le = ⊥.rec le
+        att0 : Attained 0 (Vec→FinVec (FinVec→Vec base))
+        att0 = subst (Attained 0) (sym memo0) att0'
+          where att0' : Attained 0 base
+                att0' v = base?-att v (discreteFin src₀ v)
+    step (suc n , PP.E) β = relax edgeCost prevDv , lbS , attS
+      where
+        rec : ∀ y → ShapeCat [ y , (suc n , PP.E) ]
+            → y ≺ (suc n , PP.E) → ⟨ Carrier y ⟩
+        rec y g q = ▷FamApp ShapeDir {ℓF = ℓ-zero} Carrier β g q
+        prev    = rec (n , PP.E) (ℕup , PP.idH PP.E) ↓time
+        prevDv  = prev .fst
+        prevD   = Vec→FinVec prevDv
+        prevLB  = prev .snd .fst
+        prevAtt = prev .snd .snd
+        wRead   = rec (suc n , PP.V) (ℕid , true) ↓layer
+        edgeCost : Fin N → Fin N → R
+        edgeCost = wRead .fst
+        conn : Vec→FinVec (relax edgeCost prevDv) ≡ relaxF w prevD
+        conn = relax-β edgeCost prevDv
+             ∙ cong (λ ec → relaxF ec prevD)
+                 (funExt λ i → funExt λ j → wRead .snd i j)
+        lbS' : LowerBound (suc n) (relaxF w prevD)
+        lbS' nil                _  =
+          ⊑-trans (relax-keeps w prevD src₀) (prevLB nil _)
+        lbS' (snoc {u = u} p v) le =
+          ⊑-trans (relax-lb w prevD u v) (⊗-monoˡ (w u v) (prevLB p le))
+        attS' : Attained (suc n) (relaxF w prevD)
+        attS' v = combineA (weakenA (prevAtt v)) (go (λ i → i))
+          where
+            go : ∀ {k} (g : Fin k → Fin N)
+               → AchAt (suc n) (⨁Fin (λ i → prevD (g i) ⊗ w (g i) v)) v
+            go {zero}  g = inl refl
+            go {suc k} g =
+              combineA (extendA v (prevAtt (g zero))) (go (λ i → g (suc i)))
+        lbS : LowerBound (suc n) (Vec→FinVec (relax edgeCost prevDv))
+        lbS = subst (LowerBound (suc n)) (sym conn) lbS'
+        attS : Attained (suc n) (Vec→FinVec (relax edgeCost prevDv))
+        attS = subst (Attained (suc n)) (sym conn) attS'
+
+    dist : ℕ → Fin N → R
+    dist n =
+      Vec→FinVec (löbFam ShapeDir {ℓF = ℓ-zero} Carrier step (n , PP.E) .fst)
+
+    optimal : ∀ n {j v} (p : Walk j v) → j ≤ n → dist n v ⊑ pcost p
+    optimal n = löbFam ShapeDir {ℓF = ℓ-zero} Carrier step (n , PP.E) .snd .fst
+
+    attained : ∀ n v → AchAt n (dist n v) v
+    attained n = löbFam ShapeDir {ℓF = ℓ-zero} Carrier step (n , PP.E) .snd .snd
+
+    shortest : Fin N → R
+    shortest = dist N
+
+    shortest-optimal : ∀ {j v} (p : Walk j v) → j ≤ N → shortest v ⊑ pcost p
+    shortest-optimal = optimal N
+
+    shortest-attained : ∀ v → AchAt N (shortest v) v
+    shortest-attained = attained N
+
+module Example where
+  --       7
+  --   ┌─────────────────────┐
+  --   │                     ▼
+  --   │        ┌───┐  1   ┌────┐       7
+  --   │        │ 7 │ ───▶ │ 5  │ ◀─────────────────┐
+  --   │        └───┘      └────┘                   │
+  --   │              5                             │
+  --   │          ┌──────────────────────┐          │
+  --   │          │                      ▼          │
+  -- ┌───┐  5   ┌───┐  4   ┌────┐  2   ┌───┐  3   ┌───┐
+  -- │ 3 │ ◀─── │ 0 │ ───▶ │    │ ───▶ │ 4 │ ───▶ │ 6 │
+  -- └───┘      └───┘      │ 2  │      └───┘      └───┘
+  --              ▲   1    │    │  3     │
+  --              └─────── │    │ ◀──────┘
+  --                       └────┘
+  --                         │
+  --                         │ 2
+  --                         ▼
+  --                       ┌────┐
+  --                       │ 1  │
+  --                       └────┘
+  G : GraphPsh ℓ-zero
+  G = Disc 8
+  _ : isFiniteGraph G
+  _ = finDisc 8
+  finG : Listing G
+  finG = 8 , (λ i → i) , (λ v → v , refl)
+
+  wN : ℕ → ℕ → Cost
+  wN 0 2 = just 4
+  wN 0 3 = just 5
+  wN 0 4 = just 5
+  wN 2 0 = just 1
+  wN 2 1 = just 2
+  wN 2 4 = just 2
+  wN 3 5 = just 7
+  wN 4 2 = just 3
+  wN 4 6 = just 3
+  wN 6 5 = just 7
+  wN 7 5 = just 1
+  wN _ _ = nothing
+  wMP : Fin 8 → Fin 8 → Cost
+  wMP i j = wN (toℕ i) (toℕ j)
+
+  bN : ℕ → ℕ → Bool
+  bN 0 2 = true
+  bN 0 3 = true
+  bN 0 4 = true
+  bN 2 0 = true
+  bN 2 1 = true
+  bN 2 4 = true
+  bN 3 5 = true
+  bN 4 2 = true
+  bN 4 6 = true
+  bN 6 5 = true
+  bN 7 5 = true
+  bN _ _ = false
+  wB : Fin 8 → Fin 8 → Bool
+  wB i j = bN (toℕ i) (toℕ j)
+
+  v1 v2 v3 v5 v7 : Fin 8
+  v1 = suc zero
+  v2 = suc (suc zero)
+  v3 = suc (suc (suc zero))
+  v5 = suc (suc (suc (suc (suc zero))))
+  v7 = suc (suc (suc (suc (suc (suc (suc zero))))))
+
+  _ : Search.shortest MinPlusSel G finG wMP v2 v3 ≡ just 6    -- 2→0→3
+  _ = refl
+  -- 2→4→6→5 (cheaper than 2→0→3→5 = 13)
+  _ : Search.shortest MinPlusSel G finG wMP v2 v5 ≡ just 12
+  _ = refl
+  -- 7 has no in-edge: unreachable (∞)
+  _ : Search.shortest MinPlusSel G finG wMP v2 v7 ≡ nothing
+  _ = refl
+  -- this could replace Cubical.Data.Quiver.Reachability upstream
+  _ : Search.shortest BooleanSel G finG wB v2 v1 ≡ true       -- 2→1, reachable
+  _ = refl
+  _ : Search.shortest BooleanSel G finG wB v2 v7 ≡ false      -- unreachable
+  _ = refl

--- a/Cubical/Categories/Direct/Examples/Streams.agda
+++ b/Cubical/Categories/Direct/Examples/Streams.agda
@@ -1,0 +1,365 @@
+{-# OPTIONS --lossy-unification #-}
+-- Streams internal to the topos of trees
+module Cubical.Categories.Direct.Examples.Streams where
+
+open import Cubical.Foundations.Prelude
+open import Cubical.Foundations.HLevels
+open import Cubical.Foundations.Structure using (⟨_⟩)
+
+open import Cubical.Data.Sigma
+open import Cubical.Data.Unit
+open import Cubical.Data.List
+open import Cubical.Data.Maybe
+open import Cubical.Data.Nat using (ℕ ; zero ; suc ; isSetℕ)
+open import Cubical.Data.Sum using (_⊎_ ; inl ; inr)
+import Cubical.Data.Nat.Order.Recursive as R
+import Cubical.Data.Equality as Eq
+
+open import Cubical.Categories.Category
+open import Cubical.Categories.Functor using (Functor)
+open import Cubical.Categories.Functors.Constant using (Constant)
+open import Cubical.Categories.Presheaf.Base
+open import Cubical.Categories.Presheaf.Constructions.BinProduct using (_×Psh_)
+open import Cubical.Categories.Presheaf.Constructions.Unit
+open import Cubical.Categories.Presheaf.StrictHom.Base
+open import Cubical.Categories.Presheaf.StrictHom.CartesianClosed
+
+open import Cubical.Categories.Direct.Base
+open import Cubical.Categories.Direct.Instances.Nat
+  using (ℕCat ; ℕWFOrder ; ℕDirect)
+import Cubical.Categories.Direct.StrictDownset as SD
+open import Cubical.Categories.Direct.LocallyContractive
+
+open Functor
+open PshHomStrict
+
+private
+  dir = ℕDirect
+
+  wfToR : ∀ {m n} → WFOrder._≤_ ℕWFOrder m n → m R.≤ n
+  wfToR (inl lt)    = R.<-weaken lt
+  wfToR {m} (inr e) = subst (m R.≤_) (Eq.eqToPath e) (R.≤-refl m)
+
+  rToWf : ∀ {m n} → m R.≤ n → WFOrder._≤_ ℕWFOrder m n
+  rToWf le with R.≤-split le
+  ... | inl m<n = inl m<n
+  ... | inr m≡n = inr (Eq.pathToEq m≡n)
+
+  isProp↡ : ∀ n y → isProp ⟨ SD.↡Psh dir n .F-ob y ⟩
+  isProp↡ n y = isPropΣ (WFOrder.isProp≤ ℕWFOrder) (λ _ → R.isProp≤)
+
+  ▷ : Functor (PRESHEAF ℕCat ℓ-zero) (PRESHEAF ℕCat ℓ-zero)
+  ▷ = SD.▷ dir
+
+ConstP : hSet ℓ-zero → Presheaf ℕCat ℓ-zero
+ConstP S = Constant _ _ S
+
+constHom : ∀ {S T : hSet ℓ-zero} → (⟨ S ⟩ → ⟨ T ⟩)
+         → PshHomStrict (ConstP S) (ConstP T)
+constHom f .N-ob n = f
+constHom f .N-hom n n' g s' s e = cong f e
+
+constElt : ∀ {S : hSet ℓ-zero} → ⟨ S ⟩ → PshHomStrict UnitPsh (ConstP S)
+constElt s .N-ob n _ = s
+constElt s .N-hom n n' g _ _ e = refl
+
+module Streams (𝔸 : hSet ℓ-zero) where
+
+  𝔸P : Presheaf ℕCat ℓ-zero
+  𝔸P = ConstP 𝔸
+
+  F₀ : Presheaf ℕCat ℓ-zero → Presheaf ℕCat ℓ-zero
+  F₀ X = 𝔸P ×Psh (▷ .F-ob X)
+
+  F : Functor (PRESHEAF ℕCat ℓ-zero) (PRESHEAF ℕCat ℓ-zero)
+  F .F-ob = F₀
+  F .F-hom φ = idPshHomStrict ×PshHomStrict (▷ .F-hom φ)
+  F .F-id =
+    makePshHomStrictPath (funExt λ c → funExt λ p →
+      ΣPathP (refl , makePshHomStrictPath refl))
+  F .F-seq φ ψ =
+    makePshHomStrictPath (funExt λ c → funExt λ p →
+      ΣPathP (refl , makePshHomStrictPath refl))
+
+  ▷appl : ∀ {X Y : Presheaf ℕCat ℓ-zero}
+        → PshHomStrict (▷ .F-ob (X ⇒PshLargeStrict Y) ×Psh ▷ .F-ob X)
+                       (▷ .F-ob Y)
+  ▷appl {X} {Y} = ▷× dir ⋆PshHomStrict ▷ .F-hom (appPshHomStrict X Y)
+
+  Fδ : ▷HomActionPsh dir F₀
+  Fδ {X} {Y} = λPshHomStrict (F₀ X) (F₀ Y) body
+    where
+      P⇒ = ▷ .F-ob (X ⇒PshLargeStrict Y)
+      hd : PshHomStrict (P⇒ ×Psh F₀ X) 𝔸P
+      hd = π₂ _ _ ⋆PshHomStrict π₁ 𝔸P (▷ .F-ob X)
+      tl : PshHomStrict (P⇒ ×Psh F₀ X) (▷ .F-ob Y)
+      tl = ×PshIntroStrict (π₁ _ _) (π₂ _ _ ⋆PshHomStrict π₂ 𝔸P (▷ .F-ob X))
+           ⋆PshHomStrict ▷appl
+      body : PshHomStrict (P⇒ ×Psh F₀ X) (F₀ Y)
+      body = ×PshIntroStrict hd tl
+
+  Flaw : isContractiveHomAction dir F Fδ
+  Flaw {X} {Y} h = makePshHomStrictPath (funExt λ n → funExt λ (a₀ , β) →
+    ΣPathP (refl ,
+      sym ( cong (λ z → ▷appl {X} {Y} .N-ob n (z , β))
+              (funExt⁻ (▷ .F-ob (X ⇒PshLargeStrict Y) .F-id)
+                 (▷transpose dir h .N-ob n tt))
+          ∙ makePshHomStrictPath refl )))
+
+  Fstream : LocallyContractive dir
+  Fstream = F , Fδ , Flaw
+
+  Str : Presheaf ℕCat ℓ-zero
+  Str .F-ob n =
+    ((k : ℕ) → k R.≤ n → ⟨ 𝔸 ⟩) , isSetΠ λ _ → isSetΠ λ _ → 𝔸 .snd
+  Str .F-hom f s k k≤ = s k (R.≤-trans k≤ (wfToR f))
+  Str .F-id =
+    funExt λ s → funExt λ k → funExt λ k≤ → cong (s k) (R.isProp≤ _ _)
+  Str .F-seq f g =
+    funExt λ s → funExt λ k → funExt λ k≤ → cong (s k) (R.isProp≤ _ _)
+
+  unroll : PshHomStrict Str (F₀ Str)
+  unroll .N-ob n s = (s 0 tt) , tailα
+    where
+      tailα : PshHomStrict (SD.↡Psh dir n) Str
+      tailα .N-ob y (f , q) k k≤y =
+        s (suc k) (R.≤-trans {suc k} {suc y} {n} k≤y q)
+      tailα .N-hom y y' g (f' , q') (f , q) e =
+        funExt λ k → funExt λ k≤y → cong (s (suc k)) (R.isProp≤ _ _)
+  unroll .N-hom n n' f s' s e =
+    ΣPathP ( cong (s' 0) (R.isProp≤ _ _) ∙ (λ i → e i 0 tt)
+           , makePshHomStrictPath (funExt λ y → funExt λ (g , r) →
+               funExt λ k → funExt λ k≤y →
+                 cong (s' (suc k)) (R.isProp≤ _ _)
+                 ∙ (λ i → e i (suc k) (R.≤-trans {suc k} {suc y} {n} k≤y r)) ) )
+
+  roll : PshHomStrict (F₀ Str) Str
+  roll .N-ob n (a , α) zero     k≤n = a
+  roll .N-ob n (a , α) (suc k') k≤n =
+    α .N-ob k' (inl k≤n , k≤n) k' (R.≤-refl k')
+  roll .N-hom n n' f (a' , α') (a , α) e =
+    funExt λ { zero    → funExt λ k≤n → cong fst e
+             ; (suc k') → funExt λ k≤n →
+                 cong (λ z → α' .N-ob k' z k' (R.≤-refl k')) (isProp↡ n' k' _ _)
+                 ∙ (λ i → (cong snd e i) .N-ob k' (inl k≤n , k≤n) k'
+                            (R.≤-refl k')) }
+
+  unroll-roll : unroll ⋆PshHomStrict roll ≡ idPshHomStrict
+  unroll-roll = makePshHomStrictPath (funExt λ n → funExt λ s →
+    funExt λ { zero     → funExt λ k≤n → cong (s zero)     (R.isProp≤ _ _)
+             ; (suc k') → funExt λ k≤n → cong (s (suc k')) (R.isProp≤ _ _) })
+
+  roll-unroll : roll ⋆PshHomStrict unroll ≡ idPshHomStrict
+  roll-unroll = makePshHomStrictPath (funExt λ n → funExt λ (a , α) →
+    ΣPathP ( refl
+           , makePshHomStrictPath (funExt λ y → funExt λ (g , q) →
+               funExt λ k → funExt λ k≤y →
+                 let wf  = rToWf k≤y
+                     nat = α .N-hom k y wf (g , q)
+                             (SD.↡Psh dir n .F-hom wf (g , q)) refl
+                 in cong (λ z → α .N-ob k z k (R.≤-refl k)) (isProp↡ n k _ _)
+                    ∙ sym (λ i → nat i k (R.≤-refl k))
+                    ∙ cong (α .N-ob y (g , q) k) (R.isProp≤ _ _) ) ) )
+
+  unfoldˢ : (X : Presheaf ℕCat ℓ-zero)
+          → PshHomStrict X (F₀ X) → PshHomStrict X Str
+  unfoldˢ X c = HyloPsh.hylo dir Fstream X Str c roll .fst
+
+  foldˢ : (B : Presheaf ℕCat ℓ-zero)
+        → PshHomStrict (F₀ B) B → PshHomStrict Str B
+  foldˢ B a = HyloPsh.hylo dir Fstream Str B unroll a .fst
+
+  headˢ : PshHomStrict Str 𝔸P
+  headˢ = unroll ⋆PshHomStrict π₁ 𝔸P (▷ .F-ob Str)
+
+  tailˢ : PshHomStrict Str (▷ .F-ob Str)
+  tailˢ = unroll ⋆PshHomStrict π₂ 𝔸P (▷ .F-ob Str)
+
+  elt : PshHomStrict UnitPsh Str → ℕ → ⟨ 𝔸 ⟩
+  elt g k = g .N-ob k tt k (R.≤-refl k)
+
+  takeˢ : ℕ → PshHomStrict UnitPsh Str → List (⟨ 𝔸 ⟩)
+  takeˢ zero s = [ elt s zero ]
+  takeˢ (suc n) s = takeˢ n s ∷ʳ elt s (suc n)
+
+  consˢ : PshHomStrict (F₀ Str) Str
+  consˢ = roll
+
+  repeatˢ : PshHomStrict 𝔸P Str
+  repeatˢ = unfoldˢ 𝔸P (×PshIntroStrict idPshHomStrict (SD.next dir 𝔸P))
+
+  mapˢ : PshHomStrict 𝔸P 𝔸P → PshHomStrict Str Str
+  mapˢ g = unfoldˢ Str (unroll ⋆PshHomStrict (g ×PshHomStrict idPshHomStrict))
+
+  module _ (X : Presheaf ℕCat ℓ-zero) (c : PshHomStrict X (F₀ X)) where
+    private
+      module H = HyloPsh dir Fstream X Str c roll
+
+    unfoldˢ-coalg :
+      unfoldˢ X c ⋆PshHomStrict unroll ≡ c ⋆PshHomStrict F .F-hom (unfoldˢ X c)
+    unfoldˢ-coalg =
+      cong (_⋆PshHomStrict unroll) (H.hylo .snd)
+      ∙ cong (λ z → c ⋆PshHomStrict (F .F-hom (unfoldˢ X c) ⋆PshHomStrict z))
+          roll-unroll
+
+    unfoldˢ-head : unfoldˢ X c ⋆PshHomStrict headˢ
+                 ≡ c ⋆PshHomStrict π₁ 𝔸P (▷ .F-ob X)
+    unfoldˢ-head =
+      makePshHomStrictPath refl
+      ∙ cong (_⋆PshHomStrict π₁ 𝔸P (▷ .F-ob Str)) unfoldˢ-coalg
+      ∙ makePshHomStrictPath refl
+
+    unfoldˢ-tail :
+      unfoldˢ X c ⋆PshHomStrict tailˢ
+      ≡ (c ⋆PshHomStrict π₂ 𝔸P (▷ .F-ob X)) ⋆PshHomStrict ▷ .F-hom (unfoldˢ X c)
+    unfoldˢ-tail =
+      makePshHomStrictPath refl
+      ∙ cong (_⋆PshHomStrict π₂ 𝔸P (▷ .F-ob Str)) unfoldˢ-coalg
+      ∙ makePshHomStrictPath refl
+
+  mooreCoalg : (S : hSet ℓ-zero) (out : ⟨ S ⟩ → ⟨ 𝔸 ⟩) (nxt : ⟨ S ⟩ → ⟨ S ⟩)
+             → PshHomStrict (ConstP S) (F₀ (ConstP S))
+  mooreCoalg S out nxt =
+    ×PshIntroStrict (constHom out)
+      (constHom nxt ⋆PshHomStrict SD.next dir (ConstP S))
+
+  moore : (S : hSet ℓ-zero) (out : ⟨ S ⟩ → ⟨ 𝔸 ⟩) (nxt : ⟨ S ⟩ → ⟨ S ⟩)
+        → PshHomStrict (ConstP S) Str
+  moore S out nxt = unfoldˢ (ConstP S) (mooreCoalg S out nxt)
+
+  moore-head : (S : hSet ℓ-zero) (out : ⟨ S ⟩ → ⟨ 𝔸 ⟩) (nxt : ⟨ S ⟩ → ⟨ S ⟩)
+             → moore S out nxt ⋆PshHomStrict headˢ ≡ constHom out
+  moore-head S out nxt = unfoldˢ-head (ConstP S) (mooreCoalg S out nxt)
+
+  moore-tail : (S : hSet ℓ-zero) (out : ⟨ S ⟩ → ⟨ 𝔸 ⟩) (nxt : ⟨ S ⟩ → ⟨ S ⟩)
+             → moore S out nxt ⋆PshHomStrict tailˢ
+               ≡ (constHom nxt ⋆PshHomStrict SD.next dir (ConstP S))
+                 ⋆PshHomStrict ▷ .F-hom (moore S out nxt)
+  moore-tail S out nxt = unfoldˢ-tail (ConstP S) (mooreCoalg S out nxt)
+
+-- Fibonacci as a Moore machine on state ℕ × ℕ
+module Fibonacci where
+  open import Cubical.Data.Nat using (_+_)
+  open Streams (ℕ , isSetℕ)
+
+  ℕ×ℕ : hSet ℓ-zero
+  ℕ×ℕ = (ℕ × ℕ) , isSet× isSetℕ isSetℕ
+
+  fibNext : ℕ × ℕ → ℕ × ℕ
+  fibNext (a , b) = (b , a + b)
+
+  fibStr : PshHomStrict (ConstP ℕ×ℕ) Str
+  fibStr = moore ℕ×ℕ fst fibNext
+
+  fib-head : fibStr ⋆PshHomStrict headˢ ≡ constHom fst
+  fib-head = moore-head ℕ×ℕ fst fibNext
+
+  fib-tail : fibStr ⋆PshHomStrict tailˢ
+           ≡ (constHom fibNext ⋆PshHomStrict SD.next dir (ConstP ℕ×ℕ))
+             ⋆PshHomStrict ▷ .F-hom fibStr
+  fib-tail = moore-tail ℕ×ℕ fst fibNext
+
+  fib : PshHomStrict UnitPsh Str
+  fib = constElt (0 , 1) ⋆PshHomStrict fibStr
+
+  _ : takeˢ 7 fib ≡ 0 ∷ 1 ∷ 1 ∷ 2 ∷ 3 ∷ 5 ∷ 8 ∷ 13 ∷ []
+  _ = refl
+
+-- primality, decided by Löb induction
+-- n is prime iff it is indivisible by every smaller prime
+-- this is overkill, as we could actually stop at primes bound by sqrt
+module Primality where
+  open import Cubical.Data.Bool using (Bool ; true ; false ; Dec→Bool)
+  open import Cubical.Data.Empty as ⊥ using ()
+  open import Cubical.Data.Nat.Mod using (_mod_)
+  open import Cubical.Data.Nat.Properties using (discreteℕ)
+  open import Cubical.Relation.Nullary using (¬_ ; Dec ; yes ; no ; isProp¬)
+  open import Cubical.Relation.Nullary.Properties using (isPropDec)
+  open import Cubical.Relation.Nullary.More using (Dec× ; Dec¬ ; Dec→)
+
+  decAllBelow : (n : ℕ) (Q : ∀ p → p R.< n → Type)
+                (dQ : ∀ p (q : p R.< n) → Dec (Q p q))
+              → Dec (∀ p (q : p R.< n) → Q p q)
+  decAllBelow zero    Q dQ = yes λ p q → ⊥.rec q
+  decAllBelow (suc m) Q dQ =
+    combine
+      (decAllBelow m (λ p q → Q p (R.<-weaken q)) (λ p q → dQ p (R.<-weaken q)))
+      (dQ m (R.≤-refl m))
+    where
+      combine : Dec (∀ p (q : p R.< m) → Q p (R.<-weaken q))
+              → Dec (Q m (R.≤-refl m))
+              → Dec (∀ p (q : p R.< suc m) → Q p q)
+      combine (no ¬rec) _        = no λ f → ¬rec λ p q → f p (R.<-weaken q)
+      combine (yes _)   (no ¬pm) = no λ f → ¬pm (f m (R.≤-refl m))
+      combine (yes rec) (yes pm) = yes λ p q → resolve p q (R.≤-split q)
+        where
+          resolve : ∀ p (q : p R.< suc m) → (p R.< m) ⊎ (p ≡ m) → Q p q
+          resolve p q (inl p<m) = subst (Q p) (R.isProp≤ _ _) (rec p p<m)
+          resolve p q (inr p≡m) = transport (λ i → Q (p≡m (~ i)) (qPath i)) pm
+            where
+              qPath : PathP (λ i → (p≡m (~ i)) R.< suc m) (R.≤-refl m) q
+              qPath = isProp→PathP (λ _ → R.isProp≤) (R.≤-refl m) q
+
+  A : ℕ → hSet (ℓ-suc ℓ-zero)
+  A n = (Σ[ P ∈ hProp ℓ-zero ] Dec ⟨ P ⟩)
+      , isSetΣ isSetHProp (λ P → isProp→isSet (isPropDec (P .snd)))
+
+  step : ∀ n → ⟨ SD.▷Fam dir {ℓF = ℓ-suc ℓ-zero} A n ⟩ → ⟨ A n ⟩
+  step n β = IsPrime , decIsPrime
+    where
+      primeBelow : ∀ p → p R.< n → ⟨ A p ⟩
+      primeBelow p q = SD.▷FamApp dir {ℓF = ℓ-suc ℓ-zero} A β (inl q) q
+
+      PassesTrial : ∀ p → p R.< n → Type
+      PassesTrial p q = ⟨ primeBelow p q .fst ⟩ → ¬ (n mod p ≡ 0)
+
+      IsPrime : hProp ℓ-zero
+      IsPrime = ((2 R.≤ n) × (∀ p (q : p R.< n) → PassesTrial p q))
+        , isProp× R.isProp≤ (isPropΠ2 λ p q → isPropΠ λ _ → isProp¬ _)
+
+      decIsPrime : Dec ⟨ IsPrime ⟩
+      decIsPrime = Dec× (2 R.≤? n)
+        (decAllBelow n PassesTrial λ p q →
+          Dec→ (primeBelow p q .snd) (Dec¬ (discreteℕ (n mod p) 0)))
+
+  fixP : ∀ n → ⟨ A n ⟩
+  fixP = SD.löbFam dir {ℓF = ℓ-suc ℓ-zero} A step
+
+  Prime : ℕ → Type
+  Prime n = ⟨ fst (fixP n) ⟩
+
+  decPrime : ∀ n → Dec (Prime n)
+  decPrime n = snd (fixP n)
+
+  isPropPrime : ∀ n → isProp (Prime n)
+  isPropPrime n = fst (fixP n) .snd
+
+  -- Description of primality using Löb unfolding
+  Prime-characterization : ∀ n
+    → Prime n
+    ≡ ((2 R.≤ n) × (∀ p (q : p R.< n) → Prime p → ¬ (n mod p ≡ 0)))
+  Prime-characterization n =
+    cong (λ d → ⟨ d .fst ⟩)
+      (SD.löbFam-unfold dir {ℓF = ℓ-suc ℓ-zero} A step n)
+
+  PrimeDec : hSet ℓ-zero
+  PrimeDec = (Σ[ n ∈ ℕ ] Dec (Prime n))
+           , isSetΣ isSetℕ (λ n → isProp→isSet (isPropDec (isPropPrime n)))
+
+  prime? : ⟨ PrimeDec ⟩ → Maybe ℕ
+  prime? (n , yes p) = just n
+  prime? (n , no ¬p) = nothing
+
+  open Streams PrimeDec
+
+  primesStr : PshHomStrict (ConstP (ℕ , isSetℕ)) Str
+  primesStr = moore (ℕ , isSetℕ) (λ n → n , decPrime n) suc
+
+  primes : PshHomStrict UnitPsh Str
+  primes = constElt 0 ⋆PshHomStrict primesStr
+
+  primesUpTo : ℕ → List ℕ
+  primesUpTo n = filterMap prime? (takeˢ n primes)
+
+  _ : primesUpTo 20 ≡ 2 ∷ 3 ∷ 5 ∷ 7 ∷ 11 ∷ 13 ∷ 17 ∷ 19 ∷ []
+  _ = refl

--- a/Cubical/Categories/Direct/Examples/Unification.agda
+++ b/Cubical/Categories/Direct/Examples/Unification.agda
@@ -1,0 +1,257 @@
+-- First-order unification as Löb induction over thinnings
+--
+-- McBride, "First-order unification by structural recursion" (JFP 2003)
+-- https://doi.org/10.1017/S0956796803004957
+module Cubical.Categories.Direct.Examples.Unification where
+
+open import Cubical.Foundations.Prelude
+open import Cubical.Foundations.HLevels
+open import Cubical.Foundations.Structure using (⟨_⟩)
+
+open import Cubical.Data.Sigma
+import Cubical.Data.Sum as Sum
+open import Cubical.Data.Unit using (Unit ; tt ; isPropUnit)
+open import Cubical.Data.Empty as ⊥ using (⊥)
+open import Cubical.Data.Maybe as Maybe
+  using (Maybe ; just ; nothing ; isOfHLevelMaybe)
+open import Cubical.Data.Nat using (ℕ ; zero ; suc ; _+_ ; isSetℕ)
+open import Cubical.Data.Nat.Order.Recursive using (_≤_)
+open import Cubical.Data.List using (List ; [] ; _∷_ ; length)
+open import Cubical.Data.List.Properties using (isOfHLevelList)
+import Cubical.Data.Equality as Eq
+
+open import Cubical.Categories.Direct.Base
+open import Cubical.Categories.Direct.Instances.Thinnings
+import Cubical.Categories.Direct.StrictDownset as SD
+
+module Unify (A : Type) (isSetA : isSet A) where
+  private
+    dir = ThinDirect A isSetA
+
+  open DirectNotation dir using (_≺_)
+
+  private
+    variable
+      xs ys zs : List A
+
+  data Tm (xs : List A) : Type where
+    var  : Var xs → Tm xs
+    leaf : Tm xs
+    fork : Tm xs → Tm xs → Tm xs
+
+  private
+    Cover : Tm xs → Tm xs → Type
+    Cover (var x)    (var y)    = x ≡ y
+    Cover leaf       leaf       = Unit
+    Cover (fork s t) (fork u v) = Cover s u × Cover t v
+    Cover _          _          = ⊥
+
+    reflCover : (t : Tm xs) → Cover t t
+    reflCover (var x)    = refl
+    reflCover leaf       = tt
+    reflCover (fork s t) = reflCover s , reflCover t
+
+    encode : {t u : Tm xs} → t ≡ u → Cover t u
+    encode {t = t} e = subst (Cover t) e (reflCover t)
+
+    decode : (t u : Tm xs) → Cover t u → t ≡ u
+    decode (var x)    (var y)    e        = cong var e
+    decode (var x)    leaf       c        = ⊥.rec c
+    decode (var x)    (fork u v) c        = ⊥.rec c
+    decode leaf       (var y)    c        = ⊥.rec c
+    decode leaf       leaf       _        = refl
+    decode leaf       (fork u v) c        = ⊥.rec c
+    decode (fork s t) (var y)    c        = ⊥.rec c
+    decode (fork s t) leaf       c        = ⊥.rec c
+    decode (fork s t) (fork u v) (c , c') =
+      cong₂ fork (decode s u c) (decode t v c')
+
+    decode-refl : (t : Tm xs) → decode t t (reflCover t) ≡ refl
+    decode-refl (var x)    = refl
+    decode-refl leaf       = refl
+    decode-refl (fork s t) =
+      λ i → cong₂ fork (decode-refl s i) (decode-refl t i)
+
+    decode-encode : {t u : Tm xs} (e : t ≡ u) → decode _ _ (encode e) ≡ e
+    decode-encode {t = t} =
+      J (λ u e → decode t u (encode e) ≡ e)
+        (cong (decode t t) (substRefl {B = Cover t} (reflCover t))
+         ∙ decode-refl t)
+
+    isPropCover : (t u : Tm xs) → isProp (Cover t u)
+    isPropCover {xs} (var x) (var y) = isSetVar xs x y
+    isPropCover (var x)    leaf       = ⊥.isProp⊥
+    isPropCover (var x)    (fork u v) = ⊥.isProp⊥
+    isPropCover leaf       (var y)    = ⊥.isProp⊥
+    isPropCover leaf       leaf       = isPropUnit
+    isPropCover leaf       (fork u v) = ⊥.isProp⊥
+    isPropCover (fork s t) (var y)    = ⊥.isProp⊥
+    isPropCover (fork s t) leaf       = ⊥.isProp⊥
+    isPropCover (fork s t) (fork u v) =
+      isProp× (isPropCover s u) (isPropCover t v)
+
+  isSetTm : isSet (Tm xs)
+  isSetTm t u =
+    isOfHLevelRetract 1 encode (decode t u) decode-encode (isPropCover t u)
+
+  private
+    map2Maybe : {X Y Z : Type} → (X → Y → Z) → Maybe X → Maybe Y → Maybe Z
+    map2Maybe f (just x) (just y) = just (f x y)
+    map2Maybe f (just x) nothing  = nothing
+    map2Maybe f nothing  _        = nothing
+
+  check : (x : Var xs) → Tm xs → Maybe (Tm (delete xs x))
+  check x (var y)    = Sum.rec (λ _ → nothing) (λ y' → just (var y'))
+                               (thick x y)
+  check x leaf       = just leaf
+  check x (fork s t) = map2Maybe fork (check x s) (check x t)
+
+  bind : (Var xs → Tm ys) → Tm xs → Tm ys
+  bind f (var y)    = f y
+  bind f leaf       = leaf
+  bind f (fork s t) = fork (bind f s) (bind f t)
+
+  for : (x : Var xs) → Tm (delete xs x) → Var xs → Tm (delete xs x)
+  for x t y = Sum.rec (λ _ → t) var (thick x y)
+
+  subst1 : (x : Var xs) → Tm (delete xs x) → Tm xs → Tm (delete xs x)
+  subst1 x t = bind (for x t)
+
+  Steps : ℕ → List A → List A → Type
+  Steps zero    xs ys = xs Eq.≡ ys
+  Steps (suc n) xs ys =
+    Σ[ x ∈ Var xs ] Tm (delete xs x) × Steps n (delete xs x) ys
+
+  AList : List A → List A → Type
+  AList xs ys = Σ[ n ∈ ℕ ] Steps n xs ys
+
+  isSetSteps : ∀ n (xs ys : List A) → isSet (Steps n xs ys)
+  isSetSteps zero    xs ys = isProp→isSet (isPropEqList isSetA xs ys)
+  isSetSteps (suc n) xs ys = isSetΣ (isSetVar xs) λ x →
+    isSet× isSetTm (isSetSteps n (delete xs x) ys)
+
+  isSetAList : isSet (AList xs ys)
+  isSetAList = isSetΣ isSetℕ λ n → isSetSteps n _ _
+
+  applySteps : ∀ {n} → Steps n xs ys → Tm xs → Tm ys
+  applySteps {n = zero}  Eq.refl     t = t
+  applySteps {n = suc n} (x , u , σ) t = applySteps σ (subst1 x u t)
+
+  applyA : AList xs ys → Tm xs → Tm ys
+  applyA (n , σ) = applySteps σ
+
+  appendSteps : ∀ {m n} → Steps m xs ys → Steps n ys zs → Steps (m + n) xs zs
+  appendSteps {m = zero}  Eq.refl     τ = τ
+  appendSteps {m = suc m} (x , u , σ) τ = x , u , appendSteps σ τ
+
+  _⋆A_ : AList xs ys → AList ys zs → AList xs zs
+  (m , σ) ⋆A (n , τ) = m + n , appendSteps σ τ
+
+  stepsThin : ∀ {n} → Steps n xs ys → Thin ys xs
+  stepsThin {n = zero}  Eq.refl     = idThin _
+  stepsThin {n = suc n} (x , u , σ) = seqThin (stepsThin σ) (faceThin x)
+
+  alistThin : AList xs ys → Thin ys xs
+  alistThin (n , σ) = stepsThin σ
+
+  steps-strict : ∀ {n} → Steps (suc n) xs ys → ys ≺ xs
+  steps-strict {xs = xs} {ys = ys} (x , u , σ) =
+    subst (λ k → suc (length ys) ≤ k) (length-delete xs x)
+          (thin-length (stepsThin σ))
+
+  Result : List A → Type
+  Result xs = Maybe (Σ[ ys ∈ List A ] AList xs ys)
+
+  isSetResult : ∀ xs → isSet (Result xs)
+  isSetResult xs = isOfHLevelMaybe 0
+    (isSetΣ (isOfHLevelList 0 isSetA) λ ys → isSetAList)
+
+  M : List A → hSet ℓ-zero
+  M xs = (Tm xs → Tm xs → Result xs) , isSetΠ2 λ _ _ → isSetResult xs
+
+  unifyStep : ∀ xs → ⟨ SD.▷Fam dir {ℓF = ℓ-zero} M xs ⟩ → ⟨ M xs ⟩
+  unifyStep xs β = go
+    where
+      recur : AList xs ys → ys ≺ xs → Tm ys → Tm ys → Result ys
+      recur σ q = SD.▷FamApp dir {ℓF = ℓ-zero} M β (alistThin σ) q
+
+      noop : Result xs
+      noop = just (xs , 0 , Eq.refl)
+
+      solve : (x : Var xs) → Tm (delete xs x) → Result xs
+      solve x t = just (delete xs x , 1 , x , t , Eq.refl)
+
+      flexRigid : Var xs → Tm xs → Result xs
+      flexRigid x t = Maybe.rec nothing (solve x) (check x t)
+
+      flexFlex : Var xs → Var xs → Result xs
+      flexFlex x y = Sum.rec (λ _ → noop) (λ y' → solve x (var y'))
+                             (thick x y)
+
+      go : Tm xs → Tm xs → Result xs
+      go (var x)      (var y)      = flexFlex x y
+      go (var x)      t            = flexRigid x t
+      go t            (var y)      = flexRigid y t
+      go leaf         leaf         = noop
+      go leaf         (fork _ _)   = nothing
+      go (fork _ _)   leaf         = nothing
+      go (fork s₁ t₁) (fork s₂ t₂) = afterL (go s₁ s₂)
+        where
+          afterL : Result xs → Result xs
+          afterL nothing                     = nothing
+          afterL (just (_ , zero , Eq.refl)) = go t₁ t₂
+          afterL (just (ys , suc n , σ))     =
+            afterR (recur (suc n , σ) (steps-strict σ)
+                      (applySteps σ t₁) (applySteps σ t₂))
+            where
+              afterR : Result ys → Result xs
+              afterR nothing         = nothing
+              afterR (just (zs , τ)) = just (zs , (suc n , σ) ⋆A τ)
+
+  -- unification through Löb induction on thinnings
+  unify : ∀ xs → Tm xs → Tm xs → Result xs
+  unify = SD.löbFam dir {ℓF = ℓ-zero} M unifyStep
+
+private module U = Unify ℕ isSetℕ
+
+private
+  ex why : ℕ
+  ex = 0
+  why = 1
+
+  -- A scope of two unknowns
+  sc : List ℕ
+  sc = ex ∷ why ∷ []
+
+  -- Two variables x and y
+  x y : Var sc
+  x = vz
+  y = vs vz
+
+  -- unify t = (x , leaf) with u = (leaf , y)
+  t u : U.Tm sc
+  t = U.fork (U.var x) U.leaf
+  u = U.fork U.leaf (U.var y)
+
+  -- Assign x and y both to leaf
+  σ : U.AList sc []
+  σ = 2 , x , U.leaf , vz , U.leaf , Eq.refl
+
+-- t and u can be unified by the assignment σ
+_ : U.unify sc t u ≡ just ([] , σ)
+_ = refl
+
+_ : U.applyA σ t ≡ U.applyA σ u
+_ = refl
+
+-- unifying a variable with itself needs no substitution at all
+_ : U.unify sc (U.var x) (U.var x) ≡ just (sc , 0 , Eq.refl)
+_ = refl
+
+-- A term cannot unify with a pair containing itself
+_ : U.unify sc (U.var x) (U.fork (U.var x) U.leaf) ≡ nothing
+_ = refl
+
+-- leaf is not a fork
+_ : U.unify sc U.leaf (U.fork U.leaf U.leaf) ≡ nothing
+_ = refl

--- a/Cubical/Categories/Direct/Instances/Bag.agda
+++ b/Cubical/Categories/Direct/Instances/Bag.agda
@@ -1,0 +1,90 @@
+-- Finite multisets well-ordered by size
+module Cubical.Categories.Direct.Instances.Bag where
+
+open import Cubical.Foundations.Prelude
+open import Cubical.Foundations.HLevels
+open import Cubical.Foundations.Structure using (⟨_⟩)
+
+open import Cubical.Data.Sigma
+open import Cubical.Data.Unit using (tt ; tt*)
+open import Cubical.Data.Bool using (Bool ; true ; false ; not ; if_then_else_)
+open import Cubical.Data.Nat using (ℕ ; suc ; isSetℕ)
+open import Cubical.Data.List using (List ; [] ; _∷_ ; _++_ ; length)
+open import Cubical.Data.List.More using (All ; filterL)
+open import Cubical.Functions.Logic using (_⊓_ ; ⇔toPath ; ⊤)
+import Cubical.HITs.FiniteMultiset as FMS
+
+open import Cubical.Categories.Direct.Base
+open import Cubical.Categories.Direct.Instances.Nat using (ℕWFOrder)
+open import Cubical.Categories.Direct.Instances.Poset
+
+private
+  variable
+    ℓ ℓ' : Level
+
+Bag : Type ℓ → Type ℓ
+Bag A = FMS.FMSet A
+
+module _ {A : Type ℓ} where
+  lengthFM : Bag A → ℕ
+  lengthFM = FMS.Rec.f isSetℕ 0 (λ _ n → suc n) (λ _ _ _ → refl)
+
+  fromList : List A → Bag A
+  fromList []       = FMS.[]
+  fromList (x ∷ xs) = x FMS.∷ fromList xs
+
+  fromList-++ : ∀ as bs → fromList (as ++ bs) ≡ fromList as FMS.++ fromList bs
+  fromList-++ []       bs = refl
+  fromList-++ (a ∷ as) bs = cong (a FMS.∷_) (fromList-++ as bs)
+
+  lengthFM-fromList : ∀ xs → lengthFM (fromList xs) ≡ length xs
+  lengthFM-fromList []       = refl
+  lengthFM-fromList (x ∷ xs) = cong suc (lengthFM-fromList xs)
+
+  bagShuffle : ∀ x (L H : Bag A)
+    → x FMS.∷ (L FMS.++ H) ≡ L FMS.++ (x FMS.∷ H)
+  bagShuffle x L H = FMS.ElimProp.f
+    {B = λ L' → x FMS.∷ (L' FMS.++ H) ≡ L' FMS.++ (x FMS.∷ H)}
+    (FMS.trunc _ _) refl
+    (λ y {L'} IH → FMS.comm x y (L' FMS.++ H) ∙ cong (y FMS.∷_) IH) L
+
+  partitionBag : ∀ p xs
+    → fromList xs
+    ≡ fromList (filterL p xs) FMS.++ fromList (filterL (λ y → not (p y)) xs)
+  partitionBag p []       = refl
+  partitionBag p (y ∷ ys) = go (p y)
+    where
+      go : ∀ b
+        → y FMS.∷ fromList ys
+        ≡ fromList (if b then y ∷ filterL p ys else filterL p ys)
+          FMS.++ fromList (if not b then y ∷ filterL (λ y' → not (p y')) ys
+                                    else filterL (λ y' → not (p y')) ys)
+      go true  = cong (y FMS.∷_) (partitionBag p ys)
+      go false = cong (y FMS.∷_) (partitionBag p ys)
+               ∙ bagShuffle y (fromList (filterL p ys))
+                              (fromList (filterL (λ y' → not (p y')) ys))
+
+  AllFM : (A → hProp ℓ') → Bag A → hProp ℓ'
+  AllFM Q = FMS.Rec.f isSetHProp ⊤ (λ x P → Q x ⊓ P)
+    (λ x y P → ⇔toPath (λ (qx , qy , p) → qy , qx , p)
+                       (λ (qy , qx , p) → qx , qy , p))
+
+module _ {A : Type} where
+  All→AllFM : (Q : A → hProp ℓ-zero) (xs : List A)
+    → All (λ z → ⟨ Q z ⟩) xs → ⟨ AllFM Q (fromList xs) ⟩
+  All→AllFM Q []       _          = tt*
+  All→AllFM Q (x ∷ xs) (qx , qxs) = qx , All→AllFM Q xs qxs
+
+  AllFM→All : (Q : A → hProp ℓ-zero) (xs : List A)
+    → ⟨ AllFM Q (fromList xs) ⟩ → All (λ z → ⟨ Q z ⟩) xs
+  AllFM→All Q []       _           = tt
+  AllFM→All Q (x ∷ xs) (qx , rest) = qx , AllFM→All Q xs rest
+
+module _ (A : Type ℓ) where
+  BagWFOrder : WFOrder ℓ ℓ-zero
+  BagWFOrder = pullbackWFOrder ℕWFOrder FMS.trunc (lengthFM {A = A})
+
+  BagCat = PosetCat BagWFOrder
+
+  BagDirect : DirectStr {C = BagCat} BagWFOrder
+  BagDirect = PosetDirect BagWFOrder

--- a/Cubical/Categories/Direct/Instances/Cospan.agda
+++ b/Cubical/Categories/Direct/Instances/Cospan.agda
@@ -1,0 +1,83 @@
+-- The walking cospan `L → M ← R` as a thin direct category
+module Cubical.Categories.Direct.Instances.Cospan where
+
+open import Cubical.Foundations.Prelude
+open import Cubical.Foundations.HLevels
+
+open import Cubical.Data.Unit
+open import Cubical.Data.Empty as ⊥ using (⊥ ; isProp⊥)
+open import Cubical.Data.Sum using (inl ; inr)
+import Cubical.Data.Equality as Eq
+open import Cubical.Data.Nat using (ℕ)
+
+open import Cubical.Categories.Category
+open import Cubical.Categories.Instances.Thin using (ThinCategory)
+open import Cubical.Categories.Direct.Base
+open import Cubical.Categories.Direct.Instances.Nat using (ℕWFOrder)
+
+data Ob : Type where
+  L R M : Ob
+
+Hom : Ob → Ob → Type
+Hom L L = Unit
+Hom L R = ⊥
+Hom L M = Unit
+Hom R L = ⊥
+Hom R R = Unit
+Hom R M = Unit
+Hom M L = ⊥
+Hom M R = ⊥
+Hom M M = Unit
+
+reflH : ∀ {x} → Hom x x
+reflH {L} = tt
+reflH {R} = tt
+reflH {M} = tt
+
+transH : ∀ {x y z} → Hom x y → Hom y z → Hom x z
+transH {L} {L}     f g = g
+transH {L} {R}     f g = ⊥.rec f
+transH {L} {M} {L} f g = ⊥.rec g
+transH {L} {M} {R} f g = ⊥.rec g
+transH {L} {M} {M} f g = tt
+transH {R} {L}     f g = ⊥.rec f
+transH {R} {R}     f g = g
+transH {R} {M} {L} f g = ⊥.rec g
+transH {R} {M} {R} f g = ⊥.rec g
+transH {R} {M} {M} f g = tt
+transH {M} {L}     f g = ⊥.rec f
+transH {M} {R}     f g = ⊥.rec f
+transH {M} {M}     f g = g
+
+isPropHomₖ : ∀ {x y} → isProp (Hom x y)
+isPropHomₖ {L} {L} = isPropUnit
+isPropHomₖ {L} {R} = isProp⊥
+isPropHomₖ {L} {M} = isPropUnit
+isPropHomₖ {R} {L} = isProp⊥
+isPropHomₖ {R} {R} = isPropUnit
+isPropHomₖ {R} {M} = isPropUnit
+isPropHomₖ {M} {L} = isProp⊥
+isPropHomₖ {M} {R} = isProp⊥
+isPropHomₖ {M} {M} = isPropUnit
+
+CospanCat : Category ℓ-zero ℓ-zero
+CospanCat = ThinCategory Ob Hom reflH transH isPropHomₖ
+
+deg : Ob → ℕ
+deg L = 0
+deg R = 0
+deg M = 1
+
+CospanDirect : DirectStr {C = CospanCat} ℕWFOrder
+CospanDirect = mkDirectStr {C = CospanCat} ℕWFOrder deg non-dec
+  where
+    non-dec : {x y : Ob} → Hom x y → WFOrder._≤_ ℕWFOrder (deg x) (deg y)
+    non-dec {L} {L} _ = inr Eq.refl
+    non-dec {L} {R} f = ⊥.rec f
+    non-dec {L} {M} _ = inl tt
+    non-dec {R} {L} f = ⊥.rec f
+    non-dec {R} {R} _ = inr Eq.refl
+    non-dec {R} {M} _ = inl tt
+    non-dec {M} {L} f = ⊥.rec f
+    non-dec {M} {R} f = ⊥.rec f
+    non-dec {M} {M} _ = inr Eq.refl

--- a/Cubical/Categories/Direct/Instances/ListByLength.agda
+++ b/Cubical/Categories/Direct/Instances/ListByLength.agda
@@ -1,0 +1,25 @@
+-- Lists over a carrier, well-ordered by length.
+module Cubical.Categories.Direct.Instances.ListByLength where
+
+open import Cubical.Foundations.Prelude
+open import Cubical.Foundations.HLevels
+
+open import Cubical.Data.List using (length)
+open import Cubical.Data.List.Properties using (isOfHLevelList)
+
+open import Cubical.Categories.Direct.Base
+open import Cubical.Categories.Direct.Instances.Nat using (ℕWFOrder)
+open import Cubical.Categories.Direct.Instances.Poset
+
+private
+  variable
+    ℓ : Level
+
+module _ (A : Type ℓ) (isSetA : isSet A) where
+  ListWFOrder : WFOrder ℓ ℓ-zero
+  ListWFOrder = pullbackWFOrder ℕWFOrder (isOfHLevelList 0 isSetA) length
+
+  ListCat = PosetCat ListWFOrder
+
+  ListDirect : DirectStr {C = ListCat} ListWFOrder
+  ListDirect = PosetDirect ListWFOrder

--- a/Cubical/Categories/Direct/Instances/Nat.agda
+++ b/Cubical/Categories/Direct/Instances/Nat.agda
@@ -1,0 +1,68 @@
+-- ℕ with the usual `<` as a well-ordered poset = the "topos of trees" base.
+module Cubical.Categories.Direct.Instances.Nat where
+
+open import Cubical.Foundations.Prelude
+
+open import Cubical.Foundations.Equiv
+open import Cubical.Foundations.HLevels using (isPropΣ)
+open import Cubical.Data.Nat using (ℕ ; zero ; suc ; isSetℕ)
+open import Cubical.Data.Nat.Order.Recursive using (_<_ ; isProp≤ ; <-trans ; ≤-refl ; ≤-split)
+import Cubical.Data.Nat.Order.Recursive as NatOrd
+import Cubical.Data.Nat.Order as Ord
+open import Cubical.Data.Sigma using (_,_)
+open import Cubical.Data.Sum as Sum using (inl ; inr)
+open import Cubical.Data.Unit using (tt)
+import Cubical.Data.Empty as Empty
+import Cubical.Data.Equality as Eq
+
+open import Cubical.Categories.Direct.Base
+open import Cubical.Categories.Direct.Instances.Poset
+import Cubical.Categories.Direct.Predecessor as P
+
+ℕWFOrder : WFOrder ℓ-zero ℓ-zero
+ℕWFOrder = record
+  { D       = ℕ
+  ; isSetD  = isSetℕ
+  ; _<_     = _<_
+  ; isProp< = λ a b → isProp≤ {suc a} {b}
+  ; trans<  = λ {a} {b} {c} → <-trans {a} {b} {c}
+  ; wf<     = NatOrd.WellFounded.wf-<
+  }
+
+ℕCat = PosetCat ℕWFOrder
+
+ℕDirect : DirectStr {C = ℕCat} ℕWFOrder
+ℕDirect = PosetDirect ℕWFOrder
+
+-- bridge from the Σ-style order of `Cubical.Data.Nat.Order` to ℕWFOrder's
+-- Eq-world ≤ (used by Reedy instances whose degree bounds come from
+-- combinatorics phrased with the Σ-style order)
+<→Wo< : ∀ {a b} → a Ord.< b → a < b
+<→Wo< {a}     {zero}  p = Empty.rec (Ord.¬-<-zero p)
+<→Wo< {zero}  {suc b} p = tt
+<→Wo< {suc a} {suc b} p = <→Wo< {a} {b} (Ord.pred-≤-pred p)
+
+≤→Wo≤ : ∀ {a b} → a Ord.≤ b → WFOrder._≤_ ℕWFOrder a b
+≤→Wo≤ {a} {b} a≤b with a Ord.≟ b
+... | Ord.lt a<b = inl (<→Wo< a<b)
+... | Ord.eq a≡b = inr (Eq.pathToEq a≡b)
+... | Ord.gt b<a = Empty.rec (Ord.¬m<m (Ord.≤<-trans a≤b b<a))
+
+-- every successor `suc m` has `m` as predecessor: the strict downset
+-- of `suc m` is represented by `m`
+sucPred : ∀ m → P.isPredOf ℕDirect (suc m) m
+sucPred m = record
+  { ρ    = inl (≤-refl m)
+  ; p≺x  = ≤-refl m
+  ; univ = λ y →
+      propBiimpl→Equiv (WFOrder.isProp≤ ℕWFOrder)
+        (isPropΣ (WFOrder.isProp≤ ℕWFOrder)
+          (λ _ → isProp≤ {suc y} {suc m}))
+        _
+        (λ (g , q) → Sum.map (λ z → z) Eq.pathToEq (≤-split {y} {m} q))
+        .snd
+  }
+
+ℕPredecessors : P.Predecessors ℕDirect
+ℕPredecessors zero    = P.minimal (λ y h → h)
+ℕPredecessors (suc m) = P.hasPred m (sucPred m)

--- a/Cubical/Categories/Direct/Instances/ParallelPair.agda
+++ b/Cubical/Categories/Direct/Instances/ParallelPair.agda
@@ -1,0 +1,89 @@
+-- The walking parallel pair `V ⇉ E` as a non-thin direct category
+module Cubical.Categories.Direct.Instances.ParallelPair where
+
+open import Cubical.Foundations.Prelude
+open import Cubical.Foundations.HLevels
+
+open import Cubical.Data.Unit
+open import Cubical.Data.Bool
+open import Cubical.Data.Empty as ⊥
+open import Cubical.Data.Sum using (inl ; inr)
+import Cubical.Data.Equality as Eq
+open import Cubical.Data.Nat using (ℕ ; isSetℕ)
+
+open import Cubical.Categories.Category
+open import Cubical.Categories.Direct.Base
+open import Cubical.Categories.Direct.Instances.Nat using (ℕWFOrder)
+
+data Ob : Type where
+  V E : Ob
+
+Hom : Ob → Ob → Type
+Hom V V = Unit
+Hom V E = Bool
+Hom E E = Unit
+Hom E V = ⊥
+
+s t : Hom V E
+s = false
+t = true
+
+idH : (x : Ob) → Hom x x
+idH V = tt
+idH E = tt
+
+_⋆ₚ_ : {x y z : Ob} → Hom x y → Hom y z → Hom x z
+_⋆ₚ_ {V} {V} {V} f g = tt
+_⋆ₚ_ {V} {V} {E} f g = g
+_⋆ₚ_ {V} {E} {E} f g = f
+_⋆ₚ_ {V} {E} {V} f g = ⊥.rec g
+_⋆ₚ_ {E} {E} {E} f g = tt
+_⋆ₚ_ {E} {E} {V} f g = ⊥.rec g
+_⋆ₚ_ {E} {V}     f g = ⊥.rec f
+
+isSetHomₚ : {x y : Ob} → isSet (Hom x y)
+isSetHomₚ {V} {V} = isSetUnit
+isSetHomₚ {V} {E} = isSetBool
+isSetHomₚ {E} {E} = isSetUnit
+isSetHomₚ {E} {V} = isProp→isSet isProp⊥
+
+open Category
+
+ParallelPair : Category ℓ-zero ℓ-zero
+ParallelPair .ob        = Ob
+ParallelPair .Hom[_,_]  = Hom
+ParallelPair .id {x}    = idH x
+ParallelPair ._⋆_       = _⋆ₚ_
+ParallelPair .⋆IdL {V} {V} f = refl
+ParallelPair .⋆IdL {V} {E} f = refl
+ParallelPair .⋆IdL {E} {E} f = refl
+ParallelPair .⋆IdL {E} {V} f = ⊥.rec f
+ParallelPair .⋆IdR {V} {V} f = refl
+ParallelPair .⋆IdR {V} {E} f = refl
+ParallelPair .⋆IdR {E} {E} f = refl
+ParallelPair .⋆IdR {E} {V} f = ⊥.rec f
+ParallelPair .⋆Assoc {V} {V} {V} {V} f g h = refl
+ParallelPair .⋆Assoc {V} {V} {V} {E} f g h = refl
+ParallelPair .⋆Assoc {V} {V} {E} {E} f g h = refl
+ParallelPair .⋆Assoc {V} {E} {E} {E} f g h = refl
+ParallelPair .⋆Assoc {E} {E} {E} {E} f g h = refl
+ParallelPair .⋆Assoc {E} {V}         f g h = ⊥.rec f
+ParallelPair .⋆Assoc {V} {E} {V}     f g h = ⊥.rec g
+ParallelPair .⋆Assoc {E} {E} {V}     f g h = ⊥.rec g
+ParallelPair .⋆Assoc {V} {V} {E} {V} f g h = ⊥.rec h
+ParallelPair .⋆Assoc {V} {E} {E} {V} f g h = ⊥.rec h
+ParallelPair .⋆Assoc {E} {E} {E} {V} f g h = ⊥.rec h
+ParallelPair .isSetHom  = isSetHomₚ
+
+deg : Ob → ℕ
+deg V = 0
+deg E = 1
+
+ParallelPairDirect : DirectStr {C = ParallelPair} ℕWFOrder
+ParallelPairDirect = mkDirectStr {C = ParallelPair} ℕWFOrder deg non-dec
+  where
+    non-dec : {x y : Ob} → Hom x y → WFOrder._≤_ ℕWFOrder (deg x) (deg y)
+    non-dec {V} {V} _ = inr Eq.refl
+    non-dec {V} {E} _ = inl tt
+    non-dec {E} {E} _ = inr Eq.refl
+    non-dec {E} {V} f = ⊥.rec f

--- a/Cubical/Categories/Direct/Instances/Poset.agda
+++ b/Cubical/Categories/Direct/Instances/Poset.agda
@@ -1,0 +1,30 @@
+-- A well-ordered poset is a (thin) direct category.
+module Cubical.Categories.Direct.Instances.Poset where
+
+open import Cubical.Foundations.Prelude
+open import Cubical.Foundations.HLevels
+
+open import Cubical.Categories.Category
+open import Cubical.Categories.Direct.Base
+
+private
+  variable
+    ℓ ℓ' : Level
+
+module _ (Wo : WFOrder ℓ ℓ') where
+  open WFOrder Wo
+  open Category
+
+  -- the poset (D, ≤) as a thin category
+  PosetCat : Category ℓ (ℓ-max ℓ ℓ')
+  PosetCat .ob              = D
+  PosetCat .Hom[_,_]        = _≤_
+  PosetCat .id              = ≤-refl
+  PosetCat ._⋆_             = ≤-trans
+  PosetCat .⋆IdL _          = isProp≤ _ _
+  PosetCat .⋆IdR _          = isProp≤ _ _
+  PosetCat .⋆Assoc _ _ _    = isProp≤ _ _
+  PosetCat .isSetHom        = isProp→isSet isProp≤
+
+  PosetDirect : DirectStr {C = PosetCat} Wo
+  PosetDirect = mkDirectStr {C = PosetCat} Wo (λ x → x) (λ f → f)

--- a/Cubical/Categories/Direct/Instances/Thinnings.agda
+++ b/Cubical/Categories/Direct/Instances/Thinnings.agda
@@ -1,0 +1,179 @@
+-- Lists and thinnings as a non-thin direct category
+--
+-- McBride, "Everybody's Got To Be Somewhere"
+-- https://arxiv.org/abs/1807.04085
+module Cubical.Categories.Direct.Instances.Thinnings where
+
+open import Cubical.Foundations.Prelude
+open import Cubical.Foundations.HLevels
+
+open import Cubical.Data.Sigma
+open import Cubical.Data.Sum as Sum using (_⊎_ ; inl ; inr ; isSet⊎)
+open import Cubical.Data.Unit using (Unit ; tt ; isPropUnit)
+open import Cubical.Data.Empty as ⊥ using (⊥)
+open import Cubical.Data.Nat using (ℕ ; zero ; suc)
+open import Cubical.Data.Nat.Order.Recursive using (_≤_ ; _<_)
+open import Cubical.Data.List using (List ; [] ; _∷_ ; length)
+open import Cubical.Data.List.Properties using (isOfHLevelList)
+import Cubical.Data.Equality as Eq
+
+open import Cubical.Categories.Category
+open import Cubical.Categories.Direct.Base
+open import Cubical.Categories.Direct.Instances.Nat using (ℕWFOrder)
+
+private
+  variable
+    ℓ : Level
+
+data Thin {A : Type ℓ} : List A → List A → Type ℓ where
+  done : Thin [] []
+  keep : ∀ {xs ys} (a : A) → Thin xs ys → Thin (a ∷ xs) (a ∷ ys)
+  skip : ∀ {xs ys} (a : A) → Thin xs ys → Thin xs (a ∷ ys)
+
+module _ {A : Type ℓ} where
+  private
+    variable
+      xs ys zs : List A
+
+  idThin : (xs : List A) → Thin xs xs
+  idThin []       = done
+  idThin (a ∷ xs) = keep a (idThin xs)
+
+  seqThin : Thin xs ys → Thin ys zs → Thin xs zs
+  seqThin θ          (skip a φ) = skip a (seqThin θ φ)
+  seqThin (keep _ θ) (keep a φ) = keep a (seqThin θ φ)
+  seqThin (skip _ θ) (keep a φ) = skip a (seqThin θ φ)
+  seqThin done       done       = done
+
+  seqIdL : (θ : Thin xs ys) → seqThin (idThin xs) θ ≡ θ
+  seqIdL done       = refl
+  seqIdL (keep a θ) = cong (keep a) (seqIdL θ)
+  seqIdL (skip a θ) = cong (skip a) (seqIdL θ)
+
+  seqIdR : (θ : Thin xs ys) → seqThin θ (idThin ys) ≡ θ
+  seqIdR done       = refl
+  seqIdR (keep a θ) = cong (keep a) (seqIdR θ)
+  seqIdR (skip a θ) = cong (skip a) (seqIdR θ)
+
+  seqAssoc : {ws : List A} (θ : Thin xs ys) (φ : Thin ys zs) (ψ : Thin zs ws)
+           → seqThin (seqThin θ φ) ψ ≡ seqThin θ (seqThin φ ψ)
+  seqAssoc θ          φ          (skip a ψ) = cong (skip a) (seqAssoc θ φ ψ)
+  seqAssoc (keep _ θ) (keep _ φ) (keep a ψ) = cong (keep a) (seqAssoc θ φ ψ)
+  seqAssoc (skip _ θ) (keep _ φ) (keep a ψ) = cong (skip a) (seqAssoc θ φ ψ)
+  seqAssoc θ          (skip _ φ) (keep a ψ) = cong (skip a) (seqAssoc θ φ ψ)
+  seqAssoc done       done       done       = refl
+
+  isPropEqList : isSet A → (xs ys : List A) → isProp (xs Eq.≡ ys)
+  isPropEqList sA xs ys = isOfHLevelRetract 1
+    Eq.eqToPath Eq.pathToEq Eq.pathToEq-eqToPath
+    (isOfHLevelList 0 sA xs ys)
+
+  private
+    ThinRep : List A → List A → Type _
+    ThinRep xs []       = xs Eq.≡ []
+    ThinRep xs (y ∷ ys) =
+      (Σ[ xs' ∈ List A ] (xs Eq.≡ (y ∷ xs')) × ThinRep xs' ys) ⊎ ThinRep xs ys
+
+    toRep : Thin xs ys → ThinRep xs ys
+    toRep done              = Eq.refl
+    toRep (keep {xs = xs} a θ) = inl (xs , Eq.refl , toRep θ)
+    toRep (skip a θ)           = inr (toRep θ)
+
+    fromRep : (xs ys : List A) → ThinRep xs ys → Thin xs ys
+    fromRep .[] [] Eq.refl = done
+    fromRep .(y ∷ xs') (y ∷ ys) (inl (xs' , Eq.refl , r)) =
+      keep y (fromRep xs' ys r)
+    fromRep xs (y ∷ ys) (inr r) = skip y (fromRep xs ys r)
+
+    fromRep-toRep : (θ : Thin xs ys) → fromRep xs ys (toRep θ) ≡ θ
+    fromRep-toRep done       = refl
+    fromRep-toRep (keep a θ) = cong (keep a) (fromRep-toRep θ)
+    fromRep-toRep (skip a θ) = cong (skip a) (fromRep-toRep θ)
+
+    isSetThinRep : isSet A → (xs ys : List A) → isSet (ThinRep xs ys)
+    isSetThinRep sA xs []       = isProp→isSet (isPropEqList sA xs [])
+    isSetThinRep sA xs (y ∷ ys) = isSet⊎
+      (isSetΣ (isOfHLevelList 0 sA) λ xs' → isSet×
+        (isProp→isSet (isPropEqList sA xs (y ∷ xs')))
+        (isSetThinRep sA xs' ys))
+      (isSetThinRep sA xs ys)
+
+  isSetThin : isSet A → isSet (Thin xs ys)
+  isSetThin sA =
+    isOfHLevelRetract 2 toRep (fromRep _ _) fromRep-toRep
+      (isSetThinRep sA _ _)
+
+  -- this category is genuinely not thin
+  keep≢skip : {a : A} {θ : Thin xs ys} {φ : Thin (a ∷ xs) ys}
+            → keep a θ ≡ skip a φ → ⊥
+  keep≢skip {a = a} e = subst disc (cong toRep e) tt
+    where
+      disc : ThinRep (a ∷ xs) (a ∷ ys) → Type
+      disc (inl _) = Unit
+      disc (inr _) = ⊥
+
+  thin-length : Thin xs ys → length xs ≤ length ys
+  thin-length done       = tt
+  thin-length (keep a θ) = thin-length θ
+  thin-length (skip {xs = xs} {ys = ys} a θ) =
+    ≤-up {length xs} {length ys} (thin-length θ)
+    where
+      ≤-up : ∀ {m n} → m ≤ n → m ≤ suc n
+      ≤-up {zero}          _  = tt
+      ≤-up {suc m} {zero}  le = ⊥.rec le
+      ≤-up {suc m} {suc n} le = ≤-up {m} {n} le
+
+  thin≤ : (θ : Thin xs ys) → (length xs < length ys) ⊎ (xs Eq.≡ ys)
+  thin≤ done       = inr Eq.refl
+  thin≤ (keep a θ) = Sum.map (λ lt → lt) (Eq.ap (a ∷_)) (thin≤ θ)
+  thin≤ (skip a θ) = inl (thin-length θ)
+
+Var : {A : Type ℓ} → List A → Type
+Var []       = ⊥
+Var (a ∷ xs) = Unit ⊎ Var xs
+
+pattern vz   = inl tt
+pattern vs x = inr x
+
+module _ {A : Type ℓ} where
+  isSetVar : (xs : List A) → isSet (Var xs)
+  isSetVar []       = isProp→isSet ⊥.isProp⊥
+  isSetVar (a ∷ xs) = isSet⊎ (isProp→isSet isPropUnit) (isSetVar xs)
+
+  delete : (xs : List A) → Var xs → List A
+  delete (a ∷ xs) vz     = xs
+  delete (a ∷ xs) (vs x) = a ∷ delete xs x
+
+  faceThin : {xs : List A} (x : Var xs) → Thin (delete xs x) xs
+  faceThin {xs = a ∷ xs} vz     = skip a (idThin xs)
+  faceThin {xs = a ∷ xs} (vs x) = keep a (faceThin x)
+
+  length-delete : (xs : List A) (x : Var xs)
+                → suc (length (delete xs x)) ≡ length xs
+  length-delete (a ∷ xs) vz     = refl
+  length-delete (a ∷ xs) (vs x) = cong suc (length-delete xs x)
+
+  thick : {xs : List A} (x y : Var xs) → (x ≡ y) ⊎ Var (delete xs x)
+  thick {xs = a ∷ xs} vz     vz     = inl refl
+  thick {xs = a ∷ xs} vz     (vs y) = inr y
+  thick {xs = a ∷ xs} (vs x) vz     = inr vz
+  thick {xs = a ∷ xs} (vs x) (vs y) = Sum.map (cong inr) inr (thick x y)
+
+module _ (A : Type ℓ) (isSetA : isSet A) where
+  open Category
+
+  THIN : Category ℓ ℓ
+  THIN .ob        = List A
+  THIN .Hom[_,_]  = Thin
+  THIN .id {xs}   = idThin xs
+  THIN ._⋆_       = seqThin
+  THIN .⋆IdL      = seqIdL
+  THIN .⋆IdR      = seqIdR
+  THIN .⋆Assoc    = seqAssoc
+  THIN .isSetHom  = isSetThin isSetA
+
+  ThinWFOrder : WFOrder ℓ ℓ-zero
+  ThinWFOrder = pullbackWFOrder ℕWFOrder (isOfHLevelList 0 isSetA) length
+
+  ThinDirect : DirectStr {C = THIN} ThinWFOrder
+  ThinDirect = mkDirectStr ThinWFOrder (λ xs → xs) thin≤

--- a/Cubical/Categories/Direct/LocallyContractive.agda
+++ b/Cubical/Categories/Direct/LocallyContractive.agda
@@ -1,0 +1,231 @@
+{-# OPTIONS --lossy-unification #-}
+module Cubical.Categories.Direct.LocallyContractive where
+
+open import Cubical.Foundations.Prelude
+open import Cubical.Foundations.HLevels
+open import Cubical.Foundations.Structure
+
+open import Cubical.Data.Sigma
+open import Cubical.Data.Unit
+
+open import Cubical.Categories.Category
+open import Cubical.Categories.Functor using (Functor ; _∘F_)
+import Cubical.Categories.Presheaf.Family.Base as FamBase
+open import Cubical.Categories.Presheaf.Base
+open import Cubical.Categories.Presheaf.Constructions.Unit
+open import Cubical.Categories.Presheaf.Constructions.BinProduct using (_×Psh_)
+open import Cubical.Categories.Presheaf.StrictHom.Base
+open import Cubical.Categories.Presheaf.StrictHom.CartesianClosed
+open import Cubical.Categories.Direct.Base
+open import Cubical.Categories.Direct.StrictDownset
+open import Cubical.Categories.Displayed.Instances.Algebras.Recursive
+
+open Functor
+open PshHomStrict
+
+private
+  variable
+    ℓ ℓ' ℓD : Level
+
+module _ {C : Category ℓ ℓ'} {Wo : WFOrder ℓD ℓ'}
+         (dir : DirectStr {C = C} Wo) where
+  open Category C using (ob ; id ; _⋆_ ; ⋆IdL)
+  open DirectNotation dir using (_≺_)
+
+  private
+    ℓ▷ : Level
+    ℓ▷ = ℓ-max ℓ ℓ'
+
+    infixr 5 _⇒_
+    _⇒_ : Presheaf C ℓ▷ → Presheaf C ℓ▷ → Presheaf C ℓ▷
+    X ⇒ Y = X ⇒PshLargeStrict Y
+
+  ▷HomActionPsh : (Presheaf C ℓ▷ → Presheaf C ℓ▷) → Type _
+  ▷HomActionPsh F₀ =
+    {X Y : Presheaf C ℓ▷} → PshHomStrict (▷ dir .F-ob (X ⇒ Y)) (F₀ X ⇒ F₀ Y)
+
+  private
+    nm : {X Y : Presheaf C ℓ▷} (h : PshHomStrict X Y) (y : ob)
+       → ⟨ (X ⇒ Y) .F-ob y ⟩
+    nm h y .N-ob d (f , ξ) = h .N-ob d ξ
+    nm h y .N-hom d' d g (f' , ξ') (f , ξ) e =
+      h .N-hom d' d g ξ' ξ (cong snd e)
+
+  -- the transpose of h as a global element of ▷ (X ⇒ Y)
+  ▷transpose : {X Y : Presheaf C ℓ▷} (h : PshHomStrict X Y)
+        → PshHomStrict UnitPsh (▷ dir .F-ob (X ⇒ Y))
+  ▷transpose h .N-ob x _ =
+    pshhom (λ y _ → nm h y) (λ y' y g p' p e → makePshHomStrictPath refl)
+  ▷transpose h .N-hom x' x f _ _ _ = makePshHomStrictPath refl
+
+  -- F's hom-action factors through next, via Fδ
+  isContractiveHomAction :
+    (F : Functor (PRESHEAF C ℓ▷) (PRESHEAF C ℓ▷))
+    → ▷HomActionPsh (F .F-ob) → Type _
+  isContractiveHomAction F Fδ =
+    {X Y : Presheaf C ℓ▷} (h : PshHomStrict X Y)
+    → F .F-hom h ≡ eltPshHomStrict (▷transpose h ⋆PshHomStrict Fδ {X} {Y})
+
+  LocallyContractive : Type _
+  LocallyContractive =
+    Σ[ F ∈ Functor (PRESHEAF C ℓ▷) (PRESHEAF C ℓ▷) ]
+    Σ[ Fδ ∈ ▷HomActionPsh (F .F-ob) ]
+      isContractiveHomAction F Fδ
+
+  Fam : Category _ _
+  Fam = FamBase.Fam {ℓ = ℓ'} C
+
+  module HyloPsh (F : LocallyContractive)
+                 (X B : Presheaf C ℓ▷)
+                 (c : PshHomStrict X (F .fst .F-ob X))
+                 (a : PshHomStrict (F .fst .F-ob B) B)
+                 where
+    private
+      F₀ = F .fst .F-ob
+      Fδ = F .snd .fst
+      Fhom≡ = F .snd .snd
+
+    hyloBody : PshHomStrict ((▷ dir .F-ob (X ⇒ B)) ×Psh X) B
+    hyloBody =
+      (Fδ {X} {B} ×PshHomStrict c)
+        ⋆PshHomStrict appPshHomStrict (F₀ X) (F₀ B)
+        ⋆PshHomStrict a
+
+    hyloStep : PshHomStrict (▷ dir .F-ob (X ⇒ B)) (X ⇒ B)
+    hyloStep = λPshHomStrict X B hyloBody
+
+    hyloTranspose : PshHomStrict UnitPsh (X ⇒ B)
+    hyloTranspose = löb dir (X ⇒ B) hyloStep
+
+    private
+      hyloMap : PshHomStrict X B
+      hyloMap =
+        ×PshIntroStrict (UnitPsh-introStrict ⋆PshHomStrict hyloTranspose)
+          idPshHomStrict
+          ⋆PshHomStrict appPshHomStrict X B
+
+    hyloTranspose-fix :
+      hyloTranspose ≡ (hyloTranspose ⋆PshHomStrict next dir (X ⇒ B)) ⋆PshHomStrict hyloStep
+    hyloTranspose-fix = löb-fix dir (X ⇒ B) hyloStep
+
+    hyloTranspose-uniq :
+      (s : PshHomStrict UnitPsh (X ⇒ B))
+      → s ≡ (s ⋆PshHomStrict next dir (X ⇒ B)) ⋆PshHomStrict hyloStep
+      → s ≡ hyloTranspose
+    hyloTranspose-uniq = löb-uniq dir (X ⇒ B) hyloStep
+
+    hylo : Hylo (F .fst) (X , c) (B , a)
+    hylo .fst = hyloMap
+    hylo .snd = makePshHomStrictPath (funExt λ x → funExt λ p →
+      cong (λ s → s .N-ob x tt .N-ob x (id , p)) hyloTranspose-fix
+      ∙ cong (λ z → a .N-ob x (Fδ .N-ob x z .N-ob x (id , c .N-ob x p)))
+          (funExt⁻ (▷ dir .F-ob (X ⇒ B) .F-id)
+             (next dir (X ⇒ B) .N-ob x (hyloTranspose .N-ob x tt))
+           ∙ nextT≡▷transpose x)
+      ∙ cong (λ φ → a .N-ob x (φ .N-ob x (c .N-ob x p)))
+          (sym (Fhom≡ hyloMap)))
+      where
+      nextT≡▷transpose : ∀ x →
+        next dir (X ⇒ B) .N-ob x (hyloTranspose .N-ob x tt)
+          ≡ ▷transpose hyloMap .N-ob x tt
+      nextT≡▷transpose x = makePshHomStrictPath (funExt λ y → funExt λ (g , q) →
+        makePshHomStrictPath (funExt λ d → funExt λ (f , ξ) →
+          sym (cong (λ m → hyloTranspose .N-ob x tt .N-ob d (m , ξ))
+                 (⋆IdL (f ⋆ g)))
+          ∙ cong (λ α → α .N-ob d (id , ξ))
+              (hyloTranspose .N-hom d x (f ⋆ g) tt tt refl)))
+
+  _⇒Fam_ : Category.ob Fam → Category.ob Fam → Category.ob Fam
+  (A ⇒Fam B) x = (⟨ A x ⟩ → ⟨ B x ⟩) , isSet→ (B x .snd)
+
+  ▷HomActionFam : Functor Fam Fam → Type _
+  ▷HomActionFam H =
+    {A B : Category.ob Fam}
+    → Fam [ ▷Fam dir {ℓF = ℓ-zero} (A ⇒Fam B)
+          , (H .F-ob A ⇒Fam H .F-ob B) ]
+
+  -- apply a later function-family at a strict bound
+  ▷app : {A B : Category.ob Fam} {x y : ob}
+       → ⟨ ▷Fam dir {ℓF = ℓ-zero} (A ⇒Fam B) x ⟩
+       → C [ y , x ] → y ≺ x → ⟨ A y ⟩ → ⟨ B y ⟩
+  ▷app β g q = β .N-ob _ (g , q) _ id
+
+  -- ▷ preserves the pointwise product laxly
+  ▷× : {P Q : Presheaf C ℓ▷}
+     → PshHomStrict (▷ dir .F-ob P ×Psh ▷ dir .F-ob Q)
+                    (▷ dir .F-ob (P ×Psh Q))
+  ▷× .N-ob x (α , β) = ×PshIntroStrict α β
+  ▷× .N-hom x x' f (α' , β') (α , β) e =
+    makePshHomStrictPath refl
+    ∙ (λ i → ×PshIntroStrict (cong fst e i) (cong snd e i))
+
+  -- H's hom-action factors through nextFam, via Hδ
+  isContractiveHomActionFam :
+    (H : Functor Fam Fam) → ▷HomActionFam H → Type _
+  isContractiveHomActionFam H Hδ =
+    {A B : Category.ob Fam} (h : Fam [ A , B ]) (x : ob)
+    → H .F-hom h x
+      ≡ Hδ {A} {B} x (nextFam dir {ℓF = ℓ-zero} (A ⇒Fam B) h x)
+
+  LocallyContractiveFam : Type _
+  LocallyContractiveFam =
+    Σ[ H ∈ Functor Fam Fam ]
+    Σ[ Hδ ∈ ▷HomActionFam H ]
+      isContractiveHomActionFam H Hδ
+
+  module HyloFam (H : LocallyContractiveFam)
+                 (X B : Category.ob Fam)
+                 (c : Fam [ X , H .fst .F-ob X ])
+                 (a : Fam [ H .fst .F-ob B , B ])
+                 where
+    private
+      Hδ = H .snd .fst
+      Hhom≡ = H .snd .snd
+
+      hyloStep : ∀ x → ⟨ ▷Fam dir {ℓF = ℓ-zero} (X ⇒Fam B) x ⟩
+               → ⟨ (X ⇒Fam B) x ⟩
+      hyloStep x β ξ = a x (Hδ {X} {B} x β (c x ξ))
+
+    private
+      hyloMap : Fam [ X , B ]
+      hyloMap = löbFam dir {ℓF = ℓ-zero} (X ⇒Fam B) hyloStep
+
+    hylo : Hylo (H .fst) (X , c) (B , a)
+    hylo .fst = hyloMap
+    hylo .snd = funExt λ x →
+      löbFam-unfold dir {ℓF = ℓ-zero} (X ⇒Fam B) hyloStep x
+      ∙ cong (λ k → λ ξ → a x (k (c x ξ)))
+          (sym (Hhom≡ {X} {B} hyloMap x))
+
+    hylo-uniq : (h : Hylo (H .fst) (X , c) (B , a)) → h ≡ hylo
+    hylo-uniq (h , he) = ΣPathP (mapEq , path2)
+      where
+        mapEq : h ≡ hyloMap
+        mapEq =
+          löbFam-uniq-unfold dir {ℓF = ℓ-zero} (X ⇒Fam B) hyloStep h
+            λ x → funExt⁻ he x
+                  ∙ (λ i ξ → a x (Hhom≡ {X} {B} h x i (c x ξ)))
+
+        path2 : PathP
+          (λ i → mapEq i
+                 ≡ (λ x ξ → a x (H .fst .F-hom (mapEq i) x (c x ξ))))
+          he (hylo .snd)
+        path2 = isProp→PathP
+          (λ i → isSetΠ (λ x → isSet→ (B x .snd))
+                   (mapEq i)
+                   (λ x ξ → a x (H .fst .F-hom (mapEq i) x (c x ξ))))
+          he (hylo .snd)
+
+  -- local contractivity makes the hylomorphism profunctor trivial;
+  -- recursiveness and corecursiveness are its curried readings, and
+  -- finality/initiality at a fixed point follow from FixpointRecursion
+  module Recursiveness (H : LocallyContractiveFam) where
+    hyloTrivial : HYLOTrivial (H .fst)
+    hyloTrivial (X , c) (B , a) = HF.hylo , λ h → sym (HF.hylo-uniq h)
+      where module HF = HyloFam H X B c a
+
+    recursive : ∀ Xc → isRecursiveCoalgebra (H .fst) Xc
+    recursive = HYLOTrivial→recursive (H .fst) hyloTrivial
+
+    corecursive : ∀ Ba → isCorecursiveAlgebra (H .fst) Ba
+    corecursive = HYLOTrivial→corecursive (H .fst) hyloTrivial

--- a/Cubical/Categories/Direct/LocallyContractive.agda
+++ b/Cubical/Categories/Direct/LocallyContractive.agda
@@ -105,7 +105,8 @@ module _ {C : Category ℓ ℓ'} {Wo : WFOrder ℓD ℓ'}
           ⋆PshHomStrict appPshHomStrict X B
 
     hyloTranspose-fix :
-      hyloTranspose ≡ (hyloTranspose ⋆PshHomStrict next dir (X ⇒ B)) ⋆PshHomStrict hyloStep
+      hyloTranspose
+      ≡ (hyloTranspose ⋆PshHomStrict next dir (X ⇒ B)) ⋆PshHomStrict hyloStep
     hyloTranspose-fix = löb-fix dir (X ⇒ B) hyloStep
 
     hyloTranspose-uniq :
@@ -197,6 +198,10 @@ module _ {C : Category ℓ ℓ'} {Wo : WFOrder ℓD ℓ'}
       ∙ cong (λ k → λ ξ → a x (k (c x ξ)))
           (sym (Hhom≡ {X} {B} hyloMap x))
 
+    hylo-unfold : ∀ x ξ
+      → hylo .fst x ξ ≡ a x (H .fst .F-hom {X} {B} (hylo .fst) x (c x ξ))
+    hylo-unfold x ξ = funExt⁻ (funExt⁻ (hylo .snd) x) ξ
+
     hylo-uniq : (h : Hylo (H .fst) (X , c) (B , a)) → h ≡ hylo
     hylo-uniq (h , he) = ΣPathP (mapEq , path2)
       where
@@ -215,6 +220,13 @@ module _ {C : Category ℓ ℓ'} {Wo : WFOrder ℓD ℓ'}
                    (mapEq i)
                    (λ x ξ → a x (H .fst .F-hom (mapEq i) x (c x ξ))))
           he (hylo .snd)
+
+    hylo-uniq-unfold : (h : Fam [ X , B ])
+      → (∀ x ξ → h x ξ ≡ a x (H .fst .F-hom {X} {B} h x (c x ξ)))
+      → ∀ x ξ → h x ξ ≡ hylo .fst x ξ
+    hylo-uniq-unfold h he x ξ =
+      funExt⁻
+        (funExt⁻ (cong fst (hylo-uniq (h , funExt λ y → funExt (he y)))) x) ξ
 
   -- local contractivity makes the hylomorphism profunctor trivial;
   -- recursiveness and corecursiveness are its curried readings, and

--- a/Cubical/Categories/Direct/Predecessor.agda
+++ b/Cubical/Categories/Direct/Predecessor.agda
@@ -1,0 +1,165 @@
+{-# OPTIONS --lossy-unification #-}
+-- Predecessor presentation of ▷: when the strict downset ↡x is
+-- represented by a predecessor p, ▷Psh P at x is P at p; at a minimal
+-- object ▷Psh P is trivial.
+module Cubical.Categories.Direct.Predecessor where
+
+open import Cubical.Foundations.Prelude
+open import Cubical.Foundations.Equiv
+open import Cubical.Foundations.HLevels
+open import Cubical.Foundations.Isomorphism
+open import Cubical.Foundations.Structure
+open import Cubical.Data.Sigma
+open import Cubical.Data.Unit using (Unit* ; tt*)
+open import Cubical.Data.Empty as ⊥ using ()
+open import Cubical.Relation.Nullary using (¬_)
+
+open import Cubical.Categories.Category
+open import Cubical.Categories.Functor
+open import Cubical.Categories.Presheaf.Base
+open import Cubical.Categories.Presheaf.More
+open import Cubical.Categories.Presheaf.StrictHom.Base
+open import Cubical.Categories.Direct.Base
+open import Cubical.Categories.Direct.StrictDownset
+  using ( ↡Psh ; ▷Psh ; next
+        ; ▷Fam ; nextFam ; löbFam ; löbFam-unfold ; löbFam-uniq-unfold )
+import Cubical.Categories.Presheaf.Family.Base as FamBase
+
+private
+  variable
+    ℓ ℓ' ℓD ℓP : Level
+
+module _ {C : Category ℓ ℓ'} {Wo : WFOrder ℓD ℓ'}
+         (dir : DirectStr {C = C} Wo) where
+  open Category C
+  open Functor
+  open PshHomStrict
+  open DirectNotation dir
+
+  -- p is a predecessor of x when it represents the strict downset ↡x
+  record isPredOf (x p : ob) : Type (ℓ-max ℓ ℓ') where
+    field
+      ρ   : C [ p , x ]
+      p≺x : p ≺ x
+
+    ↡fun : ∀ y → C [ y , p ] → ⟨ ↡Psh dir x .F-ob y ⟩
+    ↡fun y f = (f ⋆ ρ) , ≺-precomp f p≺x
+
+    field
+      univ : ∀ y → isEquiv (↡fun y)
+
+    ↡eq : ∀ y → C [ y , p ] ≃ ⟨ ↡Psh dir x .F-ob y ⟩
+    ↡eq y = ↡fun y , univ y
+
+  module _ {ℓP} (P : Presheaf C ℓP) where
+    private
+      module P = PresheafNotation P
+
+    -- ▷ at a minimal object is trivial
+    module _ {x : ob} (min : ∀ y → ¬ (y ≺ x)) where
+      ▷min : isContr ⟨ ▷Psh dir P .F-ob x ⟩
+      ▷min .fst = pshhom
+        (λ y (g , q) → ⊥.rec (min y q))
+        (λ y' y h (g , q) w hyp → ⊥.rec (min y q))
+      ▷min .snd α = makePshHomStrictPath
+        (funExt λ y → funExt λ (g , q) → ⊥.rec (min y q))
+
+    -- ▷ at x computes as P at the predecessor
+    module _ {x p : ob} (pred : isPredOf x p) where
+      open isPredOf pred
+
+      ▷pred : Iso ⟨ ▷Psh dir P .F-ob x ⟩ ⟨ P .F-ob p ⟩
+      ▷pred .Iso.fun α = α .N-ob p (ρ , p≺x)
+      ▷pred .Iso.inv v = pshhom
+        (λ y w → invEq (↡eq y) w P.⋆ v)
+        (λ y' y h w' w hyp →
+          sym (P.⋆Assoc h (invEq (↡eq y) w') v)
+          ∙ cong (P._⋆ v)
+              (sym (retEq (↡eq y') (h ⋆ invEq (↡eq y) w'))
+               ∙ cong (invEq (↡eq y'))
+                   (Σ≡Prop (λ _ → isProp≺ _ _)
+                      (⋆Assoc h (invEq (↡eq y) w') ρ
+                       ∙ cong (h ⋆_) (cong fst (secEq (↡eq y) w')))
+                    ∙ hyp)))
+      ▷pred .Iso.sec v =
+        cong (P._⋆ v)
+          (cong (invEq (↡eq p)) (Σ≡Prop (λ _ → isProp≺ _ _) (sym (⋆IdL ρ)))
+           ∙ retEq (↡eq p) id)
+        ∙ P.⋆IdL v
+      ▷pred .Iso.ret α = makePshHomStrictPath (funExt λ y → funExt λ w →
+        α .N-hom y p (invEq (↡eq y) w) (ρ , p≺x) _ refl
+        ∙ cong (α .N-ob y) (secEq (↡eq y) w))
+
+      -- under ▷pred, next is restriction along ρ
+      ▷pred-next : (u : ⟨ P .F-ob x ⟩)
+        → ▷pred .Iso.fun (next dir P .N-ob x u) ≡ ρ P.⋆ u
+      ▷pred-next u = refl
+
+  -- the family ▷ in predecessor form
+  module _ {ℓF} (A : ob → hSet (ℓ-max ℓF (ℓ-max ℓ ℓ'))) where
+    private
+      GA = FamBase.Cofree {ℓ = ℓF} C .F-ob A
+
+    ▷FamPred : {x p : ob} → isPredOf x p
+      → Iso ⟨ ▷Fam dir {ℓF = ℓF} A x ⟩ ((z : ob) → C [ z , p ] → ⟨ A z ⟩)
+    ▷FamPred = ▷pred GA
+
+    ▷FamMin : {x : ob} → (∀ y → ¬ (y ≺ x))
+      → isContr ⟨ ▷Fam dir {ℓF = ℓF} A x ⟩
+    ▷FamMin = ▷min GA
+
+    -- under ▷FamPred, nextFam is the constant closure, so
+    -- löbFam-unfold computes in predecessor form
+    ▷FamPred-next : {x p : ob} (pr : isPredOf x p) (t : ∀ z → ⟨ A z ⟩)
+      → ▷FamPred pr .Iso.fun (nextFam dir {ℓF = ℓF} A t x)
+        ≡ (λ z _ → t z)
+    ▷FamPred-next pr t = refl
+
+  -- every object is minimal or has a predecessor
+  data ▷View (x : ob) : Type (ℓ-max ℓ ℓ') where
+    minimal : (∀ y → ¬ (y ≺ x)) → ▷View x
+    hasPred : (p : ob) → isPredOf x p → ▷View x
+
+  Predecessors : Type (ℓ-max ℓ ℓ')
+  Predecessors = ∀ x → ▷View x
+
+  -- Löb induction through the predecessor presentation of ▷Fam
+  module _ (pv : Predecessors) {ℓF}
+           (A : ob → hSet (ℓ-max ℓF (ℓ-max ℓ ℓ'))) where
+
+    LaterPredAt : {x : ob} → ▷View x → Type (ℓ-max ℓF (ℓ-max ℓ ℓ'))
+    LaterPredAt (minimal _)   = Unit*
+    LaterPredAt (hasPred p _) = (z : ob) → C [ z , p ] → ⟨ A z ⟩
+
+    LaterPred : ob → Type (ℓ-max ℓF (ℓ-max ℓ ℓ'))
+    LaterPred x = LaterPredAt (pv x)
+
+    LaterPredIsoAt : {x : ob} (v : ▷View x)
+      → Iso ⟨ ▷Fam dir {ℓF = ℓF} A x ⟩ (LaterPredAt v)
+    LaterPredIsoAt (minimal m) .Iso.fun _ = tt*
+    LaterPredIsoAt (minimal m) .Iso.inv _ = ▷FamMin A m .fst
+    LaterPredIsoAt (minimal m) .Iso.sec _ = refl
+    LaterPredIsoAt (minimal m) .Iso.ret β = ▷FamMin A m .snd β
+    LaterPredIsoAt (hasPred p pr) = ▷FamPred A pr
+
+    LaterPredIso : ∀ x → Iso ⟨ ▷Fam dir {ℓF = ℓF} A x ⟩ (LaterPred x)
+    LaterPredIso x = LaterPredIsoAt (pv x)
+
+    module LöbPred (φ : ∀ x → LaterPred x → ⟨ A x ⟩) where
+      private
+        φ▷ : ∀ x → ⟨ ▷Fam dir {ℓF = ℓF} A x ⟩ → ⟨ A x ⟩
+        φ▷ x β = φ x (LaterPredIso x .Iso.fun β)
+
+      nextPred : (∀ z → ⟨ A z ⟩) → ∀ x → LaterPred x
+      nextPred t x = LaterPredIso x .Iso.fun (nextFam dir {ℓF = ℓF} A t x)
+
+      fix : ∀ x → ⟨ A x ⟩
+      fix = löbFam dir {ℓF = ℓF} A φ▷
+
+      unfold : ∀ x → fix x ≡ φ x (nextPred fix x)
+      unfold = löbFam-unfold dir {ℓF = ℓF} A φ▷
+
+      uniq : (t : ∀ x → ⟨ A x ⟩)
+        → (∀ x → t x ≡ φ x (nextPred t x))
+        → t ≡ fix
+      uniq = löbFam-uniq-unfold dir {ℓF = ℓF} A φ▷

--- a/Cubical/Categories/Direct/Product.agda
+++ b/Cubical/Categories/Direct/Product.agda
@@ -1,0 +1,178 @@
+-- The product of two direct categories is direct.
+module Cubical.Categories.Direct.Product where
+
+open import Cubical.Foundations.Prelude
+open import Cubical.Foundations.HLevels
+open import Cubical.Data.Sigma
+open import Cubical.Data.Sum
+open import Cubical.Data.Empty as ⊥
+open import Cubical.Relation.Nullary using (¬_ ; isProp¬)
+import Cubical.Data.Equality as Eq
+
+open import Cubical.Induction.WellFounded
+
+open import Cubical.Categories.Category
+open import Cubical.Categories.Instances.BinProduct
+open import Cubical.Categories.Direct.Base
+
+private
+  variable
+    ℓc ℓc' ℓe ℓe' ℓD ℓD' ℓ< ℓ<' : Level
+
+  ≤-antisym : (W : WFOrder ℓD ℓ<) {a b : WFOrder.D W}
+            → WFOrder._≤_ W a b → WFOrder._≤_ W b a → a Eq.≡ b
+  ≤-antisym W (inr a≡b) _         = a≡b
+  ≤-antisym W (inl a<b) (inr b≡a) = Eq.sym b≡a
+  ≤-antisym W (inl a<b) (inl b<a) =
+    ⊥.rec (WFOrder.¬<refl W (WFOrder.trans< W a<b b<a))
+
+-- The lexicographic and product well-founded orders
+module _ (Wo : WFOrder ℓD ℓ<) (Wo' : WFOrder ℓD' ℓ<') where
+  private
+    module W  = WFOrder Wo
+    module W' = WFOrder Wo'
+
+    isPropEq : ∀ {a a' : W.D} → isProp (a Eq.≡ a')
+    isPropEq {a} {a'} = isOfHLevelRetract 1
+      Eq.eqToPath Eq.pathToEq Eq.pathToEq-eqToPath (W.isSetD a a')
+
+  -- Lexicographic order
+  _<Lex_ : (W.D × W'.D) → (W.D × W'.D) → Type (ℓ-max ℓ< (ℓ-max ℓD ℓ<'))
+  (a , b) <Lex (a' , b') = (a W.< a') ⊎ ((a Eq.≡ a') × (b W'.< b'))
+
+  private
+    isProp<Lex : ∀ p q → isProp (p <Lex q)
+    isProp<Lex (a , b) (a' , b') =
+      isProp⊎ (W.isProp< a a') (isProp× isPropEq (W'.isProp< b b')) disjoint
+      where
+        disjoint : (a W.< a') → ((a Eq.≡ a') × (b W'.< b')) → ⊥
+        disjoint a<a' (a≡a' , _) = W.¬<refl (Eq.transport (a W.<_) (Eq.sym a≡a') a<a')
+
+    trans<Lex : ∀ {p q r} → p <Lex q → q <Lex r → p <Lex r
+    trans<Lex (inl a<a')          (inl a'<a'')          = inl (W.trans< a<a' a'<a'')
+    trans<Lex {p = a , _} (inl a<a') (inr (a'≡a'' , _)) =
+      inl (Eq.transport (a W.<_) a'≡a'' a<a')
+    trans<Lex {r = a'' , _} (inr (a≡a' , _)) (inl a'<a'') =
+      inl (Eq.transport (W._< a'') (Eq.sym a≡a') a'<a'')
+    trans<Lex (inr (a≡a' , b<b')) (inr (a'≡a'' , b'<b'')) =
+      inr (a≡a' Eq.∙ a'≡a'' , W'.trans< b<b' b'<b'')
+
+    wf<Lex : WellFounded _<Lex_
+    wf<Lex (a , b) = go a (W.wf< a) b (W'.wf< b)
+      where
+        go : ∀ a → Acc W._<_ a → ∀ b → Acc W'._<_ b → Acc _<Lex_ (a , b)
+        go a aA@(acc rsA) b (acc rsB) = acc λ where
+          (a' , b') (inl a'<a)             → go a' (rsA a' a'<a) b' (W'.wf< b')
+          (a' , b') (inr (Eq.refl , b'<b)) → go a  aA            b' (rsB b' b'<b)
+
+  LexWFOrder : WFOrder (ℓ-max ℓD ℓD') (ℓ-max ℓ< (ℓ-max ℓD ℓ<'))
+  LexWFOrder = record
+    { D       = W.D × W'.D
+    ; isSetD  = isSet× W.isSetD W'.isSetD
+    ; _<_     = _<Lex_
+    ; isProp< = isProp<Lex
+    ; trans<  = trans<Lex
+    ; wf<     = wf<Lex
+    }
+
+  -- Product order
+  _<Prod_ : (W.D × W'.D) → (W.D × W'.D)
+       → Type (ℓ-max (ℓ-max ℓD ℓD') (ℓ-max ℓ< ℓ<'))
+  (a , b) <Prod (a' , b') =
+    (a W.≤ a') × (b W'.≤ b') × (¬ ((a Eq.≡ a') × (b Eq.≡ b')))
+
+  private
+    isProp<Prod : ∀ p q → isProp (p <Prod q)
+    isProp<Prod (a , b) (a' , b') =
+      isProp× W.isProp≤ (isProp× W'.isProp≤ (isProp¬ _))
+
+    trans<Prod : ∀ {p q r} → p <Prod q → q <Prod r → p <Prod r
+    trans<Prod {a , b} {a' , b'} {a'' , b''}
+            (a≤a' , b≤b' , ne) (a'≤a'' , b'≤b'' , _) =
+      W.≤-trans a≤a' a'≤a'' , W'.≤-trans b≤b' b'≤b'' , ne''
+      where
+        -- If `(a,b) = (a'',b'')` then, sandwiched by the ≤'s, also
+        -- `(a,b) = (a',b')`, contradicting the first strictness witness.
+        ne'' : ¬ ((a Eq.≡ a'') × (b Eq.≡ b''))
+        ne'' (a≡a'' , b≡b'') = ne
+          ( ≤-antisym Wo  a≤a' (Eq.transport (a' W.≤_)  (Eq.sym a≡a'') a'≤a'')
+          , ≤-antisym Wo' b≤b' (Eq.transport (b' W'.≤_) (Eq.sym b≡b'') b'≤b'') )
+
+    -- `_<Prod_ ⊆ _<Lex_`, so accessibility for lex transfers to product order.
+    <Prod→<Lex : ∀ {p q} → p <Prod q → p <Lex q
+    <Prod→<Lex (inl a<a' , _        , _)  = inl a<a'
+    <Prod→<Lex (inr a≡a' , inl b<b' , _)  = inr (a≡a' , b<b')
+    <Prod→<Lex (inr a≡a' , inr b≡b' , ne) = ⊥.rec (ne (a≡a' , b≡b'))
+
+    wf<Prod : WellFounded _<Prod_
+    wf<Prod p = go p (wf<Lex p)
+      where
+        go : ∀ p → Acc _<Lex_ p → Acc _<Prod_ p
+        go p (acc r) = acc λ q q<p → go q (r q (<Prod→<Lex q<p))
+
+  ProdWFOrder : WFOrder (ℓ-max ℓD ℓD') (ℓ-max (ℓ-max ℓD ℓD') (ℓ-max ℓ< ℓ<'))
+  ProdWFOrder = record
+    { D       = W.D × W'.D
+    ; isSetD  = isSet× W.isSetD W'.isSetD
+    ; _<_     = _<Prod_
+    ; isProp< = isProp<Prod
+    ; trans<  = trans<Prod
+    ; wf<     = wf<Prod
+    }
+
+-- The product of two direct categories, over either order.
+module _ {C : Category ℓc ℓc'} {D : Category ℓe ℓe'}
+         {Wo : WFOrder ℓD ℓ<} {Wo' : WFOrder ℓD' ℓ<'} where
+  private
+    module W  = WFOrder Wo
+    module W' = WFOrder Wo'
+
+  -- Directness over the lexicographic order
+  LexDirect : DirectStr {C = C} Wo → DirectStr {C = D} Wo'
+              → DirectStr {C = C ×C D} (LexWFOrder Wo Wo')
+  LexDirect dirC dirD =
+    mkDirectStr {C = C ×C D} (LexWFOrder Wo Wo') deg× non-dec×
+    where
+      open DirectNotation dirC using () renaming (deg to degC ; non-dec to non-decC)
+      open DirectNotation dirD using () renaming (deg to degD ; non-dec to non-decD)
+
+      deg× : Category.ob (C ×C D) → W.D × W'.D
+      deg× (c , d) = degC c , degD d
+
+      -- component-wise `≤` (from the two non-decreasing degrees) is a lex `≤`.
+      lex≤ : ∀ {a a' b b'} → a W.≤ a' → b W'.≤ b'
+           → WFOrder._≤_ (LexWFOrder Wo Wo') (a , b) (a' , b')
+      lex≤ (inl a<a')     _              = inl (inl a<a')
+      lex≤ (inr Eq.refl) (inl b<b')      = inl (inr (Eq.refl , b<b'))
+      lex≤ (inr Eq.refl) (inr Eq.refl)   = inr Eq.refl
+
+      non-dec× : ∀ {x y} → (C ×C D) [ x , y ]
+               → WFOrder._≤_ (LexWFOrder Wo Wo') (deg× x) (deg× y)
+      non-dec× (f , g) = lex≤ (non-decC f) (non-decD g)
+
+  -- Directness over the product order.
+  ProdDirect : DirectStr {C = C} Wo → DirectStr {C = D} Wo'
+               → DirectStr {C = C ×C D} (ProdWFOrder Wo Wo')
+  ProdDirect dirC dirD =
+    mkDirectStr {C = C ×C D} (ProdWFOrder Wo Wo') deg× non-dec×
+    where
+      open DirectNotation dirC using () renaming (deg to degC ; non-dec to non-decC)
+      open DirectNotation dirD using () renaming (deg to degD ; non-dec to non-decD)
+
+      deg× : Category.ob (C ×C D) → W.D × W'.D
+      deg× (c , d) = degC c , degD d
+
+      -- component-wise `≤` IS the product `≤` (equal pairs go to `inr`).
+      prod≤ : ∀ {a a' b b'} → a W.≤ a' → b W'.≤ b'
+            → WFOrder._≤_ (ProdWFOrder Wo Wo') (a , b) (a' , b')
+      prod≤ {a} (inl a<a') b≤b' =
+        inl (inl a<a' , b≤b'
+            , λ (a≡a' , _) → W.¬<refl (Eq.transport (a W.<_) (Eq.sym a≡a') a<a'))
+      prod≤ {b = b} (inr a≡a') (inl b<b') =
+        inl (inr a≡a' , inl b<b'
+            , λ (_ , b≡b') → W'.¬<refl (Eq.transport (b W'.<_) (Eq.sym b≡b') b<b'))
+      prod≤ (inr Eq.refl) (inr Eq.refl) = inr Eq.refl
+
+      non-dec× : ∀ {x y} → (C ×C D) [ x , y ]
+               → WFOrder._≤_ (ProdWFOrder Wo Wo') (deg× x) (deg× y)
+      non-dec× (f , g) = prod≤ (non-decC f) (non-decD g)

--- a/Cubical/Categories/Direct/StrictDownset.agda
+++ b/Cubical/Categories/Direct/StrictDownset.agda
@@ -1,0 +1,260 @@
+-- The strict-downset sieve ↡c of a direct category.
+module Cubical.Categories.Direct.StrictDownset where
+
+open import Cubical.Foundations.Prelude
+open import Cubical.Foundations.HLevels
+open import Cubical.Foundations.Structure
+open import Cubical.Data.Sigma
+open import Cubical.Data.Sum
+import Cubical.Data.Sum as Sum
+open import Cubical.Data.Empty as ⊥
+open import Cubical.Data.Unit
+
+open import Cubical.Induction.WellFounded
+
+open import Cubical.Categories.Category
+open import Cubical.Categories.Functor
+open import Cubical.Categories.Morphism
+open import Cubical.Categories.Presheaf.Base
+open import Cubical.Categories.Presheaf.StrictHom.Base
+open import Cubical.Categories.Presheaf.Constructions.Unit
+open import Cubical.Categories.Yoneda
+open import Cubical.Categories.Subobject.Base
+open import Cubical.Categories.Presheaf.Sieve
+open import Cubical.Categories.Direct.Base
+import Cubical.Categories.Presheaf.Family.Base as FamBase
+import Cubical.Categories.Adjoint as Adjoint
+import Cubical.Categories.NaturalTransformation as NT
+import Cubical.Data.Equality as Eq
+
+private
+  variable
+    ℓ ℓ' ℓD : Level
+
+module _ {C : Category ℓ ℓ'} {Wo : WFOrder ℓD ℓ'} (dir : DirectStr {C = C} Wo) where
+  open Category C
+  open Functor
+  open PshHomStrict
+  open DirectNotation dir
+
+  -- the strict-downset sub-presheaf of よc
+  ↡Psh : (c : ob) → Presheaf C ℓ'
+  ↡Psh c .F-ob y =
+    (Σ[ f ∈ C [ y , c ] ] (y ≺ c))
+    , isSetΣ isSetHom (λ _ → isProp→isSet (isProp≺ y c))
+  ↡Psh c .F-hom g (f , p) = (g ⋆ f) , ≺-precomp g p
+  ↡Psh c .F-id     = funExt λ (f , p) → Σ≡Prop (λ _ → isProp≺ _ _) (⋆IdL f)
+  ↡Psh c .F-seq g h = funExt λ (f , p) → Σ≡Prop (λ _ → isProp≺ _ _) (⋆Assoc h g f)
+
+  ↡incl : (c : ob) → PshHomStrict (↡Psh c) (yo c)
+  ↡incl c .N-ob y (f , p) = f
+  ↡incl c .N-hom y' y g (f' , p') (f , p) e = cong fst e
+
+  ↡monic : (c : ob) → isMonic (PRESHEAF C ℓ') (↡incl c)
+  ↡monic c {a = g} {a' = g'} eq =
+    makePshHomStrictPath (funExt λ y → funExt λ t →
+      Σ≡Prop (λ _ → isProp≺ _ _) (λ i → (eq i) .N-ob y t))
+
+  -- the strict downset, as a sieve on c
+  ↡ : (c : ob) → Sieve C c
+  ↡ c = ↡Psh c , ↡incl c , ↡monic c
+
+  ↡F : Functor C (PRESHEAF C ℓ')
+  ↡F .F-ob = ↡Psh
+  ↡F .F-hom a .N-ob y (f , p) = (f ⋆ a) , ≺-postcomp p a
+  ↡F .F-hom a .N-hom y' y g (f' , p') (f , p) e =
+    Σ≡Prop (λ _ → isProp≺ _ _) (sym (⋆Assoc g f' a) ∙ cong (_⋆ a) (cong fst e))
+  ↡F .F-id =
+    makePshHomStrictPath (funExt λ y → funExt λ (f , p) →
+      Σ≡Prop (λ _ → isProp≺ _ _) (⋆IdR f))
+  ↡F .F-seq a b =
+    makePshHomStrictPath (funExt λ y → funExt λ (f , p) →
+      Σ≡Prop (λ _ → isProp≺ _ _) (sym (⋆Assoc f a b)))
+
+  private module Wo = WFOrder Wo
+
+  -- ↡c contains exactly the strict maps into c
+  ↡∋→≺ : ∀ {c y} (f : C [ y , c ]) → (↡ c) ∋ f → y ≺ c
+  ↡∋→≺ f ((_ , p) , _) = p
+
+  ≺→↡∋ : ∀ {c y} (f : C [ y , c ]) → y ≺ c → (↡ c) ∋ f
+  ≺→↡∋ f p = (f , p) , refl
+
+  -- ↡c omits the identity so its a proper sieve
+  ↡-proper : ∀ {c} → isProperSieve (↡ c)
+  ↡-proper {c} idIn = Wo.¬<refl (↡∋→≺ id idIn)
+
+  -- A direct structure is reflecting when equal-degree maps are split epis.
+  -- In such a category non-identities
+  -- strictly raise degree, so ↡ is the maximal proper sieve
+  Reflecting : Type (ℓ-max (ℓ-max ℓ ℓ') ℓD)
+  Reflecting = ∀ {x y} (f : C [ x , y ])
+    → deg x ≡ deg y → Σ[ s ∈ C [ y , x ] ] (s ⋆ f ≡ id)
+
+  -- every proper sieve refines into ↡c
+  ↡-maximal : Reflecting → ∀ {c} (S : Sieve C c) → isProperSieve S → S ⊆ ↡ c
+  ↡-maximal refl-dir {c} S proper f Sf =
+    Sum.elim {C = λ _ → (↡ c) ∋ f}
+      (λ y≺c → ≺→↡∋ f y≺c)
+      (λ y≡c → let sec = refl-dir f (Eq.eqToPath y≡c)
+               in ⊥.rec (proper (subst (S ∋_) (sec .snd)
+                                        (sieve-precomp S (sec .fst) Sf))))
+      (non-dec f)
+
+  module _ {ℓP} (P : Presheaf C ℓP) where
+    ▷Psh : Presheaf C (ℓ-max (ℓ-max (ℓ-max ℓ ℓ') ℓ') ℓP)
+    ▷Psh .F-ob x = PshHomStrict (↡Psh x) P , isSetPshHomStrict _ _
+    ▷Psh .F-hom a α = ↡F .F-hom a ⋆PshHomStrict α
+    ▷Psh .F-id     = funExt λ α → cong (_⋆PshHomStrict α) (↡F .F-id)
+    ▷Psh .F-seq a b = funExt λ α → cong (_⋆PshHomStrict α) (↡F .F-seq b a)
+
+    next : PshHomStrict P ▷Psh
+    next .N-ob x p = pshhom (λ y (g , q) → P .F-hom g p)
+      (λ c c' h (g' , q') (g , q) e →
+        sym (funExt⁻ (P .F-seq g' h) p) ∙ cong (λ k → P .F-hom k p) (cong fst e))
+    next .N-hom c c' f p' p e =
+      makePshHomStrictPath (funExt λ y → funExt λ (g , q) →
+        funExt⁻ (P .F-seq f g) p' ∙ cong (P .F-hom g) e)
+
+    module _ (fhom : PshHomStrict ▷Psh P) where
+      private
+        f₀ : ∀ c → PshHomStrict (↡Psh c) P → ⟨ P .F-ob c ⟩
+        f₀ = fhom .N-ob
+
+      down : ∀ c → Acc _≺_ c → PshHomStrict (↡Psh c) P
+      downIrr : ∀ c (A A' : Acc _≺_ c) → down c A ≡ down c A'
+      downNat : ∀ {y' y} (A' : Acc _≺_ y') (A : Acc _≺_ y) (h : C [ y' , y ])
+              → ↡F .F-hom h ⋆PshHomStrict down y A ≡ down y' A'
+
+      down c (acc r) .N-ob y (g , q) = f₀ y (down y (r y q))
+      down c (acc r) .N-hom y' y h (g' , q') (g , q) e =
+        fhom .N-hom y' y h (down y (r y q')) _ refl
+        ∙ cong (f₀ y') (downNat (r y' q) (r y q') h)
+      downIrr c (acc r) (acc r') =
+        makePshHomStrictPath (funExt λ y → funExt λ (g , q) →
+          cong (f₀ y) (downIrr y (r y q) (r' y q)))
+      downNat (acc rA') (acc rA) h =
+        makePshHomStrictPath (funExt λ z → funExt λ (m , s) →
+          cong (f₀ z) (downIrr z (rA z (≺-postcomp s h)) (rA' z s)))
+
+      löb : PshHomStrict UnitPsh P
+      löb .N-ob c _ = f₀ c (down c (wf≺ c))
+      löb .N-hom c c' h _ _ _ =
+        fhom .N-hom c c' h (down c' (wf≺ c')) _ refl
+        ∙ cong (f₀ c) (downNat (wf≺ c) (wf≺ c') h)
+
+      downValue : ∀ c (Ac : Acc _≺_ c) {y} (g : C [ y , c ]) (q : y ≺ c)
+                → down c Ac .N-ob y (g , q) ≡ f₀ y (down y (wf≺ y))
+      downValue c (acc r) {y} g q = cong (f₀ y) (downIrr y (r y q) (wf≺ y))
+
+      -- the guarded fixed-point equation:  löb = (löb ⋆ next) ⋆ f
+      löb-fix : löb ≡ (löb ⋆PshHomStrict next) ⋆PshHomStrict fhom
+      löb-fix = makePshHomStrictPath (funExt λ c → funExt λ _ →
+        cong (f₀ c) (makePshHomStrictPath (funExt λ y → funExt λ (g , q) →
+          downValue c (wf≺ c) g q ∙ sym (löb .N-hom y c g _ _ refl))))
+
+      -- and it is the unique fixed point
+      löb-uniq : (s : PshHomStrict UnitPsh P)
+               → s ≡ (s ⋆PshHomStrict next) ⋆PshHomStrict fhom
+               → s ≡ löb
+      löb-uniq s s-fix =
+        makePshHomStrictPath (funExt λ c → funExt λ _ → WFI.induction wf≺ step c)
+        where
+          step : ∀ c → (∀ y → y ≺ c → s .N-ob y tt ≡ löb .N-ob y tt)
+               → s .N-ob c tt ≡ löb .N-ob c tt
+          step c IH =
+            funExt⁻ (funExt⁻ (cong N-ob s-fix) c) tt
+            ∙ cong (f₀ c) (makePshHomStrictPath (funExt λ y → funExt λ (g , q) →
+                s .N-hom y c g _ _ refl ∙ IH y q ∙ sym (downValue c (wf≺ c) g q)))
+
+  module _ {ℓF} (A : ob → hSet (ℓ-max ℓF (ℓ-max ℓ ℓ'))) where
+    private
+      U = FamBase.PSH→Fam {ℓ = ℓF} C
+      G = FamBase.Cofree {ℓ = ℓF} C
+      module Adj = Adjoint.UnitCounit._⊣_ (FamBase.CofreeFamAdj {ℓ = ℓF} C)
+      ηP = NT.NatTrans.N-ob Adj.η
+      εA = NT.NatTrans.N-ob Adj.ε
+
+    ▷Fam : ob → hSet _
+    ▷Fam = U .F-ob (▷Psh (G .F-ob A))
+
+    toFam : PshHomStrict UnitPsh (G .F-ob A) → (∀ x → ⟨ A x ⟩)
+    toFam s x = εA A x (s .N-ob x _)
+
+    fromFam : (∀ x → ⟨ A x ⟩) → PshHomStrict UnitPsh (G .F-ob A)
+    fromFam t = pshhom (λ c _ y h → t y) (λ c c' f p' p e → refl)
+
+    toFam-fromFam : (t : ∀ x → ⟨ A x ⟩) → toFam (fromFam t) ≡ t
+    toFam-fromFam t = refl
+
+    fromFam-toFam : (s : PshHomStrict UnitPsh (G .F-ob A)) → fromFam (toFam s) ≡ s
+    fromFam-toFam s = makePshHomStrictPath (funExt λ c → funExt λ _ →
+      funExt λ y → funExt λ h →
+        sym (funExt⁻ (funExt⁻ (s .N-hom y c h _ _ refl) y) id)
+        ∙ cong (s .N-ob c _ y) (⋆IdL h))
+
+    nextFam : (∀ x → ⟨ A x ⟩) → ∀ x → ⟨ ▷Fam x ⟩
+    nextFam t x =
+      (fromFam t ⋆PshHomStrict next (G .F-ob A)) .N-ob x tt
+
+    -- apply a later element at a strict bound
+    ▷FamApp : {x y : ob} → ⟨ ▷Fam x ⟩ → C [ y , x ] → y ≺ x → ⟨ A y ⟩
+    ▷FamApp β g q = β .N-ob _ (g , q) _ id
+
+    module _ (φ : ∀ x → ⟨ ▷Fam x ⟩ → ⟨ A x ⟩) where
+      φ↑ : PshHomStrict (▷Psh (G .F-ob A)) (G .F-ob A)
+      φ↑ = ηP (▷Psh (G .F-ob A)) ⋆PshHomStrict G .F-hom φ
+
+      löbFam : ∀ x → ⟨ A x ⟩
+      löbFam = toFam (löb (G .F-ob A) φ↑)
+
+      stepFam : (∀ x → ⟨ A x ⟩) → (∀ x → ⟨ A x ⟩)
+      stepFam t =
+        toFam ((fromFam t ⋆PshHomStrict next (G .F-ob A)) ⋆PshHomStrict φ↑)
+
+      löbFam-fix : löbFam ≡ stepFam löbFam
+      löbFam-fix =
+        cong toFam (löb-fix (G .F-ob A) φ↑)
+        ∙ sym (cong (λ s →
+                 toFam ((s ⋆PshHomStrict next (G .F-ob A)) ⋆PshHomStrict φ↑))
+                 (fromFam-toFam (löb (G .F-ob A) φ↑)))
+
+      löbFam-uniq : (t : ∀ x → ⟨ A x ⟩) → t ≡ stepFam t → t ≡ löbFam
+      löbFam-uniq t t-fix =
+        sym (toFam-fromFam t)
+        ∙ cong toFam
+            (löb-uniq (G .F-ob A) φ↑ (fromFam t)
+              (cong fromFam t-fix
+               ∙ fromFam-toFam
+                   ((fromFam t ⋆PshHomStrict next (G .F-ob A)) ⋆PshHomStrict φ↑)))
+
+      löbFam-unfold : ∀ x → löbFam x ≡ φ x (nextFam löbFam x)
+      löbFam-unfold x =
+        funExt⁻ löbFam-fix x
+        ∙ cong (φ x)
+            (funExt⁻ (▷Psh (G .F-ob A) .F-id) (nextFam löbFam x))
+
+      löbFam-uniq-unfold : (t : ∀ x → ⟨ A x ⟩)
+        → (∀ x → t x ≡ φ x (nextFam t x)) → t ≡ löbFam
+      löbFam-uniq-unfold t teq = löbFam-uniq t (funExt λ x →
+        teq x
+        ∙ cong (φ x)
+            (sym (funExt⁻ (▷Psh (G .F-ob A) .F-id) (nextFam t x))))
+
+  private
+    ℓ▷ : Level
+    ℓ▷ = ℓ-max ℓ ℓ'
+
+  ▷ : Functor (PRESHEAF C ℓ▷) (PRESHEAF C ℓ▷)
+  ▷ .F-ob P = ▷Psh P
+  ▷ .F-hom φ .N-ob x β = β ⋆PshHomStrict φ
+  ▷ .F-hom φ .N-hom c c' f β' β e = cong (_⋆PshHomStrict φ) e
+  ▷ .F-id      = makePshHomStrictPath refl
+  ▷ .F-seq φ ψ = makePshHomStrictPath refl
+
+  nextNT : NT.NatTrans Id ▷
+  nextNT = NT.natTrans (λ P → next P)
+    (λ {P} {Q} φ →
+      makePshHomStrictPath (funExt λ x → funExt λ p →
+        makePshHomStrictPath (funExt λ y → funExt λ (g , q) →
+          φ .N-hom y x g p (P .F-hom g p) refl)))

--- a/Cubical/Categories/Direct/StrictUpset.agda
+++ b/Cubical/Categories/Direct/StrictUpset.agda
@@ -1,0 +1,122 @@
+{-# OPTIONS --lossy-unification #-}
+-- The strict-upset coend ◁ of a direct category — the Earlier modality,
+-- dual to the Later modality ▷ of Cubical.Categories.Direct.StrictDownset.
+module Cubical.Categories.Direct.StrictUpset where
+
+open import Cubical.Foundations.Prelude
+open import Cubical.Foundations.Function
+open import Cubical.Foundations.HLevels
+open import Cubical.Foundations.Isomorphism
+open import Cubical.Foundations.Structure
+open import Cubical.Data.Sigma
+
+open import Cubical.Categories.Category
+open import Cubical.Categories.Functor
+open import Cubical.Categories.NaturalTransformation
+open import Cubical.Categories.Instances.Sets
+open import Cubical.Categories.Presheaf.Base
+open import Cubical.Categories.Presheaf.More
+open import Cubical.Categories.Presheaf.StrictHom.Base
+open import Cubical.Categories.Presheaf.Constructions.Tensor
+open import Cubical.Categories.Direct.Base
+open import Cubical.Categories.Direct.StrictDownset using (▷Psh ; next)
+
+private
+  variable
+    ℓ ℓ' ℓD : Level
+
+module _ {C : Category ℓ ℓ'} {Wo : WFOrder ℓD ℓ'} (dir : DirectStr {C = C} Wo) where
+  open Category C
+  open Functor
+  open NatTrans
+  open PshHomStrict
+  open DirectNotation dir
+
+  ↟Fun : (x : ob) → Functor C (SET ℓ')
+  ↟Fun x .F-ob y =
+    (Σ[ f ∈ C [ x , y ] ] (x ≺ y))
+    , isSetΣ isSetHom (λ _ → isProp→isSet (isProp≺ x y))
+  ↟Fun x .F-hom g (f , p) = (f ⋆ g) , ≺-postcomp p g
+  ↟Fun x .F-id     = funExt λ (f , p) → Σ≡Prop (λ _ → isProp≺ _ _) (⋆IdR f)
+  ↟Fun x .F-seq g h = funExt λ (f , p) → Σ≡Prop (λ _ → isProp≺ _ _) (sym (⋆Assoc f g h))
+
+  ↟reindex : ∀ {x x'} (a : C [ x , x' ]) → NatTrans (↟Fun x') (↟Fun x)
+  ↟reindex a .N-ob y (f , p) = (a ⋆ f) , ≺-precomp a p
+  ↟reindex a .N-hom {y} {y'} g = funExt λ (f , p) →
+    Σ≡Prop (λ _ → isProp≺ _ _) (sym (⋆Assoc a f g))
+
+  module _ {ℓP} (P : Presheaf C ℓP) where
+    private
+      module P = PresheafNotation P
+      module ⊗x {x} = Tensor (↟Fun x) P
+
+    ◁Psh : Presheaf C (ℓ-max (ℓ-max (ℓ-max ℓ ℓ') ℓ') ℓP)
+    ◁Psh .F-ob x = (↟Fun x ⊗ P) , isSet⊗
+    ◁Psh .F-hom a = ↟reindex a ⊗NT idTrans P
+    ◁Psh .F-id {x} = funExt (⊗x.ind (λ _ → isSet⊗ _ _)
+      λ (f , p) q → cong (⊗x._,⊗ q) (Σ≡Prop (λ _ → isProp≺ _ _) (⋆IdL f)))
+    ◁Psh .F-seq a b = funExt (⊗x.ind (λ _ → isSet⊗ _ _)
+      λ (f , p) q → cong (⊗x._,⊗ q) (Σ≡Prop (λ _ → isProp≺ _ _) (⋆Assoc b a f)))
+
+    prev : PshHomStrict ◁Psh P
+    prev .N-ob x = ⊗x.rec P.isSetPsh
+      (λ (f , p) q → f P.⋆ q)
+      (λ (f , p) g q → sym (P.⋆Assoc f g q))
+    prev .N-hom x x' a t' t e =
+      prevNat t' ∙ cong (prev .N-ob x) e
+      where
+        prevNat : (u : ↟Fun x' ⊗ P)
+          → a P.⋆ prev .N-ob x' u ≡ prev .N-ob x (◁Psh .F-hom a u)
+        prevNat = ⊗x.ind (λ _ → P.isSetPsh _ _)
+          (λ (f , p) q → sym (P.⋆Assoc a f q))
+
+  -- ◁ ⊣ ▷
+  module _ {ℓP ℓQ} (P : Presheaf C ℓP) (Q : Presheaf C ℓQ) where
+    private
+      module P = PresheafNotation P
+      module Q = PresheafNotation Q
+      module ⊗P {x} = Tensor (↟Fun x) P
+
+      ◁transpose : (β : PshHomStrict P (▷Psh dir Q)) (z : ob)
+                  → (↟Fun z ⊗ P) → ⟨ Q .F-ob z ⟩
+      ◁transpose β z = ⊗P.rec Q.isSetPsh
+        (λ (g , q₀) u → β .N-ob _ u .N-ob z (g , q₀))
+        (λ (g , q₀) f u →
+          sym (λ i → β .N-hom _ _ f u _ refl i .N-ob z (g , q₀)))
+
+      ◁transposeNat : ∀ β z' z (h : C [ z' , z ]) (t' : ↟Fun z ⊗ P)
+        → h Q.⋆ ◁transpose β z t'
+          ≡ ◁transpose β z' (◁Psh P .F-hom h t')
+      ◁transposeNat β z' z h = ⊗P.ind (λ _ → Q.isSetPsh _ _)
+        λ (g , q₀) u → β .N-ob _ u .N-hom z' z h (g , q₀) _ refl
+
+    ◁UMP : Iso (PshHomStrict (◁Psh P) Q) (PshHomStrict P (▷Psh dir Q))
+    ◁UMP .Iso.fun α .N-ob y u = pshhom
+      (λ z (g , q) → α .N-ob z ((g , q) ⊗P.,⊗ u))
+      (λ z' z h (g , q) w hyp →
+        α .N-hom z' z h ((g , q) ⊗P.,⊗ u) _ refl
+        ∙ cong (λ v → α .N-ob z' (v ⊗P.,⊗ u)) hyp)
+    ◁UMP .Iso.fun α .N-hom y' y k u' u hyp =
+      makePshHomStrictPath (funExt λ z → funExt λ (g , q) →
+        cong (α .N-ob z)
+          (sym (⊗P.swap (g , q) k u') ∙ cong ((g , q) ⊗P.,⊗_) hyp))
+    ◁UMP .Iso.inv β .N-ob = ◁transpose β
+    ◁UMP .Iso.inv β .N-hom z' z h t' t hyp =
+      ◁transposeNat β z' z h t' ∙ cong (◁transpose β z') hyp
+    ◁UMP .Iso.sec β =
+      makePshHomStrictPath (funExt λ y → funExt λ u →
+        makePshHomStrictPath refl)
+    ◁UMP .Iso.ret α =
+      makePshHomStrictPath (funExt λ z →
+        funExt (⊗P.ind (λ _ → Q.isSetPsh _ _) λ (g , q₀) u → refl))
+
+  -- prev is the transpose of next
+  module _ {ℓP} (P : Presheaf C ℓP) where
+    private
+      module P = PresheafNotation P
+      module ⊗P {x} = Tensor (↟Fun x) P
+
+    transposeNext≡prev : ◁UMP P P .Iso.inv (next dir P) ≡ prev P
+    transposeNext≡prev =
+      makePshHomStrictPath (funExt λ z →
+        funExt (⊗P.ind (λ _ → P.isSetPsh _ _) λ (g , q₀) u → refl))

--- a/Cubical/Categories/Displayed/Instances/Algebras/Recursive.agda
+++ b/Cubical/Categories/Displayed/Instances/Algebras/Recursive.agda
@@ -1,0 +1,200 @@
+-- Recursive coalgebras and corecursive algebras of an endofunctor:
+-- coalgebra-to-algebra morphisms
+-- initial/final coincidence
+module Cubical.Categories.Displayed.Instances.Algebras.Recursive where
+
+open import Cubical.Foundations.Prelude
+open import Cubical.Foundations.HLevels
+open import Cubical.Foundations.Equiv
+open import Cubical.Foundations.Equiv.Properties
+open import Cubical.Foundations.Isomorphism
+open import Cubical.Data.Sigma
+open import Cubical.Data.Unit
+
+open import Cubical.Categories.Category
+open import Cubical.Categories.Functor
+open import Cubical.Categories.Bifunctor
+open import Cubical.Categories.Profunctor.Relator
+open import Cubical.Categories.NaturalTransformation
+open import Cubical.Categories.Functors.Constant
+open import Cubical.Categories.Instances.Sets
+open import Cubical.Categories.Limits.Terminal.More
+open import Cubical.Categories.Displayed.Instances.Algebras
+open import Cubical.Categories.Displayed.Instances.Coalgebras
+
+private
+  variable ℓC ℓC' : Level
+
+module _ {C : Category ℓC ℓC'} (F : Functor C C) where
+  private
+    module C = Category C
+  open Functor
+  open Bifunctor
+
+  Hylo : Coalgebra F → Algebra F → Type ℓC'
+  Hylo (X , c) (B , a) =
+    Σ[ h ∈ C [ X , B ] ] (h ≡ c C.⋆ (F .F-hom h C.⋆ a))
+
+  isSetHylo : ∀ Xc Ba → isSet (Hylo Xc Ba)
+  isSetHylo Xc Ba =
+    isSetΣ C.isSetHom (λ _ → isProp→isSet (C.isSetHom _ _))
+
+  HYLO : (COALG F) o-[ ℓC' ]-* (ALG F)
+  HYLO = mkBifunctorSep Sep
+    where
+    open BifunctorSep
+    Sep : BifunctorSep ((COALG F) ^op) (ALG F) (SET ℓC')
+    Sep .Bif-ob Xc Ba = Hylo Xc Ba , isSetHylo Xc Ba
+    Sep .Bif-homL {c = X , cX} {c' = X' , cX'} (m , msq) (B , a) (h , hsq) =
+      (m C.⋆ h)
+      , (cong (m C.⋆_) hsq
+         ∙ sym (C.⋆Assoc _ _ _)
+         ∙ cong (C._⋆ (F .F-hom h C.⋆ a)) msq
+         ∙ C.⋆Assoc _ _ _
+         ∙ cong (cX' C.⋆_)
+             (sym (C.⋆Assoc _ _ _)
+              ∙ cong (C._⋆ a) (sym (F .F-seq m h))))
+    Sep .Bif-L-id = funExt λ (h , _) →
+      Σ≡Prop (λ _ → C.isSetHom _ _) (C.⋆IdL h)
+    Sep .Bif-L-seq (m , _) (m' , _) = funExt λ (h , _) →
+      Σ≡Prop (λ _ → C.isSetHom _ _) (C.⋆Assoc m' m h)
+    Sep .Bif-homR {d = B , a} {d' = B' , a'} (X , cX) (n , nsq) (h , hsq) =
+      (h C.⋆ n)
+      , (cong (C._⋆ n) hsq
+         ∙ C.⋆Assoc _ _ _
+         ∙ cong (cX C.⋆_)
+             (C.⋆Assoc _ _ _
+              ∙ cong (F .F-hom h C.⋆_) nsq
+              ∙ sym (C.⋆Assoc _ _ _)
+              ∙ cong (C._⋆ a') (sym (F .F-seq h n))))
+    Sep .Bif-R-id = funExt λ (h , _) →
+      Σ≡Prop (λ _ → C.isSetHom _ _) (C.⋆IdR h)
+    Sep .Bif-R-seq (n , _) (n' , _) = funExt λ (h , _) →
+      Σ≡Prop (λ _ → C.isSetHom _ _) (sym (C.⋆Assoc h n n'))
+    Sep .SepBif-RL-commute (m , _) (n , _) = funExt λ (h , _) →
+      Σ≡Prop (λ _ → C.isSetHom _ _) (sym (C.⋆Assoc m h n))
+
+  isRecursiveCoalgebra : Coalgebra F → Type (ℓ-max ℓC ℓC')
+  isRecursiveCoalgebra Xc = (Ba : Algebra F) → isContr (Hylo Xc Ba)
+
+  isCorecursiveAlgebra : Algebra F → Type (ℓ-max ℓC ℓC')
+  isCorecursiveAlgebra Ba = (Xc : Coalgebra F) → isContr (Hylo Xc Ba)
+
+  HYLOTrivial : Type (ℓ-max ℓC ℓC')
+  HYLOTrivial = (Xc : Coalgebra F) (Ba : Algebra F) → isContr (Hylo Xc Ba)
+
+  HYLOTrivial→recursive : HYLOTrivial → ∀ Xc → isRecursiveCoalgebra Xc
+  HYLOTrivial→recursive t Xc Ba = t Xc Ba
+
+  HYLOTrivial→corecursive : HYLOTrivial → ∀ Ba → isCorecursiveAlgebra Ba
+  HYLOTrivial→corecursive t Ba Xc = t Xc Ba
+
+  private
+    Unit*SET : hSet ℓC'
+    Unit*SET = Unit* , isSetUnit*
+
+  module _ (Xc : Coalgebra F) where
+    open NatTrans
+
+    recursive→trivial : isRecursiveCoalgebra Xc
+      → NatIso (appL HYLO Xc) (Constant (ALG F) (SET ℓC') Unit*SET)
+    recursive→trivial rec .NatIso.trans .N-ob Ba _ = tt*
+    recursive→trivial rec .NatIso.trans .N-hom n = refl
+    recursive→trivial rec .NatIso.nIso Ba = isiso
+      (λ _ → rec Ba .fst)
+      (funExt λ _ → refl)
+      (funExt λ h → rec Ba .snd h)
+
+    trivial→recursive :
+        NatIso (appL HYLO Xc) (Constant (ALG F) (SET ℓC') Unit*SET)
+      → isRecursiveCoalgebra Xc
+    trivial→recursive ni Ba = isOfHLevelRespectEquiv 0
+      (invEquiv (isoToEquiv (iso
+        (ni .NatIso.trans .N-ob Ba)
+        (ni .NatIso.nIso Ba .isIso.inv)
+        (λ b → funExt⁻ (ni .NatIso.nIso Ba .isIso.sec) b)
+        (λ h → funExt⁻ (ni .NatIso.nIso Ba .isIso.ret) h))))
+      isContrUnit*
+
+  module _ (Ba : Algebra F) where
+    open NatTrans
+
+    corecursive→trivial : isCorecursiveAlgebra Ba
+      → NatIso (appR HYLO Ba)
+               (Constant ((COALG F) ^op) (SET ℓC') Unit*SET)
+    corecursive→trivial corec .NatIso.trans .N-ob Xc _ = tt*
+    corecursive→trivial corec .NatIso.trans .N-hom m = refl
+    corecursive→trivial corec .NatIso.nIso Xc = isiso
+      (λ _ → corec Xc .fst)
+      (funExt λ _ → refl)
+      (funExt λ h → corec Xc .snd h)
+
+    trivial→corecursive :
+        NatIso (appR HYLO Ba)
+               (Constant ((COALG F) ^op) (SET ℓC') Unit*SET)
+      → isCorecursiveAlgebra Ba
+    trivial→corecursive ni Xc = isOfHLevelRespectEquiv 0
+      (invEquiv (isoToEquiv (iso
+        (ni .NatIso.trans .N-ob Xc)
+        (ni .NatIso.nIso Xc .isIso.inv)
+        (λ b → funExt⁻ (ni .NatIso.nIso Xc .isIso.sec) b)
+        (λ h → funExt⁻ (ni .NatIso.nIso Xc .isIso.ret) h))))
+      isContrUnit*
+
+  module FixpointRecursion
+    (Fix : C.ob)
+    (fixIso : CatIso C (F .F-ob Fix) Fix)
+    (triv : HYLOTrivial)
+    where
+
+    private
+      α    = fixIso .fst
+      α⁻¹  = fixIso .snd .isIso.inv
+      αsec = fixIso .snd .isIso.sec
+      αret = fixIso .snd .isIso.ret
+
+    terminalCoalgebra : TerminalCoalgebra F
+    terminalCoalgebra = terminalToUniversalElement
+      ( (Fix , α⁻¹)
+      , λ (X , c) → isOfHLevelRespectEquiv 0
+          (Σ-cong-equiv-snd (eqv X c)) (triv (X , c) (Fix , α)) )
+      where
+        eqv : ∀ X c (m : C [ X , Fix ])
+            → (m ≡ c C.⋆ (F .F-hom m C.⋆ α))
+              ≃ (m C.⋆ α⁻¹ ≡ c C.⋆ F .F-hom m)
+        eqv X c m = propBiimpl→Equiv
+          (C.isSetHom _ _) (C.isSetHom _ _)
+          (λ p →
+            cong (C._⋆ α⁻¹) p
+            ∙ C.⋆Assoc _ _ _
+            ∙ cong (c C.⋆_) (C.⋆Assoc _ _ _
+                             ∙ cong (F .F-hom m C.⋆_) αret
+                             ∙ C.⋆IdR _))
+          (λ q →
+            sym (C.⋆IdR m)
+            ∙ cong (m C.⋆_) (sym αsec)
+            ∙ sym (C.⋆Assoc _ _ _)
+            ∙ cong (C._⋆ α) q
+            ∙ C.⋆Assoc _ _ _)
+
+    initialAlgebra : InitialAlgebra F
+    initialAlgebra = terminalToUniversalElement
+      ( (Fix , α)
+      , λ (B , a) → isOfHLevelRespectEquiv 0
+          (Σ-cong-equiv-snd (eqv B a)) (triv (Fix , α⁻¹) (B , a)) )
+      where
+        eqv : ∀ B a (m : C [ Fix , B ])
+            → (m ≡ α⁻¹ C.⋆ (F .F-hom m C.⋆ a))
+              ≃ (α C.⋆ m ≡ F .F-hom m C.⋆ a)
+        eqv B a m = propBiimpl→Equiv
+          (C.isSetHom _ _) (C.isSetHom _ _)
+          (λ p →
+            cong (α C.⋆_) p
+            ∙ sym (C.⋆Assoc _ _ _)
+            ∙ cong (C._⋆ (F .F-hom m C.⋆ a)) αret
+            ∙ C.⋆IdL _)
+          (λ q →
+            sym (C.⋆IdL m)
+            ∙ cong (C._⋆ m) (sym αsec)
+            ∙ C.⋆Assoc _ _ _
+            ∙ cong (α⁻¹ C.⋆_) q)

--- a/Cubical/Categories/Instances/DirectedGraph.agda
+++ b/Cubical/Categories/Instances/DirectedGraph.agda
@@ -1,0 +1,109 @@
+{-# OPTIONS --lossy-unification #-}
+module Cubical.Categories.Instances.DirectedGraph where
+
+open import Cubical.Foundations.Prelude
+open import Cubical.Foundations.HLevels
+open import Cubical.Foundations.Structure
+
+open import Cubical.Data.Unit
+open import Cubical.Data.Bool
+open import Cubical.Data.Empty as ⊥
+open import Cubical.Data.Sigma
+open import Cubical.Data.Sum using (_⊎_ ; inl ; inr)
+open import Cubical.Data.Nat using (ℕ)
+open import Cubical.Data.FinData using (Fin ; isSetFin)
+open import Cubical.Data.FinSet.Base using (isFinOrd)
+open import Cubical.Data.SumFin using (FinData≃SumFin)
+open import Cubical.Foundations.Equiv using (idEquiv)
+
+open import Cubical.Categories.Category
+open import Cubical.Categories.Functor
+open import Cubical.Categories.Instances.Sets using (SET)
+open import Cubical.Categories.Presheaf.Base
+open import Cubical.Categories.Direct.Instances.ParallelPair
+  using (ParallelPair ; V ; E ; Ob)
+open import Cubical.Data.Quiver.Base using (Quiver ; QuiverOver)
+
+open Functor
+open Category
+open QuiverOver
+
+private
+  variable ℓ : Level
+
+GraphPsh : (ℓ : Level) → Type _
+GraphPsh ℓ = Presheaf ParallelPair ℓ
+
+mkGraphPsh : (Vt Ed : hSet ℓ) (s t : ⟨ Ed ⟩ → ⟨ Vt ⟩) → GraphPsh ℓ
+mkGraphPsh Vt Ed s t .F-ob V = Vt
+mkGraphPsh Vt Ed s t .F-ob E = Ed
+mkGraphPsh Vt Ed s t .F-hom {V} {V} _     = λ x → x
+mkGraphPsh Vt Ed s t .F-hom {V} {E} h     = ⊥.rec h
+mkGraphPsh Vt Ed s t .F-hom {E} {V} false = s
+mkGraphPsh Vt Ed s t .F-hom {E} {V} true  = t
+mkGraphPsh Vt Ed s t .F-hom {E} {E} _     = λ x → x
+mkGraphPsh Vt Ed s t .F-id  {V} = refl
+mkGraphPsh Vt Ed s t .F-id  {E} = refl
+mkGraphPsh Vt Ed s t .F-seq {V} {V} {V} tt    tt    = refl
+mkGraphPsh Vt Ed s t .F-seq {E} {V} {V} false tt    = refl
+mkGraphPsh Vt Ed s t .F-seq {E} {V} {V} true  tt    = refl
+mkGraphPsh Vt Ed s t .F-seq {E} {E} {V} tt    false = refl
+mkGraphPsh Vt Ed s t .F-seq {E} {E} {V} tt    true  = refl
+mkGraphPsh Vt Ed s t .F-seq {E} {E} {E} tt    tt    = refl
+mkGraphPsh Vt Ed s t .F-seq {V} {E} {_} f g = ⊥.rec f
+mkGraphPsh Vt Ed s t .F-seq {_} {V} {E} f g = ⊥.rec g
+
+module Graph (Q : GraphPsh ℓ) where
+  Vertex : Type ℓ
+  Vertex = ⟨ Q .F-ob V ⟩
+  Edge : Type ℓ
+  Edge = ⟨ Q .F-ob E ⟩
+  src tgt : Edge → Vertex
+  src = Q .F-hom {E} {V} false
+  tgt = Q .F-hom {E} {V} true
+
+Graph→Quiver : GraphPsh ℓ → Quiver ℓ ℓ
+Graph→Quiver Q .fst         = Graph.Vertex Q
+Graph→Quiver Q .snd .mor    = Graph.Edge Q
+Graph→Quiver Q .snd .dom    = Graph.src Q
+Graph→Quiver Q .snd .cod    = Graph.tgt Q
+
+Quiver→Graph : (Q : Quiver ℓ ℓ) → isSet (Q .fst) → isSet (Q .snd .mor)
+             → GraphPsh ℓ
+Quiver→Graph Q sOb sMor =
+  mkGraphPsh (Q .fst , sOb) (Q .snd .mor , sMor) (Q .snd .dom) (Q .snd .cod)
+
+Quiver→Graph→Quiver :
+  (Q : Quiver ℓ ℓ) (sOb : isSet (Q .fst)) (sMor : isSet (Q .snd .mor))
+  → Graph→Quiver (Quiver→Graph Q sOb sMor) ≡ Q
+Quiver→Graph→Quiver Q sOb sMor = refl
+
+Graph→Quiver→Graph :
+  (G : GraphPsh ℓ)
+  → Quiver→Graph (Graph→Quiver G) (G .F-ob V .snd) (G .F-ob E .snd) ≡ G
+Graph→Quiver→Graph {ℓ} G = Functor≡ hOb hHom
+  where
+    mkG : GraphPsh ℓ
+    mkG = Quiver→Graph (Graph→Quiver G) (G .F-ob V .snd) (G .F-ob E .snd)
+
+    hOb : ∀ (c : Ob) → mkG .F-ob c ≡ G .F-ob c
+    hOb V = refl
+    hOb E = refl
+
+    hHom : ∀ {c c'} (f : (ParallelPair ^op) [ c , c' ])
+         → PathP (λ i → (SET ℓ) [ hOb c i , hOb c' i ])
+                 (mkG .F-hom f) (G .F-hom f)
+    hHom {V} {V} f = sym (cong (G .F-hom {V} {V}) (isPropUnit f tt) ∙ G .F-id)
+    hHom {V} {E} f = ⊥.rec f
+    hHom {E} {V} false = refl
+    hHom {E} {V} true  = refl
+    hHom {E} {E} f = sym (cong (G .F-hom {E} {E}) (isPropUnit f tt) ∙ G .F-id)
+
+isFiniteGraph : GraphPsh ℓ → Type ℓ
+isFiniteGraph Q = isFinOrd (Graph.Vertex Q) × isFinOrd (Graph.Edge Q)
+
+Disc : ℕ → GraphPsh ℓ-zero
+Disc n = mkGraphPsh (Fin n , isSetFin) (⊥ , isProp→isSet isProp⊥) ⊥.rec ⊥.rec
+
+finDisc : (n : ℕ) → isFiniteGraph (Disc n)
+finDisc n = (n , FinData≃SumFin) , (0 , idEquiv ⊥)

--- a/Cubical/Categories/Instances/PshℕGuarded.agda
+++ b/Cubical/Categories/Instances/PshℕGuarded.agda
@@ -1,0 +1,46 @@
+{-# OPTIONS --lossy-unification #-}
+-- THE TOPOS OF TREES AS `PRESHEAF ℕCat`, WITH OUR LATER/LÖB — the
+-- semantic model for the direct rebuild of the guarded canonicity, with
+-- NO ωSet.  `ℕDirect` is the topos-of-trees base, so `▷ ℕDirect` /
+-- `nextNT ℕDirect` are the later and its unit, and the guarded fixed
+-- point is our `löb` (with `löb-fix` supplying the fixpoint equation).
+module Cubical.Categories.Instances.PshℕGuarded where
+
+open import Cubical.Foundations.Prelude
+open import Cubical.Foundations.Structure
+
+open import Cubical.Data.Sigma
+
+open import Cubical.Categories.Category.Base
+open import Cubical.Categories.Functor.Base
+open import Cubical.Categories.FixedPoint
+open import Cubical.Categories.Presheaf.Base
+open import Cubical.Categories.Presheaf.Constructions.Unit
+open import Cubical.Categories.Presheaf.StrictHom.Base
+
+open import Cubical.Categories.Direct.Base
+open import Cubical.Categories.Direct.Instances.Nat using (ℕWFOrder ; ℕCat ; ℕDirect)
+open import Cubical.Categories.Direct.StrictDownset using (▷ ; nextNT ; löb ; löb-fix)
+
+open Functor
+
+private
+  variable
+    ℓ : Level
+
+-- the later modality and its unit on the topos of trees `PRESHEAF ℕCat`
+▷ℕ : Functor (PRESHEAF ℕCat ℓ-zero) (PRESHEAF ℕCat ℓ-zero)
+▷ℕ = ▷ ℕDirect
+
+nextℕ : ∀ (P : Presheaf ℕCat ℓ-zero) → PshHomStrict P (▷ℕ .F-ob P)
+nextℕ P = NatTrans.N-ob (nextNT ℕDirect) P
+  where open import Cubical.Categories.NaturalTransformation using (NatTrans)
+
+-- THE GUARDED FIXED POINT, via our Löb: for f : ▷P → P, `löb` is a
+-- global element of P and `löb-fix` says it is a fixed point of next ⋆ f.
+guarded-fixed-points-Psh :
+  {P : Presheaf ℕCat ℓ-zero}
+  (f : PshHomStrict (▷ℕ .F-ob P) P)
+  → fixed-point (PRESHEAF ℕCat ℓ-zero) UnitPsh (nextℕ P ⋆PshHomStrict f)
+guarded-fixed-points-Psh {P = P} f .fst = löb ℕDirect P f
+guarded-fixed-points-Psh {P = P} f .snd = sym (löb-fix ℕDirect P f)

--- a/Cubical/Categories/Instances/PshℕGuardedModel.agda
+++ b/Cubical/Categories/Instances/PshℕGuardedModel.agda
@@ -1,0 +1,87 @@
+{-# OPTIONS --lossy-unification #-}
+-- STAGE 1 OF THE DIRECT REBUILD: the `GuardedLogic (SET)` semantic model
+-- over `Fam (PRESHEAF ℕCat)` — the topos of trees with OUR later/löb,
+-- replacing `ωSETᴰ-Guarded` of `Gluing/Category/GuardedFixedPoint.agda`.
+-- The generic `Fam`/`FamTerminalsⱽ`/`isFibrationFam`/`FamF`/`Fam-PtNT`
+-- machinery is instantiated at `PRESHEAF ℕCat`; `gfpⱽ` is wired to our
+-- `guarded-fixed-points-Psh` (= `löb`).
+module Cubical.Categories.Instances.PshℕGuardedModel where
+
+open import Cubical.Foundations.Prelude
+open import Cubical.Foundations.Isomorphism
+open import Cubical.Foundations.Equiv
+open import Cubical.Foundations.Structure
+
+open import Cubical.Data.Unit
+open import Cubical.Data.Sigma
+
+open import Cubical.Categories.Category.Base
+open import Cubical.Categories.Functor.Base
+open import Cubical.Categories.FixedPoint
+open import Cubical.Categories.Limits.Terminal as Term
+open import Cubical.Categories.Limits.Terminal.More as Term
+open import Cubical.Categories.Presheaf.Base
+open import Cubical.Categories.Presheaf.Representable
+open import Cubical.Categories.Presheaf.Constructions.Unit
+open import Cubical.Categories.Presheaf.StrictHom.Base
+open import Cubical.Categories.Presheaf.StrictHom.CartesianClosed using (UnitPsh-introStrict)
+
+open import Cubical.Categories.Instances.Fiber hiding (fiber)
+open import Cubical.Categories.Displayed.Base
+open import Cubical.Categories.Displayed.FixedPoint
+open import Cubical.Categories.Instances.Sets
+open import Cubical.Categories.Displayed.Instances.Family.Base
+open import Cubical.Categories.Displayed.Instances.Family.Properties
+open import Cubical.Categories.Displayed.Instances.Family.EqProperties
+open import Cubical.Categories.Displayed.Presheaf.Uncurried.UniversalProperties
+open import Cubical.Categories.Displayed.Presheaf.Uncurried.Fibration
+open import Cubical.Categories.Displayed.Presheaf.Uncurried.Eq.Conversion.CartesianV
+open import Cubical.Categories.Displayed.Presheaf.Uncurried.Eq.Sets
+
+open import Cubical.Categories.Direct.Instances.Nat using (ℕCat ; ℕDirect)
+open import Cubical.Categories.Direct.StrictDownset using (▷ ; nextNT)
+open import Cubical.Categories.Instances.PshℕGuarded
+  using (▷ℕ ; nextℕ ; guarded-fixed-points-Psh)
+
+open Category
+open Categoryᴰ
+open Functor
+open UniversalElement
+
+-- the terminal presheaf on ℕCat with vertex `UnitPsh` (so it matches the
+-- `UnitPsh` domain of `löb`)
+UnitPsh-Terminal : Terminal' (PRESHEAF ℕCat ℓ-zero)
+UnitPsh-Terminal .vertex  = UnitPsh
+UnitPsh-Terminal .element = tt
+UnitPsh-Terminal .universal _ =
+  isoToIsEquiv (iso (λ _ → tt) (λ _ → UnitPsh-introStrict) (λ _ → refl) (λ _ → refl))
+
+-- the displayed category (fibration) of ℕ-presheaf families over SET
+Pshℕᴰ0 : Categoryᴰ (SET ℓ-zero) (ℓ-suc ℓ-zero) ℓ-zero
+Pshℕᴰ0 = Fam (PRESHEAF ℕCat ℓ-zero)
+
+module Pshℕᴰ0 = Fibers Pshℕᴰ0
+
+Pshℕᴰ-Terminalsⱽ : Terminalsⱽ Pshℕᴰ0
+Pshℕᴰ-Terminalsⱽ = EqTerminalsⱽ→Terminalsⱽ SetAssoc Pshℕᴰ0
+  (FamTerminalsⱽ {ℓ = ℓ-zero} (PRESHEAF ℕCat ℓ-zero) UnitPsh-Terminal)
+
+Pshℕᴰ-fibration : isFibration Pshℕᴰ0
+Pshℕᴰ-fibration = EqFibration→Fibration {C = SET ℓ-zero}
+  SetAssoc
+  Pshℕᴰ0
+  (isFibrationFam {ℓ = ℓ-zero} (PRESHEAF ℕCat ℓ-zero))
+
+Pshℕᴰ-Guarded : GuardedLogic (SET ℓ-zero) _ _
+Pshℕᴰ-Guarded .GuardedLogic.Cᴰ = Pshℕᴰ0
+Pshℕᴰ-Guarded .GuardedLogic.▷ⱽ = FamF (▷ ℕDirect)
+Pshℕᴰ-Guarded .GuardedLogic.next = Fam-PtNT (nextNT ℕDirect)
+Pshℕᴰ-Guarded .GuardedLogic.isFibCᴰ = Pshℕᴰ-fibration
+Pshℕᴰ-Guarded .GuardedLogic.termⱽ = Pshℕᴰ-Terminalsⱽ
+Pshℕᴰ-Guarded .GuardedLogic.gfpⱽ {A = X} {Aᴰ = Xᴰ} fⱽ =
+  fixed-pointⱽ'→ⱽ _ _ _ _
+    (subst (fixed-pointⱽ' Pshℕᴰ0 X (Pshℕᴰ-Terminalsⱽ X .fst))
+      (Pshℕᴰ0.rectifyOut {a = X} {b = X} {aᴰ = Xᴰ} {bᴰ = Xᴰ} {e' = refl}
+        (Pshℕᴰ0.reind-filler _))
+      ( (λ x → guarded-fixed-points-Psh (fⱽ x) .fst)
+      , funExt (λ x → guarded-fixed-points-Psh (fⱽ x) .snd) ))

--- a/Cubical/Categories/Presheaf/Sieve.agda
+++ b/Cubical/Categories/Presheaf/Sieve.agda
@@ -1,0 +1,66 @@
+-- A sieve on `c` is a subobject of the representable presheaf `よc`.
+--
+-- This instantiates the general displayed-category notion of subobject
+-- (`Cubical.Categories.Subobject.Base`) at `(PRESHEAF C , よc)`, where
+-- PRESHEAF has *strict* presheaf morphisms (`PshHomStrict`) as homs — the
+-- same category used for the presheaf/family monadicity.  A sieve is thus a
+-- sub-presheaf `S` of `よc` together with the proof that the inclusion
+-- `S ↪ よc` is monic.
+module Cubical.Categories.Presheaf.Sieve where
+
+open import Cubical.Foundations.Prelude
+open import Cubical.Foundations.Structure
+open import Cubical.Data.Sigma
+open import Cubical.Relation.Nullary
+
+open import Cubical.Categories.Category
+open import Cubical.Categories.Functor
+open import Cubical.Categories.Presheaf.Base
+open import Cubical.Categories.Presheaf.StrictHom.Base
+open import Cubical.Categories.Yoneda
+open import Cubical.Categories.Subobject.Base
+
+private
+  variable
+    ℓ ℓ' : Level
+
+module _ (C : Category ℓ ℓ') where
+  open Category C
+
+  -- a sieve on c = a subobject of the representable よc in PRESHEAF
+  Sieve : ob → Type (ℓ-max ℓ (ℓ-suc ℓ'))
+  Sieve c = Subobject (PRESHEAF C ℓ') (yo c)
+
+module _ {C : Category ℓ ℓ'} where
+  open Category C
+  open Functor
+  open PshHomStrict
+
+  module _ {c : ob} where
+    -- the underlying sub-presheaf
+    sievePsh : Sieve C c → Presheaf C ℓ'
+    sievePsh = sub-dom (PRESHEAF C ℓ') (yo c)
+
+    -- the inclusion S ↪ よc (a strict presheaf morphism)
+    sieveIncl : (S : Sieve C c) → PshHomStrict (sievePsh S) (yo c)
+    sieveIncl = sub-incl (PRESHEAF C ℓ') (yo c)
+
+    -- "S contains f": f : y → c lies in the image of the inclusion
+    _∋_ : (S : Sieve C c) {y : ob} (f : C [ y , c ]) → Type ℓ'
+    _∋_ S {y} f = Σ[ t ∈ ⟨ sievePsh S .F-ob y ⟩ ] (sieveIncl S .N-ob y t ≡ f)
+
+    -- sieves are closed under precomposition
+    sieve-precomp : (S : Sieve C c) {y z : ob} {f : C [ y , c ]} (g : C [ z , y ])
+      → S ∋ f → S ∋ (g ⋆ f)
+    sieve-precomp S {y} {z} {f} g (t , eq) =
+      sievePsh S .F-hom g t ,
+      sym (sieveIncl S .N-hom z y g t (sievePsh S .F-hom g t) refl)
+      ∙ cong (yo {C = C} c .F-hom g) eq
+
+    -- proper: does not contain the identity
+    isProperSieve : Sieve C c → Type ℓ'
+    isProperSieve S = ¬ (S ∋ id)
+
+    -- refinement order on sieves
+    _⊆_ : Sieve C c → Sieve C c → Type (ℓ-max ℓ ℓ')
+    S ⊆ T = ∀ {y} (f : C [ y , c ]) → S ∋ f → T ∋ f

--- a/Cubical/Categories/Presheaf/StrictHom/CartesianClosed.agda
+++ b/Cubical/Categories/Presheaf/StrictHom/CartesianClosed.agda
@@ -230,19 +230,6 @@ module _ {C : Category ℓC ℓC'} {P : Presheaf C ℓP} {Q : Presheaf C ℓQ} w
     ×PshIntroStrict (UnitPsh-introStrict ⋆PshHomStrict s) idPshHomStrict
       ⋆PshHomStrict appPshHomStrict P Q
 
-  -- β at a pairing: applying the transpose of γ to a pair (u , v)
-  module _ {R : Presheaf C ℓR} {W : Presheaf C ℓS}
-    (u : PshHomStrict W R) (v : PshHomStrict W P)
-    (γ : PshHomStrict (R ×Psh P) Q) where
-
-    applyλ :
-      ×PshIntroStrict (u ⋆PshHomStrict λPshHomStrict P Q γ) v
-        ⋆PshHomStrict appPshHomStrict P Q
-      ≡ ×PshIntroStrict u v ⋆PshHomStrict γ
-    applyλ = makePshHomStrictPath (funExt λ c → funExt λ x →
-      cong (λ z → γ .N-ob c (z , v .N-ob c x))
-        (funExt⁻ (R .F-id) (u .N-ob c x)))
-
 module _ (C : Category ℓC ℓC') (ℓP : Level) where
   Exp-PRESHEAF :
     AllExponentiable (PRESHEAF C (ℓP ⊔ℓ ℓC ⊔ℓ ℓC'))

--- a/Cubical/Categories/Presheaf/StrictHom/CartesianClosed.agda
+++ b/Cubical/Categories/Presheaf/StrictHom/CartesianClosed.agda
@@ -82,6 +82,11 @@ Unit*Psh-introStrict : ∀ {ℓA} {ℓ1} {C : Category ℓ ℓ'}{P : Presheaf C 
 Unit*Psh-introStrict .N-ob = λ x _ → tt*
 Unit*Psh-introStrict .N-hom c c' f p' p x = refl
 
+UnitPsh-introStrict : ∀ {ℓA} {C : Category ℓ ℓ'}{P : Presheaf C ℓA}
+  → PshHomStrict P UnitPsh
+UnitPsh-introStrict .N-ob = λ x _ → tt
+UnitPsh-introStrict .N-hom c c' f p' p x = refl
+
 module _
   {C : Category ℓc ℓc'}
   where
@@ -215,6 +220,28 @@ module _ {C : Category ℓC ℓC'} (P : Presheaf C ℓP) (Q : Presheaf C ℓQ) w
         (funExt₂ λ d (f , p) →
           sym (cong (λ x → α .N-ob c r .N-ob d (x , p)) (sym (C.⋆IdL f))
           ∙ funExt⁻ (funExt⁻ (cong N-ob (α .N-hom d c f r (f R.⋆ r) refl)) d) (C.id , p))))
+
+module _ {C : Category ℓC ℓC'} {P : Presheaf C ℓP} {Q : Presheaf C ℓQ} where
+
+  -- the external hom underlying a global element of the internal hom
+  eltPshHomStrict : PshHomStrict UnitPsh (P ⇒PshLargeStrict Q)
+                  → PshHomStrict P Q
+  eltPshHomStrict s =
+    ×PshIntroStrict (UnitPsh-introStrict ⋆PshHomStrict s) idPshHomStrict
+      ⋆PshHomStrict appPshHomStrict P Q
+
+  -- β at a pairing: applying the transpose of γ to a pair (u , v)
+  module _ {R : Presheaf C ℓR} {W : Presheaf C ℓS}
+    (u : PshHomStrict W R) (v : PshHomStrict W P)
+    (γ : PshHomStrict (R ×Psh P) Q) where
+
+    applyλ :
+      ×PshIntroStrict (u ⋆PshHomStrict λPshHomStrict P Q γ) v
+        ⋆PshHomStrict appPshHomStrict P Q
+      ≡ ×PshIntroStrict u v ⋆PshHomStrict γ
+    applyλ = makePshHomStrictPath (funExt λ c → funExt λ x →
+      cong (λ z → γ .N-ob c (z , v .N-ob c x))
+        (funExt⁻ (R .F-id) (u .N-ob c x)))
 
 module _ (C : Category ℓC ℓC') (ℓP : Level) where
   Exp-PRESHEAF :

--- a/Cubical/Categories/Subobject/Base.agda
+++ b/Cubical/Categories/Subobject/Base.agda
@@ -1,0 +1,56 @@
+-- A subobject of `c` in a category `D` is a monomorphism into `c`.
+--
+-- We build the category of subobjects of `c` compositionally as a displayed
+-- category over `D`: it is the `StructureOver` whose structure on an object
+-- `a` is a mono `a → c`, and whose (propositional) hom-constraint on a map
+-- `f : a → a'` is that the triangle commutes.  `SubobjectCat` is its total
+-- category.  Sieves instantiate this at `(PSh C , よc)`.
+module Cubical.Categories.Subobject.Base where
+
+open import Cubical.Foundations.Prelude
+open import Cubical.Data.Sigma
+
+open import Cubical.Categories.Category
+open import Cubical.Categories.Morphism
+open import Cubical.Categories.Displayed.Base
+open import Cubical.Categories.Displayed.Instances.StructureOver.Base
+open import Cubical.Categories.Instances.TotalCategory
+
+open Category
+
+private
+  variable
+    ℓ ℓ' : Level
+
+module _ (D : Category ℓ ℓ') (c : D .ob) where
+  private module D = Category D
+
+  -- structure on `a`: a mono into c ;  constraint on `f`: the triangle commutes
+  SubobjectStr : StructureOver D (ℓ-max ℓ ℓ') ℓ'
+  SubobjectStr .StructureOver.ob[_] a = Σ[ m ∈ D [ a , c ] ] isMonic D m
+  SubobjectStr .StructureOver.Hom[_][_,_] f m m' = (f D.⋆ m' .fst) ≡ m .fst
+  SubobjectStr .StructureOver.idᴰ {p = m} = D.⋆IdL (m .fst)
+  SubobjectStr .StructureOver._⋆ᴰ_ {f = f} {g = g} {zᴰ = m''} p q =
+    D.⋆Assoc f g (m'' .fst) ∙ cong (f D.⋆_) q ∙ p
+  SubobjectStr .StructureOver.isPropHomᴰ = D.isSetHom _ _
+
+  Subobjectᴰ : Categoryᴰ D (ℓ-max ℓ ℓ') ℓ'
+  Subobjectᴰ = StructureOver→Catᴰ SubobjectStr
+
+  -- subobjects of c, with refinement morphisms (commuting triangles)
+  SubobjectCat : Category (ℓ-max ℓ ℓ') ℓ'
+  SubobjectCat = ∫C Subobjectᴰ
+
+  -- a subobject of c = a mono into c
+  Subobject : Type (ℓ-max ℓ ℓ')
+  Subobject = SubobjectCat .ob
+
+  module _ (S : Subobject) where
+    sub-dom : D .ob
+    sub-dom = S .fst
+
+    sub-incl : D [ sub-dom , c ]
+    sub-incl = S .snd .fst
+
+    sub-isMonic : isMonic D sub-incl
+    sub-isMonic = S .snd .snd

--- a/Cubical/Data/List/More.agda
+++ b/Cubical/Data/List/More.agda
@@ -1,0 +1,154 @@
+-- `All`, membership, and (order-parametrised) `Sorted` predicates on lists,
+-- with the append/split lemmas shared by the sorting/searching
+-- hylomorphism examples.
+module Cubical.Data.List.More where
+
+open import Cubical.Foundations.Prelude
+open import Cubical.Foundations.HLevels
+open import Cubical.Data.Sigma
+open import Cubical.Data.Sum as Sum using (_⊎_ ; inl ; inr ; isSet⊎)
+open import Cubical.Data.Empty as ⊥ using (⊥ ; isProp⊥)
+open import Cubical.Data.Unit using (Unit ; tt ; isPropUnit)
+open import Cubical.Data.Bool using (Bool ; true ; false ; if_then_else_)
+open import Cubical.Data.Nat using (ℕ ; zero ; suc)
+open import Cubical.Data.Nat.Order.Recursive
+  using (_≤_ ; _<_ ; ≤-refl ; ≤-trans ; n≤k+n)
+open import Cubical.Data.List
+  using (List ; [] ; _∷_ ; _++_ ; length ; take ; drop)
+open import Cubical.Data.Fin using (Fin ; fzero ; fsuc)
+
+private
+  variable
+    ℓ : Level
+
+  ≤-suc : ∀ {m n} → m ≤ n → m ≤ suc n
+  ≤-suc {zero}          _  = tt
+  ≤-suc {suc m} {zero}  le = ⊥.rec le
+  ≤-suc {suc m} {suc n} le = ≤-suc {m} {n} le
+
+-- total indexing with a default for the out-of-range / empty case
+lookupD : {A : Type ℓ} → A → List A → ℕ → A
+lookupD d []       _       = d
+lookupD d (x ∷ xs) zero    = x
+lookupD d (x ∷ xs) (suc n) = lookupD d xs n
+
+filterL : {A : Type ℓ} → (A → Bool) → List A → List A
+filterL p []       = []
+filterL p (y ∷ ys) = if p y then y ∷ filterL p ys else filterL p ys
+
+filter-length : {A : Type ℓ} (p : A → Bool) (xs : List A)
+              → length (filterL p xs) ≤ length xs
+filter-length p []       = tt
+filter-length p (y ∷ ys) = go (p y)
+  where
+    go : ∀ b → length (if b then y ∷ filterL p ys else filterL p ys)
+             ≤ suc (length ys)
+    go true  = filter-length p ys
+    go false = ≤-suc {length (filterL p ys)} {length ys} (filter-length p ys)
+
+module _ {A : Type} where
+  All : (A → Type) → List A → Type
+  All P []       = Unit
+  All P (x ∷ xs) = P x × All P xs
+
+  isPropAll : ∀ {P} → (∀ z → isProp (P z)) → ∀ xs → isProp (All P xs)
+  isPropAll pr []       = isPropUnit
+  isPropAll pr (x ∷ xs) = isProp× (pr x) (isPropAll pr xs)
+
+  All-++ : ∀ {P} as {bs} → All P as → All P bs → All P (as ++ bs)
+  All-++ []       _          qb = qb
+  All-++ (a ∷ as) (qa , qas) qb = qa , All-++ as qas qb
+
+  All-++⁻ : ∀ {P} as {bs} → All P (as ++ bs) → All P as × All P bs
+  All-++⁻ []       a        = tt , a
+  All-++⁻ (x ∷ as) (px , a) with All-++⁻ as a
+  ... | la , lb = (px , la) , lb
+
+  All-mono : ∀ {P Q : A → Type} (f : ∀ z → P z → Q z) xs → All P xs → All Q xs
+  All-mono f []       _          = tt
+  All-mono f (x ∷ xs) (qx , qxs) = f x qx , All-mono f xs qxs
+
+  All-filter-sound : ∀ (p : A → Bool) (Q : A → Type)
+    → (∀ y → p y ≡ true → Q y) → ∀ xs → All Q (filterL p xs)
+  All-filter-sound p Q sound []       = tt
+  All-filter-sound p Q sound (y ∷ ys) = go (p y) refl
+    where
+      go : ∀ b → p y ≡ b
+         → All Q (if b then y ∷ filterL p ys else filterL p ys)
+      go true  e = sound y e , All-filter-sound p Q sound ys
+      go false e = All-filter-sound p Q sound ys
+
+  _∈_ : A → List A → Type
+  q ∈ []       = ⊥
+  q ∈ (x ∷ xs) = (q ≡ x) ⊎ (q ∈ xs)
+
+  isSet∈ : isSet A → ∀ {q} xs → isSet (q ∈ xs)
+  isSet∈ sA []       = isProp→isSet isProp⊥
+  isSet∈ sA (x ∷ xs) = isSet⊎ (isProp→isSet (sA _ _)) (isSet∈ sA xs)
+
+  ∈→Fin : ∀ {q xs} → q ∈ xs → Fin (length xs)
+  ∈→Fin {xs = x ∷ xs} (inl _) = fzero
+  ∈→Fin {xs = x ∷ xs} (inr m) = fsuc (∈→Fin m)
+
+  ∈-++ˡ : ∀ {q as bs} → q ∈ as → q ∈ (as ++ bs)
+  ∈-++ˡ {as = x ∷ as} (inl p) = inl p
+  ∈-++ˡ {as = x ∷ as} (inr m) = inr (∈-++ˡ m)
+
+  ∈-++ʳ : ∀ {q} as {bs} → q ∈ bs → q ∈ (as ++ bs)
+  ∈-++ʳ []       m = m
+  ∈-++ʳ (x ∷ as) m = inr (∈-++ʳ as m)
+
+  ∈-++⁻ : ∀ {q} as {bs} → q ∈ (as ++ bs) → (q ∈ as) ⊎ (q ∈ bs)
+  ∈-++⁻ []       m       = inr m
+  ∈-++⁻ (x ∷ as) (inl p) = inl (inl p)
+  ∈-++⁻ (x ∷ as) (inr m) = Sum.map inr (λ r → r) (∈-++⁻ as m)
+
+  All-∈ : ∀ {P q xs} → All P xs → q ∈ xs → P q
+  All-∈ {P} {xs = x ∷ xs} (px , _)  (inl p) = subst P (sym p) px
+  All-∈     {xs = x ∷ xs} (_  , ps) (inr m) = All-∈ ps m
+
+  length-take-≤ : ∀ k (xs : List A) → length (take k xs) ≤ k
+  length-take-≤ zero    xs       = tt
+  length-take-≤ (suc k) []       = tt
+  length-take-≤ (suc k) (x ∷ xs) = length-take-≤ k xs
+
+  length-drop-≤ : ∀ k (xs : List A) → length (drop k xs) ≤ length xs
+  length-drop-≤ zero    xs       = ≤-refl (length xs)
+  length-drop-≤ (suc k) []       = tt
+  length-drop-≤ (suc k) (x ∷ xs) =
+    ≤-trans {length (drop k xs)} {length xs} {suc (length xs)}
+      (length-drop-≤ k xs) (n≤k+n {k = 1} (length xs))
+
+  take-lookup-drop : ∀ (d : A) k xs → k < length xs
+    → take k xs ++ (lookupD d xs k ∷ drop (suc k) xs) ≡ xs
+  take-lookup-drop d k       []       hyp = ⊥.rec hyp
+  take-lookup-drop d zero    (x ∷ xs) hyp = refl
+  take-lookup-drop d (suc k) (x ∷ xs) hyp =
+    cong (x ∷_) (take-lookup-drop d k xs hyp)
+
+module Ordered {A : Type} (_≤_ : A → A → Type)
+               (isProp≤ : ∀ {a b} → isProp (a ≤ b))
+               (≤-trans : ∀ {a b c} → a ≤ b → b ≤ c → a ≤ c) where
+  Sorted : List A → Type
+  Sorted []       = Unit
+  Sorted (x ∷ xs) = All (x ≤_) xs × Sorted xs
+
+  isPropSorted : ∀ xs → isProp (Sorted xs)
+  isPropSorted []       = isPropUnit
+  isPropSorted (x ∷ xs) =
+    isProp× (isPropAll (λ _ → isProp≤) xs) (isPropSorted xs)
+
+  Sorted-split : ∀ lo {mid hi} → Sorted (lo ++ mid ∷ hi)
+    → All (_≤ mid) lo × Sorted lo × All (mid ≤_) hi × Sorted hi
+  Sorted-split []       (midB , shi) = tt , tt , midB , shi
+  Sorted-split (y ∷ lo) (yAll , srest)
+    with All-++⁻ lo yAll | Sorted-split lo srest
+  ... | yAll-lo , (y≤mid , _) | loB , slo , hiB , shi =
+        (y≤mid , loB) , (yAll-lo , slo) , hiB , shi
+
+  sorted-++ : ∀ l {piv r} → Sorted l → Sorted r
+    → All (_≤ piv) l → All (piv ≤_) r → Sorted (l ++ piv ∷ r)
+  sorted-++ []      _          sr _          ar = ar , sr
+  sorted-++ (y ∷ l) {piv} {r} (ybd , sl) sr (y≤p , al) ar =
+      All-++ l ybd (y≤p , All-mono (λ _ p≤z → ≤-trans y≤p p≤z) r ar)
+    , sorted-++ l sl sr al ar

--- a/Cubical/Data/Nat/More.agda
+++ b/Cubical/Data/Nat/More.agda
@@ -1,0 +1,152 @@
+-- Extended naturals `Maybe ℕ` (with `∞ = nothing`) and their min-plus
+-- (tropical) semiring — `⊕ = min`, `⊗ = +`.  Used for shortest-path costs.
+module Cubical.Data.Nat.More where
+
+open import Cubical.Foundations.Prelude
+open import Cubical.Data.Sum using (_⊎_ ; inl ; inr)
+open import Cubical.Data.Unit using (Unit ; tt)
+open import Cubical.Data.Nat
+  using (ℕ ; zero ; suc ; _+_ ; +-comm ; +-zero ; +-assoc ; isSetℕ)
+open import Cubical.Data.Maybe using (Maybe ; nothing ; just ; isOfHLevelMaybe)
+open import Cubical.Data.Empty as ⊥ using (⊥)
+
+Cost : Type
+Cost = Maybe ℕ
+
+pattern ∞ = nothing
+
+isSetCost : isSet Cost
+isSetCost = isOfHLevelMaybe 0 isSetℕ
+
+minℕ : ℕ → ℕ → ℕ
+minℕ zero    _       = zero
+minℕ (suc _) zero    = zero
+minℕ (suc x) (suc y) = suc (minℕ x y)
+
+_⊕_ : Cost → Cost → Cost        -- ⊕ = min : take the cheaper route
+∞      ⊕ y      = y
+just x ⊕ ∞      = just x
+just x ⊕ just y = just (minℕ x y)
+
+_⊗_ : Cost → Cost → Cost        -- ⊗ = + : extend a route by one edge
+∞      ⊗ _      = ∞
+just _ ⊗ ∞      = ∞
+just x ⊗ just y = just (x + y)
+
+infixr 6 _⊕_
+infixr 7 _⊗_
+
+minℕ-comm : ∀ x y → minℕ x y ≡ minℕ y x
+minℕ-comm zero    zero    = refl
+minℕ-comm zero    (suc _) = refl
+minℕ-comm (suc _) zero    = refl
+minℕ-comm (suc x) (suc y) = cong suc (minℕ-comm x y)
+
+minℕ-idem : ∀ x → minℕ x x ≡ x
+minℕ-idem zero    = refl
+minℕ-idem (suc x) = cong suc (minℕ-idem x)
+
+minℕ-assoc : ∀ x y z → minℕ (minℕ x y) z ≡ minℕ x (minℕ y z)
+minℕ-assoc zero    _       _       = refl
+minℕ-assoc (suc _) zero    _       = refl
+minℕ-assoc (suc _) (suc _) zero    = refl
+minℕ-assoc (suc x) (suc y) (suc z) = cong suc (minℕ-assoc x y z)
+
++-minℕ-distribˡ : ∀ z x y → z + minℕ x y ≡ minℕ (z + x) (z + y)
++-minℕ-distribˡ zero    x y = refl
++-minℕ-distribˡ (suc z) x y = cong suc (+-minℕ-distribˡ z x y)
+
+minℕ-+-distrib : ∀ x y z → minℕ x y + z ≡ minℕ (x + z) (y + z)
+minℕ-+-distrib x y z =
+    +-comm (minℕ x y) z ∙ +-minℕ-distribˡ z x y
+  ∙ cong₂ minℕ (+-comm z x) (+-comm z y)
+
+⊕-comm : ∀ x y → x ⊕ y ≡ y ⊕ x
+⊕-comm ∞        ∞        = refl
+⊕-comm ∞        (just _) = refl
+⊕-comm (just _) ∞        = refl
+⊕-comm (just x) (just y) = cong just (minℕ-comm x y)
+
+⊕-idem : ∀ x → x ⊕ x ≡ x
+⊕-idem ∞        = refl
+⊕-idem (just x) = cong just (minℕ-idem x)
+
+⊕-assoc : ∀ x y z → (x ⊕ y) ⊕ z ≡ x ⊕ (y ⊕ z)
+⊕-assoc ∞        _        _        = refl
+⊕-assoc (just _) ∞        _        = refl
+⊕-assoc (just _) (just _) ∞        = refl
+⊕-assoc (just x) (just y) (just z) = cong just (minℕ-assoc x y z)
+
+⊗-distribˡ : ∀ x y z → (x ⊕ y) ⊗ z ≡ (x ⊗ z) ⊕ (y ⊗ z)
+⊗-distribˡ ∞        _        _        = refl
+⊗-distribˡ (just _) ∞        ∞        = refl
+⊗-distribˡ (just _) ∞        (just _) = refl
+⊗-distribˡ (just _) (just _) ∞        = refl
+⊗-distribˡ (just x) (just y) (just z) = cong just (minℕ-+-distrib x y z)
+
+-- the min-plus order:  x ⊑ y  means "x is no more expensive than y".
+_⊑_ : Cost → Cost → Type
+x ⊑ y = x ⊕ y ≡ x
+
+⊑-refl : ∀ {x} → x ⊑ x
+⊑-refl {x} = ⊕-idem x
+
+⊑-trans : ∀ {x y z} → x ⊑ y → y ⊑ z → x ⊑ z
+⊑-trans {x} {y} {z} p q =
+  cong (_⊕ z) (sym p) ∙ ⊕-assoc x y z ∙ cong (x ⊕_) q ∙ p
+
+⊕-lb₁ : ∀ x y → (x ⊕ y) ⊑ x
+⊕-lb₁ x y = ⊕-assoc x y x ∙ cong (x ⊕_) (⊕-comm y x)
+          ∙ sym (⊕-assoc x x y) ∙ cong (_⊕ y) (⊕-idem x)
+
+⊕-lb₂ : ∀ x y → (x ⊕ y) ⊑ y
+⊕-lb₂ x y = ⊕-assoc x y y ∙ cong (x ⊕_) (⊕-idem y)
+
+-- skip the head of a ⊕-chain, keeping a lower bound on the tail
+⊕-skip : ∀ x {y z} → y ⊑ z → (x ⊕ y) ⊑ z
+⊕-skip x p = ⊑-trans (⊕-lb₂ x _) p
+
+⊗-monoˡ : ∀ {x x'} y → x ⊑ x' → (x ⊗ y) ⊑ (x' ⊗ y)
+⊗-monoˡ {x} {x'} y p = sym (⊗-distribˡ x x' y) ∙ cong (_⊗ y) p
+
+⊑∞ : ∀ x → x ⊑ ∞
+⊑∞ ∞        = refl
+⊑∞ (just _) = refl
+
+⊑-antisym : ∀ {x y} → x ⊑ y → y ⊑ x → x ≡ y
+⊑-antisym {x} {y} p q = sym p ∙ ⊕-comm x y ∙ q
+
+∞≢just : ∀ {c : ℕ} → ∞ ≡ just c → ⊥
+∞≢just p = subst (λ { ∞ → Unit ; (just _) → ⊥ }) p tt
+
+-- a `⊕` (min) is always realised by one of its arguments — the key fact
+-- behind attainment.
+minℕ-select : ∀ x y → (minℕ x y ≡ x) ⊎ (minℕ x y ≡ y)
+minℕ-select zero    y       = inl refl
+minℕ-select (suc x) zero    = inr refl
+minℕ-select (suc x) (suc y) with minℕ-select x y
+... | inl p = inl (cong suc p)
+... | inr q = inr (cong suc q)
+
+⊕-select : ∀ x y → (x ⊕ y ≡ x) ⊎ (x ⊕ y ≡ y)
+⊕-select ∞        y        = inr refl
+⊕-select (just x) ∞        = inl refl
+⊕-select (just x) (just y) with minℕ-select x y
+... | inl p = inl (cong just p)
+... | inr q = inr (cong just q)
+
+-- ⊗ is a monoid with unit `just 0` (this is (ℕ,+,0) with ∞ absorbing) —
+-- the structure delooped into the cost category `BCost`.
+⊗-unitˡ : ∀ c → just 0 ⊗ c ≡ c
+⊗-unitˡ ∞        = refl
+⊗-unitˡ (just y) = refl
+
+⊗-unitʳ : ∀ c → c ⊗ just 0 ≡ c
+⊗-unitʳ ∞        = refl
+⊗-unitʳ (just x) = cong just (+-zero x)
+
+⊗-assoc : ∀ x y z → (x ⊗ y) ⊗ z ≡ x ⊗ (y ⊗ z)
+⊗-assoc ∞        y        z        = refl
+⊗-assoc (just x) ∞        z        = refl
+⊗-assoc (just x) (just y) ∞        = refl
+⊗-assoc (just x) (just y) (just z) = cong just (sym (+-assoc x y z))

--- a/Cubical/Relation/Nullary/More.agda
+++ b/Cubical/Relation/Nullary/More.agda
@@ -1,0 +1,41 @@
+-- Closure properties of Dec missing from Cubical.Relation.Nullary
+module Cubical.Relation.Nullary.More where
+
+open import Cubical.Foundations.Prelude
+open import Cubical.Foundations.HLevels
+open import Cubical.Data.Sigma
+open import Cubical.Data.Sum using (_⊎_ ; inl ; inr ; isSet⊎)
+open import Cubical.Data.Empty as ⊥ using ()
+open import Cubical.Relation.Nullary using (¬_ ; Dec ; yes ; no ; isProp¬)
+
+private
+  variable
+    ℓ ℓ' : Level
+
+isSetDec : {A : Type ℓ} → isSet A → isSet (Dec A)
+isSetDec {A = A} sA =
+  isOfHLevelRetract 2 f g fg (isSet⊎ sA (isProp→isSet (isProp¬ A)))
+  where
+    f : Dec A → A ⊎ (¬ A)
+    f (yes a) = inl a
+    f (no ¬a) = inr ¬a
+    g : A ⊎ (¬ A) → Dec A
+    g (inl a)  = yes a
+    g (inr ¬a) = no ¬a
+    fg : ∀ d → g (f d) ≡ d
+    fg (yes a) = refl
+    fg (no ¬a) = refl
+
+Dec× : {A : Type ℓ} {B : Type ℓ'} → Dec A → Dec B → Dec (A × B)
+Dec× (yes a) (yes b) = yes (a , b)
+Dec× (no ¬a) _       = no (λ (a , _) → ¬a a)
+Dec× _       (no ¬b) = no (λ (_ , b) → ¬b b)
+
+Dec¬ : {A : Type ℓ} → Dec A → Dec (¬ A)
+Dec¬ (yes a) = no (λ ¬a → ¬a a)
+Dec¬ (no ¬a) = yes ¬a
+
+Dec→ : {A : Type ℓ} {B : Type ℓ'} → Dec A → Dec B → Dec (A → B)
+Dec→ (yes a) (yes b) = yes (λ _ → b)
+Dec→ (yes a) (no ¬b) = no (λ f → ¬b (f a))
+Dec→ (no ¬a) _       = yes (λ a → ⊥.rec (¬a a))

--- a/Gluing/Category/GuardedFixedPoint/Direct.agda
+++ b/Gluing/Category/GuardedFixedPoint/Direct.agda
@@ -1,0 +1,379 @@
+{-
+
+  The guarded canonicity theorem, with the step-indexed semantics given
+  by presheaves on ω — the direct-category Löb framework instantiated
+  at ℕDirect — in place of the hand-rolled ωSets of
+  Gluing.Category.GuardedFixedPoint.
+
+-}
+{-# OPTIONS --lossy-unification #-}
+module Gluing.Category.GuardedFixedPoint.Direct where
+
+open import Cubical.Foundations.Prelude
+open import Cubical.Foundations.Function
+open import Cubical.Foundations.HLevels
+open import Cubical.Foundations.Isomorphism
+open import Cubical.Foundations.Equiv
+open import Cubical.Foundations.More
+open import Cubical.Foundations.Structure
+
+open import Cubical.Data.Bool as Bool hiding (elim)
+open import Cubical.Data.Sigma
+open import Cubical.Data.Unit
+open import Cubical.Data.Sum as Sum using (inl ; inr)
+open import Cubical.Data.Empty as Empty using ()
+open import Cubical.Data.Nat as Nat hiding (elim)
+open import Cubical.Data.Nat.Order.Recursive as R using ()
+import Cubical.Data.Equality as Eq
+import Cubical.Data.Equality.More as Eq
+
+open import Cubical.Categories.Category.Base
+open import Cubical.Categories.FixedPoint
+open import Cubical.Categories.Functor.Base
+open import Cubical.Categories.NaturalTransformation hiding (_⟦_⟧)
+open import Cubical.Categories.Instances.Sets
+open import Cubical.Categories.Instances.Fiber hiding (fiber)
+open import Cubical.Categories.Instances.Free.Category.GuardedFixedPoint as Syn
+open import Cubical.Categories.Limits.Terminal as Term
+open import Cubical.Categories.Limits.Terminal.More as Term
+open import Cubical.Categories.Presheaf.Base
+open import Cubical.Categories.Presheaf.StrictHom.Base
+open import Cubical.Categories.Presheaf.StrictHom.CartesianClosed
+open import Cubical.Categories.Presheaf.Constructions.Unit
+open import Cubical.Categories.Presheaf.Representable
+open import Cubical.Categories.Presheaf.Representable.More
+open import Cubical.Categories.Presheaf.Morphism.Alt
+
+open import Cubical.Categories.Direct.Base
+open import Cubical.Categories.Direct.Instances.Nat
+  using (ℕWFOrder ; ℕCat ; ℕDirect)
+open import Cubical.Categories.Direct.StrictDownset as SD
+  using (↡Psh ; ▷Psh ; next ; löb ; löb-fix ; ▷ ; nextNT)
+
+open import Cubical.Categories.Displayed.Base
+open import Cubical.Categories.Displayed.Functor
+open import Cubical.Categories.Displayed.Functor.More
+open import Cubical.Categories.Displayed.FixedPoint
+open import Cubical.Categories.Displayed.More
+open import Cubical.Categories.Displayed.NaturalTransformation
+open import Cubical.Categories.Displayed.Section.Base
+open import Cubical.Categories.Instances.TotalCategory as TotalCat
+  hiding (elim; recᴰ)
+open import Cubical.Categories.Displayed.Instances.Family.Base
+open import Cubical.Categories.Displayed.Instances.Family.Properties
+open import Cubical.Categories.Displayed.Instances.Family.EqProperties
+open import Cubical.Categories.Displayed.Instances.Reindex.Eq
+open import Cubical.Categories.Displayed.Instances.Reindex
+open import Cubical.Categories.Displayed.Instances.Reindex.Cartesian
+open import Cubical.Categories.Displayed.Instances.Reindex.Fibration
+open import Cubical.Categories.Displayed.HLevels
+open import Cubical.Categories.Displayed.Presheaf.Uncurried.Base
+open import Cubical.Categories.Displayed.Presheaf.Uncurried.Representable
+open import Cubical.Categories.Displayed.Presheaf.Uncurried.UniversalProperties
+open import Cubical.Categories.Displayed.Presheaf.Uncurried.Fibration
+open import Cubical.Categories.Displayed.Presheaf.Uncurried.Eq.Conversion.CartesianV
+open import Cubical.Categories.Displayed.Presheaf.Uncurried.Eq.Sets
+
+private
+  variable
+    ℓ ℓ' ℓᴰ ℓᴰ' : Level
+
+open Category
+open Categoryᴰ
+open Functor
+open Functorᴰ
+open NatTrans
+open NatTransᴰ
+open PshHomStrict
+open Section
+open UniversalElement
+
+PSHω : Category (ℓ-suc ℓ-zero) ℓ-zero
+PSHω = PRESHEAF ℕCat ℓ-zero
+
+PSHω-Terminal : Terminal' PSHω
+PSHω-Terminal = PSH1 ℕCat ℓ-zero
+
+module _ {P : Presheaf ℕCat ℓ-zero}
+         (f : PshHomStrict (▷Psh ℕDirect P) P) where
+  private
+    !* : PSHω [ Unit*Psh , UnitPsh ]
+    !* .N-ob _ _ = tt
+    !* .N-hom _ _ _ _ _ _ = refl
+
+  gfixω : PSHω [ Unit*Psh , P ]
+  gfixω = !* ⋆PshHomStrict löb ℕDirect P f
+
+  guarded-fixed-pointsω :
+    fixed-point PSHω Unit*Psh {x = P}
+      (next ℕDirect P ⋆PshHomStrict f)
+  guarded-fixed-pointsω .fst = gfixω
+  guarded-fixed-pointsω .snd =
+    cong (!* ⋆PshHomStrict_) (sym (löb-fix ℕDirect P f))
+
+-- the displayed family stack over SET
+PSHωᴰ0 : Categoryᴰ (SET ℓ-zero) (ℓ-suc ℓ-zero) ℓ-zero
+PSHωᴰ0 = Fam PSHω
+
+module PSHωᴰ0 = Fibers PSHωᴰ0
+
+PSHωᴰ-Terminalsⱽ : Terminalsⱽ PSHωᴰ0
+PSHωᴰ-Terminalsⱽ = EqTerminalsⱽ→Terminalsⱽ SetAssoc PSHωᴰ0
+  (FamTerminalsⱽ {ℓ = ℓ-zero} PSHω PSHω-Terminal)
+
+PSHωᴰ-fibration : isFibration PSHωᴰ0
+PSHωᴰ-fibration = EqFibration→Fibration {C = SET ℓ-zero}
+  SetAssoc
+  PSHωᴰ0
+  (isFibrationFam {ℓ = ℓ-zero} PSHω)
+
+PSHωᴰ-Guarded : GuardedLogic (SET ℓ-zero) _ _
+PSHωᴰ-Guarded .GuardedLogic.Cᴰ = PSHωᴰ0
+PSHωᴰ-Guarded .GuardedLogic.▷ⱽ = FamF (▷ ℕDirect)
+PSHωᴰ-Guarded .GuardedLogic.next = Fam-PtNT (nextNT ℕDirect)
+PSHωᴰ-Guarded .GuardedLogic.isFibCᴰ = PSHωᴰ-fibration
+PSHωᴰ-Guarded .GuardedLogic.termⱽ = PSHωᴰ-Terminalsⱽ
+PSHωᴰ-Guarded .GuardedLogic.gfpⱽ {A = X}{Aᴰ = Xᴰ} fⱽ =
+  fixed-pointⱽ'→ⱽ _ _ _ _
+    (subst (fixed-pointⱽ' PSHωᴰ0 X (PSHωᴰ-Terminalsⱽ X .fst))
+      (PSHωᴰ0.rectifyOut {a = X}{b = X}{aᴰ = Xᴰ}{bᴰ = Xᴰ}{e' = refl}
+        (PSHωᴰ0.reind-filler _))
+      ((λ x → gfixω (fⱽ x))
+      , (funExt (λ x → guarded-fixed-pointsω (fⱽ x) .snd))))
+
+-- the delay predicate, as a presheaf on ω
+module DelayPshᴰ {V : Type ℓ}{X : Type ℓ'} (ret : V → X) (δ : X → X)
+                 (Vᴰ : V → Presheaf ℕCat ℓᴰ) where
+
+  data |Delayᴰ| : (x : X) → ℕ → Type (ℓ-max ℓ (ℓ-max ℓ' ℓᴰ)) where
+    terminates : ∀ {v n} → ⟨ Vᴰ v .F-ob n ⟩ → |Delayᴰ| (ret v) n
+    timeout : ∀ {x}                → |Delayᴰ| (δ x) 0
+    steps : ∀ {x n} → |Delayᴰ| x n → |Delayᴰ| (δ x) (suc n)
+
+  isSet|Delayᴰ| :
+    isSet X
+    → isSet V
+    → ∀ x n → isSet (|Delayᴰ| x n)
+  isSet|Delayᴰ| isSetX isSetV = λ x n →
+    isSetRetract {B = Dᴰ (x , n)} enc dec dec∘enc≡id isSetDᴰ
+    where
+    open import Cubical.Data.W.Indexed
+    Dᴰ : (X × ℕ) → Type (ℓ-max ℓ (ℓ-max ℓ' ℓᴰ))
+    Dᴰ = IW
+      (λ (x , n) →
+        (Σ[ v ∈ Eq.fiber ret x ] ⟨ Vᴰ (v .fst) .F-ob n ⟩)
+        Sum.⊎ (Eq.fiber δ x × ((n Eq.≡ 0) Sum.⊎ Eq.fiber suc n)))
+      (λ { (x , n) (inl (ret⁻x , vᴰ)) → ⊥*
+        ; (x , n) (inr (δ⁻x , inl n≡0)) → ⊥*
+        ; (x , n) (inr (δ⁻x , inr suc⁻n)) → Unit
+        })
+      λ { (x , n) (inr (δ⁻x , inr suc⁻n)) tt → (δ⁻x .fst) , (suc⁻n .fst) }
+      where open Empty using (⊥*)
+
+    enc : ∀ {x n} → |Delayᴰ| x n → Dᴰ (x , n)
+    enc (terminates vᴰ) = node (inl ((_ , Eq.refl) , vᴰ)) λ ()
+    enc timeout = node (inr ((_ , Eq.refl) , (inl Eq.refl))) (λ ())
+    enc (steps d) =
+      node (inr ((_ , Eq.refl) , (inr (_ , Eq.refl)))) (λ _ → enc d)
+
+    dec : ∀ {x n} → Dᴰ (x , n) → |Delayᴰ| x n
+    dec (node (inl ((_ , Eq.refl) , vᴰ)) _) = terminates vᴰ
+    dec (node (inr ((_ , Eq.refl) , inl Eq.refl)) _) = timeout
+    dec (node (inr ((_ , Eq.refl) , inr (n , Eq.refl))) dᴰ) = steps (dec (dᴰ _))
+
+    dec∘enc≡id : ∀ {x n} (dᴰ : |Delayᴰ| x n) → dec (enc dᴰ) ≡ dᴰ
+    dec∘enc≡id (terminates x) = refl
+    dec∘enc≡id timeout = refl
+    dec∘enc≡id (steps dᴰ) = cong steps (dec∘enc≡id dᴰ)
+
+    isSetDᴰ : ∀ {x n} → isSet (Dᴰ (x , n))
+    isSetDᴰ = isOfHLevelSuc-IW 1
+      (λ (x , n) →
+        Sum.isSet⊎
+          (isSetΣ (Eq.isSet→isSetEqFiber isSetV isSetX)
+            (λ x₂ → Vᴰ (x₂ .fst) .F-ob n .snd))
+          (isSet× (Eq.isSet→isSetEqFiber isSetX isSetX)
+            (Sum.isSet⊎ (isProp→isSet (Eq.isSet→isSetEq isSetℕ))
+              (Eq.isSet→isSetEqFiber isSetℕ isSetℕ)))) _
+
+  -- one-step restriction
+  π1 : ∀ {x} n → |Delayᴰ| x (suc n) → |Delayᴰ| x n
+  π1 n (terminates {v} vᴰ) =
+    terminates (Vᴰ v .F-hom (inl (R.≤-refl n)) vᴰ)
+  π1 zero (steps d) = timeout
+  π1 (suc n) (steps d) = steps (π1 n d)
+
+  private
+    hom≤ : ∀ {m n} → m R.≤ n → ℕCat [ m , n ]
+    hom≤ le = Sum.map (λ z → z) Eq.pathToEq (R.≤-split le)
+
+    hom→≤R : ∀ {m n} → ℕCat [ m , n ] → m R.≤ n
+    hom→≤R {m} {n} (inl m<n) = R.<-weaken {m} {n} m<n
+    hom→≤R {m} (inr Eq.refl) = R.≤-refl m
+
+    isPropHomℕ : ∀ {m n} → isProp (ℕCat [ m , n ])
+    isPropHomℕ = WFOrder.isProp≤ ℕWFOrder
+
+  -- iterated restriction along any hom of ω
+  π* : ∀ {x m n} → ℕCat [ m , n ] → |Delayᴰ| x n → |Delayᴰ| x m
+  π* (inr Eq.refl) d = d
+  π* {m = m} {n = zero}  (inl m<0)  d = Empty.rec m<0
+  π* {m = m} {n = suc n} (inl m<sn) d = π* (hom≤ {m} {n} m<sn) (π1 n d)
+
+  π*-irr : ∀ {x m n} (p q : ℕCat [ m , n ]) (d : |Delayᴰ| x n)
+         → π* p d ≡ π* q d
+  π*-irr p q d = cong (λ p → π* p d) (isPropHomℕ p q)
+
+  π*-comp : ∀ {x k m n} (g : ℕCat [ m , n ]) (h : ℕCat [ k , m ])
+            (d : |Delayᴰ| x n)
+          → π* (h ⋆⟨ ℕCat ⟩ g) d ≡ π* h (π* g d)
+  π*-comp (inr Eq.refl) h d =
+    π*-irr (h ⋆⟨ ℕCat ⟩ inr Eq.refl) h d
+  π*-comp {k = k} {m = m} {n = zero} (inl m<0) h d = Empty.rec m<0
+  π*-comp {k = k} {m = m} {n = suc n} (inl m<sn) h d =
+    π*-irr (h ⋆⟨ ℕCat ⟩ inl m<sn) (inl κ) d
+    ∙ π*-irr (hom≤ {k} {n} κ) (h ⋆⟨ ℕCat ⟩ hom≤ {m} {n} m<sn) (π1 n d)
+    ∙ π*-comp (hom≤ {m} {n} m<sn) h (π1 n d)
+    where
+      κ : k R.< suc n
+      κ = R.≤-trans {k} {m} {n} (hom→≤R h) m<sn
+
+  private
+    isProp↡ω : ∀ n y → isProp ⟨ ↡Psh ℕDirect n .F-ob y ⟩
+    isProp↡ω n y = isPropΣ isPropHomℕ (λ _ → R.isProp≤)
+
+  π*-suc : ∀ {x} n (d : |Delayᴰ| x (suc n))
+         → π* (inl (R.≤-refl n)) d ≡ π1 n d
+  π*-suc n d =
+    π*-irr (hom≤ (R.≤-refl n)) (inr Eq.refl) (π1 n d)
+
+  module _ (isSetX : isSet X) (isSetV : isSet V) where
+    Delayᴰ : X → Presheaf ℕCat (ℓ-max ℓ (ℓ-max ℓ' ℓᴰ))
+    Delayᴰ x .F-ob n = |Delayᴰ| x n , isSet|Delayᴰ| isSetX isSetV x n
+    Delayᴰ x .F-hom g = π* g
+    Delayᴰ x .F-id = refl
+    Delayᴰ x .F-seq g h = funExt (π*-comp g h)
+
+    private
+      θ-ob : ∀ x n → ⟨ ▷Psh ℕDirect (Delayᴰ x) .F-ob n ⟩
+           → |Delayᴰ| (δ x) n
+      θ-ob x zero    β = timeout
+      θ-ob x (suc n) β = steps (β .N-ob n (inl (R.≤-refl n) , R.≤-refl n))
+
+      ▷restr : ∀ x {m n} → ℕCat [ m , n ]
+             → ⟨ ▷Psh ℕDirect (Delayᴰ x) .F-ob n ⟩
+             → ⟨ ▷Psh ℕDirect (Delayᴰ x) .F-ob m ⟩
+      ▷restr x h = ▷Psh ℕDirect (Delayᴰ x) .F-hom h
+
+      restr₂ : ∀ x {k m n} (g : ℕCat [ k , m ]) (f : ℕCat [ m , n ])
+               (h : ℕCat [ k , n ]) (β : ⟨ ▷Psh ℕDirect (Delayᴰ x) .F-ob n ⟩)
+             → ▷restr x g (▷restr x f β) ≡ ▷restr x h β
+      restr₂ x g f h β = makePshHomStrictPath (funExt λ y → funExt λ w →
+        cong (β .N-ob y) (isProp↡ω _ y _ _))
+
+      π1-θ : ∀ x n (β : ⟨ ▷Psh ℕDirect (Delayᴰ x) .F-ob (suc n) ⟩)
+           → π1 n (θ-ob x (suc n) β)
+             ≡ θ-ob x n (▷restr x (inl (R.≤-refl n)) β)
+      π1-θ x zero    β = refl
+      π1-θ x (suc n) β = cong steps
+        ( sym (π*-suc n (β .N-ob (suc n)
+            (inl (R.≤-refl (suc n)) , R.≤-refl (suc n))))
+        ∙ β .N-hom n (suc n) (inl (R.≤-refl n)) _ _ refl
+        ∙ cong (β .N-ob n) (isProp↡ω (suc (suc n)) n _ _) )
+
+      θ-nat : ∀ x {m n} (h : ℕCat [ m , n ])
+              (β : ⟨ ▷Psh ℕDirect (Delayᴰ x) .F-ob n ⟩)
+            → π* h (θ-ob x n β) ≡ θ-ob x m (▷restr x h β)
+      θ-nat x (inr Eq.refl) β =
+        sym (cong (θ-ob x _)
+          (funExt⁻ (▷Psh ℕDirect (Delayᴰ x) .F-id) β))
+      θ-nat x {m} {zero}  (inl m<0)  β = Empty.rec m<0
+      θ-nat x {m} {suc n} (inl m<sn) β =
+        cong (π* (hom≤ {m} {n} m<sn)) (π1-θ x n β)
+        ∙ θ-nat x (hom≤ {m} {n} m<sn) (▷restr x (inl (R.≤-refl n)) β)
+        ∙ cong (θ-ob x m)
+            (restr₂ x (hom≤ {m} {n} m<sn) (inl (R.≤-refl n)) (inl m<sn) β)
+
+    θᴰ : ∀ x → PshHomStrict (▷Psh ℕDirect (Delayᴰ x)) (Delayᴰ (δ x))
+    θᴰ x .N-ob = θ-ob x
+    θᴰ x .N-hom m n h β' β e = θ-nat x h β' ∙ cong (θ-ob x m) e
+
+    private
+      π*-term : ∀ {v m n} (h : ℕCat [ m , n ]) (vᴰ : ⟨ Vᴰ v .F-ob n ⟩)
+              → π* h (terminates vᴰ) ≡ terminates (Vᴰ v .F-hom h vᴰ)
+      π*-term (inr Eq.refl) vᴰ =
+        sym (cong terminates (funExt⁻ (Vᴰ _ .F-id) vᴰ))
+      π*-term {m = m} {n = zero}  (inl m<0)  vᴰ = Empty.rec m<0
+      π*-term {v} {m} {suc n} (inl m<sn) vᴰ =
+        π*-term (hom≤ {m} {n} m<sn) (Vᴰ v .F-hom (inl (R.≤-refl n)) vᴰ)
+        ∙ cong terminates
+            ( sym (funExt⁻
+                (Vᴰ v .F-seq (inl (R.≤-refl n)) (hom≤ {m} {n} m<sn)) vᴰ)
+            ∙ cong (λ z → Vᴰ v .F-hom z vᴰ) (isPropHomℕ _ _) )
+
+    retᴰ : ∀ v → PshHomStrict (Vᴰ v) (Delayᴰ (ret v))
+    retᴰ v .N-ob n = terminates
+    retᴰ v .N-hom m n h vᴰ' vᴰ e = π*-term h vᴰ' ∙ cong terminates e
+
+-- Gluing
+Γ : Functor EXP (SET ℓ-zero)
+Γ = EXP [ [1] ,-]
+
+𝓖 = reindex PSHωᴰ0 Γ
+
+𝓖-guardedLogic : GuardedLogic EXP _ _
+𝓖-guardedLogic = reindexGuardedLogic Γ PSHωᴰ-Guarded
+
+private
+  module 𝓖 where
+    open GuardedLogic 𝓖-guardedLogic hiding (module Cᴰ) public
+    open Fibers Cᴰ public
+
+1ᴰ𝓖 : Terminalᴰ 𝓖 [1]-TERMINAL
+1ᴰ𝓖 = Terminalⱽ→ᴰ 𝓖 [1]-TERMINAL (𝓖.termⱽ (vertex [1]-TERMINAL))
+
+can-lem : ∀ {B} (γ : Exp [1] [1]) (M : Exp [1] B) → M ≡ γ ⋆ₑ M
+can-lem γ M = sym (EXP.⋆IdL _) ∙ EXP.⟨ 1ηₑ ∙ sym 1ηₑ ⟩⋆⟨ refl ⟩
+
+Unit*ω : Presheaf ℕCat ℓ-zero
+Unit*ω = Unit*Psh
+
+open DelayPshᴰ {V = Bool} quoteBool (_⋆ₑ [δ]) (λ _ → Unit*ω)
+
+DelayP : Exp [1] [RetBool] → Presheaf ℕCat ℓ-zero
+DelayP = Delayᴰ isSetExp isSetBool
+
+bool-gen : ∀ b e → PSHω [ Unit*ω , DelayP (e ⋆ₑ quoteBool b) ]
+bool-gen b e = subst (λ M → PSHω [ Unit*ω , DelayP M ])
+  (can-lem e (quoteBool b))
+  (retᴰ isSetExp isSetBool b)
+
+[RetBoolᴰ] : 𝓖.ob[ [RetBool] ]
+[RetBoolᴰ] = DelayP
+
+⟦_⟧ : ∀ B → 𝓖.ob[ B ]
+⟦_⟧ = elimOb 𝓖 1ᴰ𝓖 [RetBoolᴰ]
+
+[θᴰ] : ∀ B → 𝓖.Hom[ [δ] ][ 𝓖.▷ⱽ .F-obᴰ ⟦ B ⟧ , ⟦ B ⟧ ]
+[θᴰ] [1] = λ _ → UniversalElementNotation.intro PSHω-Terminal
+  {c = ▷Psh ℕDirect (⟦ [1] ⟧ idₑ)} tt
+[θᴰ] [RetBool] = θᴰ isSetExp isSetBool
+
+[δᴰ] : ∀ B → 𝓖.Hom[ [δ] ][ ⟦ B ⟧ , ⟦ B ⟧ ]
+[δᴰ] B = 𝓖._⋆ⱽᴰ_ {xᴰ = ⟦ B ⟧} {xᴰ' = 𝓖.▷ⱽ .F-obᴰ ⟦ B ⟧} {yᴰ = ⟦ B ⟧}
+  (𝓖.next .N-obᴰ ⟦ B ⟧)
+  ([θᴰ] B)
+
+GuardedCanonicitySection : GlobalSection 𝓖
+GuardedCanonicitySection = elim 𝓖 1ᴰ𝓖
+  [RetBoolᴰ]
+  (λ e → bool-gen true e)
+  (λ e → bool-gen false e)
+  (λ {B} → [δᴰ] B)
+  λ {B} {M} Mᴰ → 𝓖.gfixⱽ→ᴰ [1] B ⟦ B ⟧ [δ] M ([θᴰ] B) Mᴰ
+    (Syn.guarded-fixed-points M)
+
+GuardedCanonicity : ∀ (M : Exp [1] [RetBool]) n → |Delayᴰ| M n
+GuardedCanonicity M n = subst (λ M → |Delayᴰ| M n)
+  (EXP.⋆IdL M)
+  (GuardedCanonicitySection .F-homᴰ M EXP.id .N-ob n tt*)


### PR DESCRIPTION
I am leaving this PR a draft. This branch builds examples of using guarded recursion, but is a bit of a scattershot of applications. These include GCD, quicksort, Karatsuba multiplication, Ackermann's function, shortest path in a weighted graph, a toy unification algorithm, binary search, towers of Hanoi, and some stream programming in the topos of trees. 

If you have the time, I think skimming through it to see if you'd be interested in any of the results there landing on `main`. I think it has plenty of neat stuff, but I'm not sure how in-scope these examples are to `cubical-categorical-logic`

This depends on #260 